### PR TITLE
VMware: when attaching volume pick the adapter type from the instance…

### DIFF
--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -326,7 +326,8 @@ class VMwareVolumeOps(object):
         # Get details required for adding disk device such as
         # adapter_type, disk_type
         vmdk = vm_util.get_vmdk_info(self._session, volume_ref)
-        adapter_type = adapter_type or vmdk.adapter_type
+        instance_root_vmdk_info = vm_util.get_vmdk_info(self._session, vm_ref, uuid=instance.uuid)
+        adapter_type = adapter_type or instance_root_vmdk_info.adapter_type
 
         # IDE does not support disk hotplug
         if adapter_type == constants.ADAPTER_TYPE_IDE:


### PR DESCRIPTION
… instead of from the shadow VM