### PR TITLE
add a uniqueness constraint to the quota_usages table

### DIFF
--- a/nova/db/sqlalchemy/migrate_repo/versions/320_fix_quota_double_spending.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/320_fix_quota_double_spending.py
@@ -1,0 +1,19 @@
+from sqlalchemy import MetaData, Table
+from migrate.changeset.constraint import UniqueConstraint
+
+def _build_constraint(migrate_engine):
+    meta = MetaData()
+    meta.bind = migrate_engine
+    table = Table('quota_usages', meta, autoload=True)
+    cons = UniqueConstraint(
+        'project_id', 'user_id', 'resource', 'deleted',
+        table=table,
+    )
+
+def upgrade(migrate_engine):
+    cons = _build_constraint(migrate_engine)
+    cons.create()
+
+def downgrade(migrate_engine):
+    cons = _build_constraint(migrate_engine)
+    cons.drop()


### PR DESCRIPTION
This fixes an issue where multiple usage records were created for the same project, user and resource. When those were updated during a reservation, quota would be spent multiple times for a single VM.