### PR TITLE
baremetal quota handling

### DIFF
--- a/nova/api/openstack/common.py
+++ b/nova/api/openstack/common.py
@@ -304,6 +304,7 @@ def check_img_metadata_properties_quota(context, metadata):
     if not metadata:
         return
     try:
+        QUOTAS.initialize()
         QUOTAS.limit_check(context, metadata_items=len(metadata))
     except exception.OverQuota:
         expl = _("Image metadata limit exceeded")

--- a/nova/api/openstack/compute/legacy_v2/contrib/os_tenant_networks.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/os_tenant_networks.py
@@ -112,6 +112,7 @@ class NetworkController(object):
         reservation = None
         try:
             if CONF.enable_network_quota:
+                QUOTAS.initialize()
                 reservation = QUOTAS.reserve(context, networks=-1)
         except Exception:
             reservation = None
@@ -179,6 +180,7 @@ class NetworkController(object):
         networks = []
         try:
             if CONF.enable_network_quota:
+                QUOTAS.initialize()
                 reservation = QUOTAS.reserve(context, networks=1)
         except exception.OverQuota:
             msg = _("Quota exceeded, too many networks.")

--- a/nova/api/openstack/compute/legacy_v2/contrib/quota_classes.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/quota_classes.py
@@ -36,15 +36,16 @@ authorize = extensions.extension_authorizer('compute', 'quota_classes')
 
 class QuotaClassSetsController(wsgi.Controller):
 
-    supported_quotas = []
-
     def __init__(self, ext_mgr):
         self.ext_mgr = ext_mgr
+
+    def _supported_quotas(self):
         QUOTAS.initialize()
-        self.supported_quotas = QUOTAS.resources
+        result = QUOTAS.resources
         for resource, extension in EXTENDED_QUOTAS.items():
             if not self.ext_mgr.is_loaded(extension):
-                self.supported_quotas.remove(resource)
+                result.remove(resource)
+        return result
 
     def _format_quota_set(self, quota_class, quota_set):
         """Convert the quota object to a result dict."""
@@ -54,7 +55,7 @@ class QuotaClassSetsController(wsgi.Controller):
         else:
             result = {}
 
-        for resource in self.supported_quotas:
+        for resource in self._supported_quotas():
             if resource in quota_set:
                 result[resource] = quota_set[resource]
 
@@ -88,8 +89,9 @@ class QuotaClassSetsController(wsgi.Controller):
             msg = _("quota_class_set not specified")
             raise webob.exc.HTTPBadRequest(explanation=msg)
         quota_class_set = body['quota_class_set']
+        supported_quotas = self._supported_quotas()
         for key in quota_class_set.keys():
-            if key not in self.supported_quotas:
+            if key not in supported_quotas:
                 bad_keys.append(key)
                 continue
             try:

--- a/nova/api/openstack/compute/legacy_v2/contrib/quota_classes.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/quota_classes.py
@@ -40,6 +40,7 @@ class QuotaClassSetsController(wsgi.Controller):
 
     def __init__(self, ext_mgr):
         self.ext_mgr = ext_mgr
+        QUOTAS.initialize()
         self.supported_quotas = QUOTAS.resources
         for resource, extension in EXTENDED_QUOTAS.items():
             if not self.ext_mgr.is_loaded(extension):
@@ -64,6 +65,7 @@ class QuotaClassSetsController(wsgi.Controller):
         authorize(context)
         try:
             nova.context.authorize_quota_class_context(context, id)
+            QUOTAS.initialize()
             values = QUOTAS.get_class_quotas(context, id)
             return self._format_quota_set(id, values)
         except exception.Forbidden:
@@ -116,6 +118,7 @@ class QuotaClassSetsController(wsgi.Controller):
             except exception.QuotaClassNotFound:
                 db.quota_class_create(context, quota_class, key, value)
 
+        QUOTAS.initialize()
         values = QUOTAS.get_class_quotas(context, quota_class)
         return self._format_quota_set(None, values)
 

--- a/nova/api/openstack/compute/legacy_v2/contrib/quotas.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/quotas.py
@@ -46,6 +46,7 @@ class QuotaSetsController(wsgi.Controller):
 
     def __init__(self, ext_mgr):
         self.ext_mgr = ext_mgr
+        QUOTAS.initialize()
         self.supported_quotas = QUOTAS.resources
         for resource, extension in EXTENDED_QUOTAS.items():
             if not self.ext_mgr.is_loaded(extension):
@@ -94,6 +95,7 @@ class QuotaSetsController(wsgi.Controller):
             raise webob.exc.HTTPBadRequest(explanation=msg)
 
     def _get_quotas(self, context, id, user_id=None, usages=False):
+        QUOTAS.initialize()
         if user_id:
             values = QUOTAS.get_user_quotas(context, id, user_id,
                                             usages=usages)
@@ -155,6 +157,7 @@ class QuotaSetsController(wsgi.Controller):
             # NOTE(alex_xu): back-compatible with db layer hard-code admin
             # permission checks.
             nova.context.authorize_project_context(context, id)
+            QUOTAS.initialize()
             settable_quotas = QUOTAS.get_settable_quotas(context, project_id,
                                                          user_id=user_id)
         except exception.Forbidden:
@@ -223,6 +226,7 @@ class QuotaSetsController(wsgi.Controller):
     def defaults(self, req, id):
         context = req.environ['nova.context']
         authorize_show(context)
+        QUOTAS.initialize()
         values = QUOTAS.get_defaults(context)
         return self._format_quota_set(id, values)
 
@@ -242,6 +246,7 @@ class QuotaSetsController(wsgi.Controller):
                 # only admins can call this method while the policy could be
                 # changed.
                 nova.context.require_admin_context(context)
+                QUOTAS.initialize()
                 if user_id:
                     QUOTAS.destroy_all_by_project_and_user(context,
                                                            id, user_id)

--- a/nova/api/openstack/compute/legacy_v2/contrib/server_group_quotas.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/server_group_quotas.py
@@ -25,6 +25,7 @@ class ExtendedLimitsController(wsgi.Controller):
     def index(self, req, resp_obj):
 
         context = req.environ['nova.context']
+        QUOTAS.initialize()
         quotas = QUOTAS.get_project_quotas(context, context.project_id,
                                            usages=False)
         abs = resp_obj.obj.get('limits', {}).get('absolute', {})

--- a/nova/api/openstack/compute/legacy_v2/contrib/used_limits.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/used_limits.py
@@ -45,6 +45,7 @@ class UsedLimitsController(wsgi.Controller):
     def index(self, req, resp_obj):
         context = req.environ['nova.context']
         project_id = self._project_id(context, req)
+        QUOTAS.initialize()
         quotas = QUOTAS.get_project_quotas(context, project_id, usages=True)
         quota_map = {
             'totalRAMUsed': 'ram',

--- a/nova/api/openstack/compute/legacy_v2/limits.py
+++ b/nova/api/openstack/compute/legacy_v2/limits.py
@@ -62,6 +62,7 @@ class LimitsController(object):
         """Return all global and rate limit information."""
         context = req.environ['nova.context']
         project_id = req.params.get('tenant_id', context.project_id)
+        QUOTAS.initialize()
         quotas = QUOTAS.get_project_quotas(context, project_id,
                                            usages=False)
         abs_limits = {k: v['limit'] for k, v in quotas.items()}

--- a/nova/api/openstack/compute/limits.py
+++ b/nova/api/openstack/compute/limits.py
@@ -39,6 +39,7 @@ class LimitsController(wsgi.Controller):
         context = req.environ['nova.context']
         authorize(context)
         project_id = req.params.get('tenant_id', context.project_id)
+        QUOTAS.initialize()
         quotas = QUOTAS.get_project_quotas(context, project_id,
                                            usages=False)
         abs_limits = {k: v['limit'] for k, v in quotas.items()}

--- a/nova/api/openstack/compute/quota_classes.py
+++ b/nova/api/openstack/compute/quota_classes.py
@@ -46,7 +46,7 @@ class QuotaClassSetsController(wsgi.Controller):
         QUOTAS.initialize()
         result = QUOTAS.resources
         for resource, extension in EXTENDED_QUOTAS.items():
-            if extension not in extension_info:
+            if extension not in self.__extension_info:
                 result.remove(resource)
         return result
 

--- a/nova/api/openstack/compute/quota_classes.py
+++ b/nova/api/openstack/compute/quota_classes.py
@@ -39,15 +39,16 @@ authorize = extensions.os_compute_authorizer(ALIAS)
 
 class QuotaClassSetsController(wsgi.Controller):
 
-    supported_quotas = []
-
     def __init__(self, **kwargs):
+        self.__extension_info = kwargs.pop('extension_info').get_extensions()
+
+    def _supported_quotas(self):
         QUOTAS.initialize()
-        self.supported_quotas = QUOTAS.resources
-        extension_info = kwargs.pop('extension_info').get_extensions()
+        result = QUOTAS.resources
         for resource, extension in EXTENDED_QUOTAS.items():
             if extension not in extension_info:
-                self.supported_quotas.remove(resource)
+                result.remove(resource)
+        return result
 
     def _format_quota_set(self, quota_class, quota_set):
         """Convert the quota object to a result dict."""
@@ -57,7 +58,7 @@ class QuotaClassSetsController(wsgi.Controller):
         else:
             result = {}
 
-        for resource in self.supported_quotas:
+        for resource in self._supported_quotas():
             if resource in quota_set:
                 result[resource] = quota_set[resource]
 

--- a/nova/api/openstack/compute/quota_classes.py
+++ b/nova/api/openstack/compute/quota_classes.py
@@ -42,6 +42,7 @@ class QuotaClassSetsController(wsgi.Controller):
     supported_quotas = []
 
     def __init__(self, **kwargs):
+        QUOTAS.initialize()
         self.supported_quotas = QUOTAS.resources
         extension_info = kwargs.pop('extension_info').get_extensions()
         for resource, extension in EXTENDED_QUOTAS.items():
@@ -66,6 +67,7 @@ class QuotaClassSetsController(wsgi.Controller):
     def show(self, req, id):
         context = req.environ['nova.context']
         authorize(context, action='show', target={'quota_class': id})
+        QUOTAS.initialize()
         values = QUOTAS.get_class_quotas(context, id)
         return self._format_quota_set(id, values)
 
@@ -89,6 +91,7 @@ class QuotaClassSetsController(wsgi.Controller):
             except exception.QuotaClassNotFound:
                 db.quota_class_create(context, quota_class, key, value)
 
+        QUOTAS.initialize()
         values = QUOTAS.get_class_quotas(context, quota_class)
         return self._format_quota_set(None, values)
 

--- a/nova/api/openstack/compute/quota_sets.py
+++ b/nova/api/openstack/compute/quota_sets.py
@@ -44,6 +44,7 @@ class QuotaSetsController(wsgi.Controller):
         else:
             result = {}
 
+        QUOTAS.initialize()
         for resource in QUOTAS.resources:
             if resource in quota_set:
                 result[resource] = quota_set[resource]
@@ -73,6 +74,7 @@ class QuotaSetsController(wsgi.Controller):
             raise webob.exc.HTTPBadRequest(explanation=msg)
 
     def _get_quotas(self, context, id, user_id=None, usages=False):
+        QUOTAS.initialize()
         if user_id:
             values = QUOTAS.get_user_quotas(context, id, user_id,
                                             usages=usages)
@@ -123,6 +125,7 @@ class QuotaSetsController(wsgi.Controller):
 
         force_update = strutils.bool_from_string(quota_set.get('force',
                                                                'False'))
+        QUOTAS.initialize()
         settable_quotas = QUOTAS.get_settable_quotas(context, project_id,
                                                      user_id=user_id)
 
@@ -162,6 +165,7 @@ class QuotaSetsController(wsgi.Controller):
     def defaults(self, req, id):
         context = req.environ['nova.context']
         authorize(context, action='defaults', target={'project_id': id})
+        QUOTAS.initialize()
         values = QUOTAS.get_defaults(context)
         return self._format_quota_set(id, values)
 
@@ -175,6 +179,7 @@ class QuotaSetsController(wsgi.Controller):
         authorize(context, action='delete', target={'project_id': id})
         params = urlparse.parse_qs(req.environ.get('QUERY_STRING', ''))
         user_id = params.get('user_id', [None])[0]
+        QUOTAS.initialize()
         if user_id:
             QUOTAS.destroy_all_by_project_and_user(context,
                                                    id, user_id)

--- a/nova/api/openstack/compute/tenant_networks.py
+++ b/nova/api/openstack/compute/tenant_networks.py
@@ -111,6 +111,7 @@ class TenantNetworkController(wsgi.Controller):
         reservation = None
         try:
             if CONF.enable_network_quota:
+                QUOTAS.initialize()
                 reservation = QUOTAS.reserve(context, networks=-1)
         except Exception:
             reservation = None
@@ -165,6 +166,7 @@ class TenantNetworkController(wsgi.Controller):
         networks = []
         try:
             if CONF.enable_network_quota:
+                QUOTAS.initialize()
                 reservation = QUOTAS.reserve(context, networks=1)
         except exception.OverQuota:
             msg = _("Quota exceeded, too many networks.")

--- a/nova/api/openstack/compute/used_limits.py
+++ b/nova/api/openstack/compute/used_limits.py
@@ -56,6 +56,15 @@ class UsedLimitsController(wsgi.Controller):
                             if self._reserved(req) else 0)
                 used_limits[display_name] = quotas[key]['in_use'] + reserved
 
+        # extension to report per-flavor instance quota usage
+        per_flavor_used_limits = {}
+        for key, stat in quotas:
+            if key.startswith('instances_'):
+                flavorname = key[10:]
+                reserved = stat['reserved'] if self._reserved(req) else 0
+                per_flavor_used_limits[flavorname] = stat['in_use'] + value
+        used_limits['totalInstancesUsedPerFlavor'] = per_flavor_used_limits
+
         resp_obj.obj['limits']['absolute'].update(used_limits)
 
     def _project_id(self, context, req):

--- a/nova/api/openstack/compute/used_limits.py
+++ b/nova/api/openstack/compute/used_limits.py
@@ -40,6 +40,7 @@ class UsedLimitsController(wsgi.Controller):
     def index(self, req, resp_obj):
         context = req.environ['nova.context']
         project_id = self._project_id(context, req)
+        QUOTAS.initialize()
         quotas = QUOTAS.get_project_quotas(context, project_id, usages=True)
         quota_map = {
             'totalRAMUsed': 'ram',

--- a/nova/api/openstack/compute/used_limits.py
+++ b/nova/api/openstack/compute/used_limits.py
@@ -57,6 +57,8 @@ class UsedLimitsController(wsgi.Controller):
                             if self._reserved(req) else 0)
                 used_limits[display_name] = quotas[key]['in_use'] + reserved
 
+        resp_obj.obj['limits']['absolute'].update(used_limits)
+
         # extension to report per-flavor instance quota usage
         per_flavor = resp_obj.obj['limits']['absolutePerFlavor']
         for key, stat in six.iteritems(quotas):

--- a/nova/api/openstack/compute/used_limits.py
+++ b/nova/api/openstack/compute/used_limits.py
@@ -58,15 +58,13 @@ class UsedLimitsController(wsgi.Controller):
                 used_limits[display_name] = quotas[key]['in_use'] + reserved
 
         # extension to report per-flavor instance quota usage
-        per_flavor_used_limits = {}
-        for key, stat in quotas:
+        per_flavor = resp_obj.obj['limits']['absolutePerFlavor']
+        for key, stat in six.iteritems(quotas):
             if key.startswith('instances_'):
                 flavorname = key[10:]
                 reserved = stat['reserved'] if self._reserved(req) else 0
-                per_flavor_used_limits[flavorname] = stat['in_use'] + value
-        used_limits['totalInstancesUsedPerFlavor'] = per_flavor_used_limits
-
-        resp_obj.obj['limits']['absolute'].update(used_limits)
+                per_flavor[flavorname]['totalInstancesUsed'] = (
+                    stat['in_use'] + reserved)
 
     def _project_id(self, context, req):
         if 'tenant_id' in req.GET:

--- a/nova/api/openstack/compute/views/limits.py
+++ b/nova/api/openstack/compute/views/limits.py
@@ -58,11 +58,19 @@ class ViewBuilder(object):
         For example: {"ram": 512, "gigabytes": 1024}.
 
         """
+        per_flavor_limits = {}
         limits = {}
         for name, value in six.iteritems(absolute_limits):
             if name in self.limit_names and value is not None:
                 for limit_name in self.limit_names[name]:
                     limits[limit_name] = value
+
+            # extension to report per-flavor instance quotas
+            elif name.startswith('instances_'):
+                flavorname = name[10:]
+                per_flavor_limits[flavorname] = value
+
+        limits['maxTotalInstancesPerFlavor'] = per_flavor_limits
         return limits
 
     def _build_rate_limits(self, rate_limits):

--- a/nova/api/openstack/compute/views/limits.py
+++ b/nova/api/openstack/compute/views/limits.py
@@ -18,7 +18,6 @@ import six
 
 from nova import utils
 
-
 class ViewBuilder(object):
     """OpenStack API base limits view builder."""
 
@@ -40,12 +39,14 @@ class ViewBuilder(object):
 
     def build(self, rate_limits, absolute_limits):
         rate_limits = self._build_rate_limits(rate_limits)
+        per_flavor_limits = self._build_absolute_limits_per_flavor(absolute_limits)
         absolute_limits = self._build_absolute_limits(absolute_limits)
 
         output = {
             "limits": {
                 "rate": rate_limits,
                 "absolute": absolute_limits,
+                "absolutePerFlavor": per_flavor_limits,
             },
         }
 
@@ -58,19 +59,21 @@ class ViewBuilder(object):
         For example: {"ram": 512, "gigabytes": 1024}.
 
         """
-        per_flavor_limits = {}
         limits = {}
         for name, value in six.iteritems(absolute_limits):
             if name in self.limit_names and value is not None:
                 for limit_name in self.limit_names[name]:
                     limits[limit_name] = value
 
-            # extension to report per-flavor instance quotas
-            elif name.startswith('instances_'):
-                flavorname = name[10:]
-                per_flavor_limits[flavorname] = value
+        return limits
 
-        limits['maxTotalInstancesPerFlavor'] = per_flavor_limits
+    def _build_absolute_limits_per_flavor(self, absolute_limits):
+        limits = {}
+        for name, value in six.iteritems(absolute_limits):
+            if name.startswith('instances_'):
+                flavorname = name[10:]
+                limits[flavorname] = { 'maxTotalInstances': value }
+
         return limits
 
     def _build_rate_limits(self, rate_limits):

--- a/nova/cmd/api.py
+++ b/nova/cmd/api.py
@@ -31,6 +31,7 @@ from nova import config
 from nova import exception
 from nova.i18n import _LE, _LW
 from nova import objects
+from nova import quota
 from nova import service
 from nova import utils
 from nova import version
@@ -51,6 +52,7 @@ def main():
 
     launcher = service.process_launcher()
     started = 0
+    quota.QUOTAS.initialize()
     for api in CONF.enabled_apis:
         should_use_ssl = api in CONF.enabled_ssl_apis
         try:

--- a/nova/cmd/manage.py
+++ b/nova/cmd/manage.py
@@ -257,6 +257,7 @@ class ProjectCommands(object):
         """
 
         ctxt = context.get_admin_context()
+        QUOTAS.initialize()
         if user_id:
             quota = QUOTAS.get_user_quotas(ctxt, project_id, user_id)
         else:

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -325,7 +325,7 @@ class API(base.Base):
         if instance_type['extra_specs'].get('quota:separate', 'false') == 'true':
             quota_key_instances = 'instances_' + instance_type['name']
         deltas = { quota_key_instances: max_count }
-        reserve_cpu_ram = instance_type['extra_specs'].get('quota:no_reserve_cpu_ram', 'false') != 'true'
+        reserve_cpu_ram = instance_type['extra_specs'].get('quota:instance_only', 'false') != 'true'
         if reserve_cpu_ram:
             deltas.update(cores=req_cores, ram=req_ram)
         # TODO: adjust _get_headroom() to not fail when cores/ram/instances keys are missing
@@ -1781,13 +1781,13 @@ class API(base.Base):
             instance_memory_mb = old_flavor.memory_mb + vram_mb
             if old_flavor.extra_specs.get('quota:separate', 'false') == 'true':
                 quota_key_instances = 'instances_' + old_flavor.name
-            reserve_cpu_ram = old_flavor.extra_specs.get('quota:no_reserve_cpu_ram', 'false') != 'true'
+            reserve_cpu_ram = old_flavor.extra_specs.get('quota:instance_only', 'false') != 'true'
         else:
             instance_vcpus = instance.vcpus
             instance_memory_mb = instance.memory_mb
             if instance.flavor.extra_specs.get('quota:separate', 'false') == 'true':
                 quota_key_instances = 'instances_' + instance.flavor.name
-            reserve_cpu_ram = instance.flavor.extra_specs.get('quota:no_reserve_cpu_ram', 'false') != 'true'
+            reserve_cpu_ram = instance.flavor.extra_specs.get('quota:instance_only', 'false') != 'true'
 
         deltas = { quota_key_instances: -1 }
         if reserve_cpu_ram:

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -323,7 +323,7 @@ class API(base.Base):
 
         quota_key_instances = 'instances'
         if instance_type['extra_specs'].get('quota:separate', 'false') == 'true':
-            quota_key_instances = 'instances_' + instance_type['flavorid']
+            quota_key_instances = 'instances_' + instance_type['name']
         deltas = { quota_key_instances: max_count }
         reserve_cpu_ram = instance_type['extra_specs'].get('quota:no_reserve_cpu_ram', 'false') != 'true'
         if reserve_cpu_ram:
@@ -1780,13 +1780,13 @@ class API(base.Base):
             vram_mb = old_flavor.extra_specs.get('hw_video:ram_max_mb', 0)
             instance_memory_mb = old_flavor.memory_mb + vram_mb
             if old_flavor.extra_specs.get('quota:separate', 'false') == 'true':
-                quota_key_instances = 'instances_' + old_flavor.flavorid
+                quota_key_instances = 'instances_' + old_flavor.name
             reserve_cpu_ram = old_flavor.extra_specs.get('quota:no_reserve_cpu_ram', 'false') != 'true'
         else:
             instance_vcpus = instance.vcpus
             instance_memory_mb = instance.memory_mb
             if instance.flavor.extra_specs.get('quota:separate', 'false') == 'true':
-                quota_key_instances = 'instances_' + instance.flavor.flavorid
+                quota_key_instances = 'instances_' + instance.flavor.name
             reserve_cpu_ram = instance.flavor.extra_specs.get('quota:no_reserve_cpu_ram', 'false') != 'true'
 
         deltas = { quota_key_instances: -1 }

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -932,11 +932,10 @@ class ComputeManager(manager.Manager):
         quota_key_instances = 'instances'
         if instance.flavor.extra_specs.get('quota:separate', 'false') == 'true':
             quota_key_instances = 'instances_' + instance.flavor.flavorid
-        deltas = {
-            quota_key_instances: -1,
-            'cores': -vcpus,
-            'ram': -mem_mb,
-        }
+        deltas = { quota_key_instances: -1 }
+        if instance.flavor.extra_specs.get('quota:no_reserve_cpu_ram', 'false') != 'true':
+            deltas.update(cores=-vcpus, ram=-mem_mb)
+
         quotas = objects.Quotas(context=context)
         quotas.reserve(project_id=project_id, user_id=user_id, **deltas)
         return quotas

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -931,7 +931,7 @@ class ComputeManager(manager.Manager):
 
         quota_key_instances = 'instances'
         if instance.flavor.extra_specs.get('quota:separate', 'false') == 'true':
-            quota_key_instances = 'instances_' + instance.flavor.flavorid
+            quota_key_instances = 'instances_' + instance.flavor.name
         deltas = { quota_key_instances: -1 }
         if instance.flavor.extra_specs.get('quota:no_reserve_cpu_ram', 'false') != 'true':
             deltas.update(cores=-vcpus, ram=-mem_mb)

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -933,7 +933,7 @@ class ComputeManager(manager.Manager):
         if instance.flavor.extra_specs.get('quota:separate', 'false') == 'true':
             quota_key_instances = 'instances_' + instance.flavor.name
         deltas = { quota_key_instances: -1 }
-        if instance.flavor.extra_specs.get('quota:no_reserve_cpu_ram', 'false') != 'true':
+        if instance.flavor.extra_specs.get('quota:instance_only', 'false') != 'true':
             deltas.update(cores=-vcpus, ram=-mem_mb)
 
         quotas = objects.Quotas(context=context)

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -438,7 +438,12 @@ def resize_quota_delta(context, new_flavor, old_flavor, sense, compare):
                     -1 indicates negative deltas
     """
     def _quota_delta(resource):
-        return sense * (new_flavor[resource] - old_flavor[resource])
+        old_reserve = old_flavor['extra_specs'].get('quota:no_reserve_cpu_ram', 'false') != 'true'
+        new_reserve = new_flavor['extra_specs'].get('quota:no_reserve_cpu_ram', 'false') != 'true'
+        old_factor = 1 if old_reserve else 0
+        new_factor = 1 if new_reserve else 0
+        return sense * (new_flavor[resource] * new_factor - old_flavor[resource] * old_factor)
+
 
     deltas = {}
     if compare * _quota_delta('vcpus') > 0:

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -438,8 +438,8 @@ def resize_quota_delta(context, new_flavor, old_flavor, sense, compare):
                     -1 indicates negative deltas
     """
     def _quota_delta(resource):
-        old_reserve = old_flavor['extra_specs'].get('quota:no_reserve_cpu_ram', 'false') != 'true'
-        new_reserve = new_flavor['extra_specs'].get('quota:no_reserve_cpu_ram', 'false') != 'true'
+        old_reserve = old_flavor['extra_specs'].get('quota:instance_only', 'false') != 'true'
+        new_reserve = new_flavor['extra_specs'].get('quota:instance_only', 'false') != 'true'
         old_factor = 1 if old_reserve else 0
         new_factor = 1 if new_reserve else 0
         return sense * (new_flavor[resource] * new_factor - old_flavor[resource] * old_factor)

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -446,6 +446,18 @@ def resize_quota_delta(context, new_flavor, old_flavor, sense, compare):
     if compare * _quota_delta('memory_mb') > 0:
         deltas['ram'] = _quota_delta('memory_mb')
 
+    old_separate = old_flavor['extra_specs'].get('quota:separate', 'false') == 'true'
+    new_separate = new_flavor['extra_specs'].get('quota:separate', 'false') == 'true'
+    if old_separate and not new_separate:
+        deltas['instances_' + old_flavor['flavorid']] = -1 * sense
+        deltas['instances'] = +1 * sense
+    if not old_separate and new_separate:
+        deltas['instances'] = -1 * sense
+        deltas['instances_' + new_flavor['flavorid']] = +1 * sense
+    if old_separate and new_separate:
+        deltas['instances_' + old_flavor['flavorid']] = -1 * sense
+        deltas['instances_' + new_flavor['flavorid']] = +1 * sense
+
     return deltas
 
 

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -446,22 +446,24 @@ def resize_quota_delta(context, new_flavor, old_flavor, sense, compare):
 
 
     deltas = {}
-    if compare * _quota_delta('vcpus') > 0:
-        deltas['cores'] = _quota_delta('vcpus')
-    if compare * _quota_delta('memory_mb') > 0:
-        deltas['ram'] = _quota_delta('memory_mb')
+    def add_delta(resource, delta):
+        if compare * delta > 0:
+            deltas[resource] = delta
+
+    add_delta('cores', _quota_delta('vcpus'))
+    add_delta('ram', _quota_delta('memory_mb'))
 
     old_separate = old_flavor['extra_specs'].get('quota:separate', 'false') == 'true'
     new_separate = new_flavor['extra_specs'].get('quota:separate', 'false') == 'true'
     if old_separate and not new_separate:
-        deltas['instances_' + old_flavor['name']] = -1 * sense
-        deltas['instances'] = +1 * sense
+        add_delta('instances_' + old_flavor['name'], -1 * sense)
+        add_delta('instances', +1 * sense)
     if not old_separate and new_separate:
-        deltas['instances'] = -1 * sense
-        deltas['instances_' + new_flavor['name']] = +1 * sense
+        add_delta('instances', -1 * sense)
+        add_delta('instances_' + new_flavor['name'], +1 * sense)
     if old_separate and new_separate:
-        deltas['instances_' + old_flavor['name']] = -1 * sense
-        deltas['instances_' + new_flavor['name']] = +1 * sense
+        add_delta('instances_' + old_flavor['name'], -1 * sense)
+        add_delta('instances_' + new_flavor['name'], +1 * sense)
 
     return deltas
 

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -454,14 +454,14 @@ def resize_quota_delta(context, new_flavor, old_flavor, sense, compare):
     old_separate = old_flavor['extra_specs'].get('quota:separate', 'false') == 'true'
     new_separate = new_flavor['extra_specs'].get('quota:separate', 'false') == 'true'
     if old_separate and not new_separate:
-        deltas['instances_' + old_flavor['flavorid']] = -1 * sense
+        deltas['instances_' + old_flavor['name']] = -1 * sense
         deltas['instances'] = +1 * sense
     if not old_separate and new_separate:
         deltas['instances'] = -1 * sense
-        deltas['instances_' + new_flavor['flavorid']] = +1 * sense
+        deltas['instances_' + new_flavor['name']] = +1 * sense
     if old_separate and new_separate:
-        deltas['instances_' + old_flavor['flavorid']] = -1 * sense
-        deltas['instances_' + new_flavor['flavorid']] = +1 * sense
+        deltas['instances_' + old_flavor['name']] = -1 * sense
+        deltas['instances_' + new_flavor['name']] = +1 * sense
 
     return deltas
 

--- a/nova/db/api.py
+++ b/nova/db/api.py
@@ -2031,3 +2031,6 @@ def instance_tag_delete_all(context, instance_uuid):
 def instance_tag_exists(context, instance_uuid, tag):
     """Check if specified tag exist on the instance."""
     return IMPL.instance_tag_exists(context, instance_uuid, tag)
+
+def get_flavornames_with_separate_quota(context):
+    return IMPL.get_flavornames_with_separate_quota(context)

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -422,7 +422,7 @@ def _sync_instances(context, project_id, user_id):
     '''
     stats = context.session.execute(query, { 'pid': project_id, 'uid': user_id })
     output = { "instances": 0, "cores": 0, "ram": 0 }
-    for flavor_name, count, vcpus, memory_mb, separate in result:
+    for flavor_name, count, vcpus, memory_mb, separate in stats:
         output["cores"] += vcpus
         output["ram"]   += memory_mb
         if separate:

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -411,9 +411,26 @@ def convert_objects_related_datetimes(values, *datetime_keys):
 
 
 def _sync_instances(context, project_id, user_id):
-    return dict(zip(('instances', 'cores', 'ram'),
-                    _instance_data_get_for_user(context, project_id, user_id)))
-
+    query = '''
+      SELECT instance_type_id, COUNT(id), SUM(vcpus), SUM(memory_mb),
+        EXISTS(SELECT instance_type_id
+               FROM instance_type_extra_specs
+               WHERE instance_type_id = instances.instance_type_id
+               AND key = 'quota:separate' AND value = 'true')
+      FROM instances WHERE project_id = :pid AND user_id = :uid AND deleted = 0
+      GROUP BY instance_type_id
+    '''
+    stats = context.session.execute(query, { 'pid': project_id, 'uid': user_id })
+    output = { "instances": 0, "cores": 0, "ram": 0 }
+    for flavor_id, count, vcpus, memory_mb, separate in result:
+        output["cores"] += vcpus
+        output["ram"]   += memory_mb
+        if separate:
+            key = "instances_" + flavor_id
+            output[key] = output.get(key, 0) + count
+        else:
+            output["instances"] += count
+    return
 
 def _sync_floating_ips(context, project_id, user_id):
     return dict(floating_ips=_floating_ip_count_by_project(

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -7103,4 +7103,5 @@ def get_flavornames_with_separate_quota(context):
             WHERE i.deleted = 0 AND i.instance_type_id = t.id
           ))
     '''
-    return list(context.session.execute(query))
+    result = context.session.execute(query)
+    return [x[0] for x in result]

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -1113,6 +1113,7 @@ def floating_ip_bulk_destroy(context, ips):
     # been committed first.
     for project_id, count in project_id_to_quota_count.items():
         try:
+            quota.QUOTAS.initialize()
             reservations = quota.QUOTAS.reserve(context,
                                                 project_id=project_id,
                                                 floating_ips=count)

--- a/nova/network/floating_ips.py
+++ b/nova/network/floating_ips.py
@@ -227,6 +227,7 @@ class FloatingIP(object):
         # called into from other places
         try:
             if use_quota:
+                QUOTAS.initialize()
                 reservations = QUOTAS.reserve(context, floating_ips=1,
                                               project_id=project_id)
         except exception.OverQuota:
@@ -282,6 +283,7 @@ class FloatingIP(object):
         # Get reservations...
         try:
             if use_quota:
+                QUOTAS.initialize()
                 reservations = QUOTAS.reserve(context,
                                               project_id=project_id,
                                               floating_ips=-1)

--- a/nova/objects/quotas.py
+++ b/nova/objects/quotas.py
@@ -86,6 +86,7 @@ class Quotas(base.NovaObject):
     @base.remotable
     def reserve(self, expire=None, project_id=None, user_id=None,
                 **deltas):
+        quota.QUOTAS.initialize()
         reservations = quota.QUOTAS.reserve(self._context, expire=expire,
                                             project_id=project_id,
                                             user_id=user_id,
@@ -99,6 +100,7 @@ class Quotas(base.NovaObject):
     def commit(self):
         if not self.reservations:
             return
+        quota.QUOTAS.initialize()
         quota.QUOTAS.commit(self._context, self.reservations,
                             project_id=self.project_id,
                             user_id=self.user_id)
@@ -110,6 +112,7 @@ class Quotas(base.NovaObject):
         """Rollback quotas."""
         if not self.reservations:
             return
+        quota.QUOTAS.initialize()
         quota.QUOTAS.rollback(self._context, self.reservations,
                               project_id=self.project_id,
                               user_id=self.user_id)
@@ -119,12 +122,14 @@ class Quotas(base.NovaObject):
     @base.remotable_classmethod
     def limit_check(cls, context, project_id=None, user_id=None, **values):
         """Check quota limits."""
+        quota.QUOTAS.initialize()
         return quota.QUOTAS.limit_check(
             context, project_id=project_id, user_id=user_id, **values)
 
     @base.remotable_classmethod
     def count(cls, context, resource, *args, **kwargs):
         """Count a resource."""
+        quota.QUOTAS.initialize()
         return quota.QUOTAS.count(
             context, resource, *args, **kwargs)
 

--- a/nova/quota.py
+++ b/nova/quota.py
@@ -1497,11 +1497,12 @@ resources = [
 if ctxt is None:
     ctxt = context.get_admin_context()
 query = '''
-    SELECT s.instance_type_id FROM instance_type_extra_specs s
+    SELECT DISTINCT t.flavorid FROM instance_types t
+    JOIN instance_type_extra_specs s ON t.id = s.instance_type_id
     WHERE s.key = 'quota:separate' AND s.value = 'true'
       AND (s.deleted = 0 OR EXISTS(
         SELECT 1 FROM instances i
-        WHERE i.deleted = 0 AND i.instance_type_id = s.instance_type_id
+        WHERE i.deleted = 0 AND i.instance_type_id = t.id
       ))
 '''
 for flavor_id in ctxt.session.execute(query):

--- a/nova/quota.py
+++ b/nova/quota.py
@@ -1497,7 +1497,7 @@ resources = [
 if ctxt is None:
     ctxt = context.get_admin_context()
 query = '''
-    SELECT DISTINCT t.flavorid FROM instance_types t
+    SELECT DISTINCT t.name FROM instance_types t
     JOIN instance_type_extra_specs s ON t.id = s.instance_type_id
     WHERE s.key = 'quota:separate' AND s.value = 'true'
       AND (s.deleted = 0 OR EXISTS(
@@ -1507,7 +1507,7 @@ query = '''
 '''
 for flavor_id in ctxt.session.execute(query):
     a.append(ReservableResource(
-        'instances_' + flavor_id,
+        'instances_' + flavor_name,
         '_sync_instances',
         flag=None, default=0,
     ))

--- a/nova/quota.py
+++ b/nova/quota.py
@@ -1157,16 +1157,8 @@ class QuotaEngine(object):
 
             # construct resources for each flavor that has a separate quota
             # (also for deleted flavors that still have running instances)
-            query = '''
-                SELECT DISTINCT t.name FROM instance_types t
-                JOIN instance_type_extra_specs s ON t.id = s.instance_type_id
-                WHERE s.key = 'quota:separate' AND s.value = 'true'
-                  AND (s.deleted = 0 OR EXISTS(
-                    SELECT 1 FROM instances i
-                    WHERE i.deleted = 0 AND i.instance_type_id = t.id
-                  ))
-            '''
-            for flavor_id in context.get_admin_context().session.execute(query):
+            ctxt = context.get_admin_context()
+            for flavor_name in db.get_flavornames_with_separate_quota(ctxt):
                 a.append(ReservableResource(
                     'instances_' + flavor_name,
                     '_sync_instances',

--- a/nova/quota.py
+++ b/nova/quota.py
@@ -1159,7 +1159,7 @@ class QuotaEngine(object):
             # (also for deleted flavors that still have running instances)
             ctxt = context.get_admin_context()
             for flavor_name in db.get_flavornames_with_separate_quota(ctxt):
-                a.append(ReservableResource(
+                resources.append(ReservableResource(
                     'instances_' + flavor_name,
                     '_sync_instances',
                     flag=None, default=0,

--- a/nova/scheduler/manager.py
+++ b/nova/scheduler/manager.py
@@ -80,6 +80,7 @@ class SchedulerManager(manager.Manager):
 
     @periodic_task.periodic_task
     def _expire_reservations(self, context):
+        QUOTAS.initialize()
         QUOTAS.expire(context)
 
     @periodic_task.periodic_task(spacing=CONF.scheduler_driver_task_period,


### PR DESCRIPTION
This adds two new extra specs:

## `quota:separate = true`

When an instance with such a flavor is started, it counts against the instance quota *for that flavor* instead of the overall instance quota. So a quota of

    instances = 5
    instances_baremetal6 = 2

means that there can be up to 2 instances with `flavor_name = 'baremetal6'`, and up to 5 instances with flavors without the `quota:separate` flag (so up to 7 instances total).

## `quota:instance_only = true`

Instances of such a flavor do not count towards the RAM and CPU quotas (only, as the name says, towards the instance quota), such that these two resources reflect the virtualized capacity only. Previously called `quota:no_reserve_cpu_ram`.

## Notes

* These two specs are separate because `quota:separate` may also be useful for virtualized flavors (e.g. to restrict the usage of large HANA flavors).

## Tests conducted

I verified that:

* quota usages are reserved and freed up correctly when...
  * ...starting and terminating instances with such special flavors, and with regular flavors
  * ...resizing instances from special flavors to regular flavors:
    * flavor-specific instance quota usage gets converted into regular instance quota usage and vice-versa when moving from or to a `separate` flavor
    * RAM/CPU quota is reserved and freed up when moving from or to an `instance_only` flavor
* this also works with instances whose flavor has already been deleted
* the `os-quota-sets`, `os-quota-class-sets` and `limits` endpoints report flavor-specific instance quota and usage accurately
* flavor-specific instance quota can be set by a resource admin