### PR TITLE
Resize: allow_resize_to_same_host=True fails (fd9508038351d027dcbf94282ba83caed5864a97 commit number)

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3322,6 +3322,8 @@ class API(base.Base):
 
         if not CONF.allow_resize_to_same_host:
             filter_properties['ignore_hosts'].append(instance.host)
+        else:
+            filter_properties['force_nodes'] = [instance.node]
 
         if self.cell_type == 'api':
             # Create migration record.


### PR DESCRIPTION
When allow_resize_to_same_host is set to True, and
if more than one hypervisors are configured, nova
resize api fails to force the resize to the same
