### PR TITLE
Merge from queens-m3 to rocky-m3: [vmwareapi] Expose cpu model on hom…

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -49,6 +49,7 @@ from nova.virt.vmwareapi import vim_util as nova_vim_util
 from nova.virt.vmwareapi import vm_util
 from nova.virt.vmwareapi import vmops
 from nova.virt.vmwareapi import volumeops
+from oslo_serialization import jsonutils
 
 LOG = logging.getLogger(__name__)
 
@@ -331,7 +332,7 @@ class VMwareVCDriver(driver.ComputeDriver):
                 # likely many different CPU models in use. As such it is
                 # impossible to provide any meaningful info on the CPU
                 # model of the "host"
-               'cpu_info': None,
+               'cpu_info': jsonutils.dumps(host_stats["cpu_model"]),
                'supported_instances': host_stats['supported_instances'],
                'numa_topology': None,
                }

--- a/nova/virt/vmwareapi/host.py
+++ b/nova/virt/vmwareapi/host.py
@@ -31,6 +31,7 @@ from nova.virt.vmwareapi import ds_util
 from nova.virt.vmwareapi import vim_util
 from nova.virt.vmwareapi import vm_util
 from nova.virt.vmwareapi import cluster_util
+from oslo_vmware import vim_util as vutil
 
 CONF = nova.conf.CONF
 LOG = logging.getLogger(__name__)
@@ -59,6 +60,7 @@ class VCState(object):
         self._cluster = cluster
         self._datastore_regex = datastore_regex
         self._stats = {}
+        self._cpu_model = None
         self._auto_service_disabled = False
         about_info = self._session._call_method(vim_util, "get_about_info")
         self._hypervisor_type = about_info.name
@@ -124,3 +126,91 @@ class VCState(object):
         service.disabled_reason = 'set by vmwareapi host_state'
         service.save()
         self._auto_service_disabled = service.disabled
+
+    def to_cpu_model(self):
+        max_objects = 100
+        vim = self._session.vim
+        property_collector = vim.service_content.propertyCollector
+
+        traversal_spec = vutil.build_traversal_spec(
+            vim.client.factory,
+            "c_to_h",
+            "ComputeResource",
+            "host",
+            False,
+            [])
+
+        object_spec = vutil.build_object_spec(
+            vim.client.factory,
+            self._cluster,
+            [traversal_spec])
+        property_spec = vutil.build_property_spec(
+            vim.client.factory,
+            "HostSystem",
+            ["hardware.cpuPkg", "hardware.cpuInfo", "config.featureCapability"])
+
+        property_filter_spec = vutil.build_property_filter_spec(
+            vim.client.factory,
+            [property_spec],
+            [object_spec])
+        options = vim.client.factory.create('ns0:RetrieveOptions')
+        options.maxObjects = max_objects
+
+        pc_result = vim.RetrievePropertiesEx(property_collector, specSet=[property_filter_spec], options=options)
+
+        result = []
+        topology = dict()
+
+        """ Retrieving needed hardware properties from ESX hosts """
+        with vutil.WithRetrieval(vim, pc_result) as pc_objects:
+            for objContent in pc_objects:
+                props_in = {prop.name: prop.val for prop in objContent.propSet}
+                processor_type = None
+                cpu_vendor = None
+                hardware_cpu_pkg = props_in.get("hardware.cpuPkg", [])[0]
+
+                if hardware_cpu_pkg and hardware_cpu_pkg[0]:
+                    t = hardware_cpu_pkg[0]
+                    processor_type = t.description
+                    cpu_vendor = t.vendor.title()
+
+                features = []
+                for featureCapability in props_in.get("config.featureCapability", []):
+                    for feature in featureCapability[1]:
+                        if feature.featureName.startswith("cpuid."):
+                            if feature.value == "1":
+                                features.append(feature.featureName.split(".", 1)[1].lower())
+
+                props = {
+                    "model": processor_type,
+                    "vendor": cpu_vendor,
+                    "features": sorted(features)
+                    }
+
+                hardware_cpu_info = props_in.get("hardware.cpuInfo", None)
+                if hardware_cpu_info:
+                    props["topology"] = {
+                        "cores": hardware_cpu_info.numCpuCores,
+                        "sockets": hardware_cpu_info.numCpuPackages,
+                        "threads": hardware_cpu_info.numCpuThreads
+                    }
+
+                result.append(props)
+
+        equal = True
+
+        """ Compare found ESX hosts """
+        if len(result) > 1:
+            for i in range(len(result) - 1):
+                if result[i] == result[i + 1]:
+                    continue
+                else:
+                    equal = False
+                    break
+
+        if not equal:
+            self._cpu_model = "CPU's for this cluster have different values!"
+        elif result:
+            self._cpu_model = result[0]
+
+        return self._cpu_model


### PR DESCRIPTION
…ogeneous cluster

If the cluster is homogeneous, we can expose the cpu model information.
That way, vms can be scheduled in different clusters depending on the underlying capabilities.