### PR TITLE
Limit instance creation cfg fix - acb63d3f0512dad58eec7725ce26ef8b9546d544 id

### DIFF
--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -594,6 +594,9 @@ Possible values:
 * Any positive integer representing maximum number of live migrations
   to run concurrently.
 """),
+    cfg.IntOpt('max_concurrent_builds_per_project',
+               default=0,
+               help='Maximum number of instance builds to run concurrently per project'),
     cfg.IntOpt('block_device_allocate_retries',
         default=60,
         help="""
@@ -621,7 +624,8 @@ for performance reasons, for example, with Ironic.
 Possible values:
 
 * Any positive integer representing greenthreads count.
-""")
+"""),
+
 ]
 
 compute_group_opts = [


### PR DESCRIPTION
Adding missing cfg max_concurrent_builds_per_project - acb63d3f0512dad58eec7725ce26ef8b9546d544 commit from mitaka-m3 merge