### PR TITLE
VMware: Image as VM template

### DIFF
--- a/nova/virt/vmwareapi/ds_util.py
+++ b/nova/virt/vmwareapi/ds_util.py
@@ -177,12 +177,21 @@ def _get_allowed_datastores(data_stores, datastore_regex):
     return allowed
 
 
-def get_available_datastores(session, cluster=None, datastore_regex=None):
+def get_available_datastores(session, cluster=None, datastore_regex=None, dc_ref=None):
     """Get the datastore list and choose the first local storage."""
-    ds = session._call_method(vutil,
-                              "get_object_property",
-                              cluster,
-                              "datastore")
+    if cluster:
+        ds = session._call_method(vutil,
+                                  "get_object_property",
+                                  cluster,
+                                  "datastore")
+    elif dc_ref:
+        ds = session._call_method(vutil,
+                                  "get_object_property",
+                                  dc_ref,
+                                  "datastore")
+    else:
+        return []
+
     if not ds:
         return []
     data_store_mors = ds.ManagedObjectReference

--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -395,8 +395,7 @@ def fetch_image_stream_optimized(context, instance, session, vm_name,
     LOG.info("Downloaded image file data %(image_ref)s",
              {'image_ref': instance.image_ref}, instance=instance)
     vmdk = vm_util.get_vmdk_info(session, imported_vm_ref, vm_name)
-    session._call_method(session.vim, "UnregisterVM", imported_vm_ref)
-    LOG.info("The imported VM '%s' was unregistered", vm_name, instance=instance)
+    vm_util.mark_vm_as_template(session, instance, imported_vm_ref)
     return vmdk.capacity_in_bytes, vmdk.path
 
 
@@ -494,10 +493,7 @@ def fetch_image_ova(context, instance, session, vm_name, ds_name,
                 vmdk = vm_util.get_vmdk_info(session,
                                              imported_vm_ref,
                                              vm_name)
-                session._call_method(session.vim, "UnregisterVM",
-                                     imported_vm_ref)
-                LOG.info("The imported VM was unregistered",
-                         instance=instance)
+                vm_util.mark_vm_as_template(session, instance, imported_vm_ref)
                 try:
                     return vmdk.capacity_in_bytes, vmdk.path.parent
                 except AttributeError:

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -213,14 +213,30 @@ def _get_allocation_info(client_factory, limits, allocation_type):
         allocation.shares = shares
     return allocation
 
+def append_vif_infos_to_config_spec(client_factory, config_spec, vif_infos, vif_limits, index=0):
+    if not config_spec.deviceChange:
+        config_spec.deviceChange = []
+    for vif_info in vif_infos:
+        vif_spec = _create_vif_spec(client_factory, vif_info, vif_limits)
+        config_spec.deviceChange.append(vif_spec)
+
+    if not config_spec.extraConfig:
+        config_spec.extraConfig = []
+    port_index = index
+    for vif_info in vif_infos:
+        if vif_info['iface_id']:
+            config_spec.extraConfig.append(_iface_id_option_value(client_factory,
+                                                                  vif_info['iface_id'],
+                                                                  port_index))
+            port_index += 1
 
 def get_vm_create_spec(client_factory, instance, data_store_name,
                        vif_infos, extra_specs,
                        os_type=constants.DEFAULT_OS_TYPE,
-                       profile_spec=None, metadata=None):
+                       profile_spec=None, metadata=None, vm_name=None):
     """Builds the VM Create spec."""
     config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
-    config_spec.name = instance.uuid
+    config_spec.name = vm_name or instance.uuid
     config_spec.guestId = os_type
     # The name is the unique identifier for the VM.
     config_spec.instanceUuid = instance.uuid
@@ -270,11 +286,6 @@ def get_vm_create_spec(client_factory, instance, data_store_name,
         config_spec.firmware = extra_specs.firmware
 
     devices = []
-    for vif_info in vif_infos:
-        vif_spec = _create_vif_spec(client_factory, vif_info,
-                                    extra_specs.vif_limits)
-        devices.append(vif_spec)
-
     serial_port_spec = create_serial_port_spec(client_factory)
     if serial_port_spec:
         devices.append(serial_port_spec)
@@ -298,14 +309,6 @@ def get_vm_create_spec(client_factory, instance, data_store_name,
     opt.value = True
     extra_config.append(opt)
 
-    port_index = 0
-    for vif_info in vif_infos:
-        if vif_info['iface_id']:
-            extra_config.append(_iface_id_option_value(client_factory,
-                                                       vif_info['iface_id'],
-                                                       port_index))
-            port_index += 1
-
     if (CONF.vmware.console_delay_seconds and
         CONF.vmware.console_delay_seconds > 0):
         opt = client_factory.create('ns0:OptionValue')
@@ -314,6 +317,8 @@ def get_vm_create_spec(client_factory, instance, data_store_name,
         extra_config.append(opt)
 
     config_spec.extraConfig = extra_config
+
+    append_vif_infos_to_config_spec(client_factory, config_spec, vif_infos, extra_specs.vif_limits)
 
     # Set the VM to be 'managed' by 'OpenStack'
     managed_by = client_factory.create('ns0:ManagedByInfo')
@@ -525,12 +530,9 @@ def get_network_attach_config_spec(client_factory, vif_info, index,
                                    vif_limits=None):
     """Builds the vif attach config spec."""
     config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
-    vif_spec = _create_vif_spec(client_factory, vif_info, vif_limits)
-    config_spec.deviceChange = [vif_spec]
-    if vif_info['iface_id'] is not None:
-        config_spec.extraConfig = [_iface_id_option_value(client_factory,
-                                                          vif_info['iface_id'],
-                                                          index)]
+
+    append_vif_infos_to_config_spec(client_factory, config_spec, [vif_info], vif_limits, index)
+
     return config_spec
 
 
@@ -1139,6 +1141,14 @@ def _get_vm_ref_from_vm_uuid(session, instance_uuid):
         return vm_refs[0]
 
 
+def find_by_inventory_path(session, inv_path):
+    return session._call_method(
+        session.vim,
+        "FindByInventoryPath",
+        session.vim.service_content.searchIndex,
+        inventoryPath=inv_path)
+
+
 def _get_vm_ref_from_extraconfig(session, instance_uuid):
     """Get reference to the VM with the uuid specified."""
     vms = session._call_method(vim_util, "get_objects",
@@ -1410,6 +1420,18 @@ def destroy_vm(session, instance, vm_ref=None):
         LOG.info("Destroyed the VM", instance=instance)
     except Exception:
         LOG.exception(_('Destroy VM failed'), instance=instance)
+
+
+def mark_vm_as_template(session, instance, vm_ref=None):
+    """Mark a VM instance as template. Assumes VM is powered off."""
+    try:
+        if not vm_ref:
+            vm_ref = get_vm_ref(session, instance)
+        LOG.debug("Marking the VM as template", instance=instance)
+        session._call_method(session.vim, "MarkAsTemplate", vm_ref)
+        LOG.info("Marked the VM as template", instance=instance)
+    except Exception:
+        LOG.exception(_('Mark VM as template failed'), instance=instance)
 
 
 def create_virtual_disk(session, dc_ref, adapter_type, disk_type,

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -24,6 +24,8 @@ import os
 import time
 import re
 import copy
+import math
+import six
 
 import decorator
 import cluster_util
@@ -82,6 +84,13 @@ vmops_opts = [
     cfg.BoolOpt('clone_from_snapshot',
                 default=True,
                 help='Create a snapshot of the VM before cloning it'),
+    cfg.BoolOpt('image_as_template',
+                default=True,
+                help='Keep Glance images as VM templates in vCenter per datastore and create instances as clone from template.'),
+    cfg.BoolOpt('fetch_image_from_other_datastores',
+                default=True,
+                help='Before fetching from Glance an image missing on the datastore first look for it on other '
+                     'datastores and clone it from there if available.'),
     ]
 
 
@@ -295,14 +304,19 @@ class VMwareVMOps(object):
         # We cannot truncate the 'id' as this is unique across OpenStack.
         return '%s (%s)' % (name[:40], id[:36])
 
-    def _get_project_folder(self, dc_info, project_id=None, type_=None):
+    def _get_project_folder_path(self, project_id, type_):
         folder_name = self._get_folder_name('Project', project_id)
         folder_path = 'OpenStack/%s/%s' % (folder_name, type_)
+
+        return folder_path
+
+    def _get_project_folder(self, dc_info, project_id=None, type_=None):
+        folder_path = self._get_project_folder_path(project_id, type_)
         return self._create_folders(dc_info.vmFolder, folder_path)
 
-    def build_virtual_machine(self, instance, context, image_info,
-                              dc_info, datastore, network_info, extra_specs,
-                              metadata):
+    def _get_vm_config_spec(self, instance, image_info,
+                            datastore, network_info, extra_specs,
+                            metadata, vm_name=None):
         vif_infos = vmwarevif.get_vif_info(self._session,
                                            self._cluster,
                                            utils.is_neutron(),
@@ -323,15 +337,19 @@ class VMwareVMOps(object):
                                                  extra_specs,
                                                  image_info.os_type,
                                                  profile_spec=profile_spec,
-                                                 metadata=metadata)
+                                                 metadata=metadata,
+                                                 vm_name=vm_name)
 
-        folder = self._get_project_folder(dc_info, project_id=instance.project_id, type_='Instances')
+        return config_spec
 
-        folder_name = self._get_folder_name('Project',
-                                            instance.project_id)
-        #folder_path = 'OpenStack/%s/Instances' % folder_name
-        #folder = self._create_folders(dc_info.vmFolder, folder_path)
-        folder = self._get_project_folder(dc_info, project_id=instance.project_id, type_='Instances')
+    def build_virtual_machine(self, instance, context, image_info,
+                              dc_info, datastore, network_info, extra_specs,
+                              metadata, folder_type='Instances', vm_name=None):
+        config_spec = self._get_vm_config_spec(instance, image_info, datastore,
+                                               network_info, extra_specs, metadata,
+                                               vm_name=vm_name)
+
+        folder = self._get_project_folder(dc_info, project_id=instance.project_id, type_=folder_type)
 
         # Create the VM
         vm_ref = vm_util.create_vm(self._session, instance, folder,
@@ -465,12 +483,14 @@ class VMwareVMOps(object):
             image_ds_loc.rel_path,
             cookies=cookies)
 
+    def _get_image_template_vm_name(self, image_id, datastore_name):
+        templ_vm_name = '%s (%s)' % (image_id, datastore_name)
+        return templ_vm_name
+
     def _fetch_image_as_vapp(self, context, vi, image_ds_loc):
         """Download stream optimized image to host as a vApp."""
 
-        # The directory of the imported disk is the unique name
-        # of the VM use to import it with.
-        vm_name = '%s (%s)' % (vi.ii.image_id, vi.datastore.name)
+        vm_name = self._get_image_template_vm_name(vi.ii.image_id, vi.datastore.name)
 
         LOG.debug("Downloading stream optimized image %(image_id)s to "
                   "%(vm_name)s on the data store "
@@ -486,7 +506,7 @@ class VMwareVMOps(object):
             self._session,
             vm_name,
             vi.datastore.name,
-            self._get_project_folder(vi.dc_info, project_id=vi.ii.owner, type_='Images'),
+            self._get_project_folder(vi.dc_info, project_id=vi.instance.project_id, type_='Images'),
             self._root_resource_pool)
         # The size of the image is different from the size of the virtual disk.
         # We want to use the latter. On vSAN this is the only way to get this
@@ -497,26 +517,16 @@ class VMwareVMOps(object):
     def _fetch_image_as_ova(self, context, vi, image_ds_loc):
         """Download root disk of an OVA image as streamOptimized."""
 
-        # The directory of the imported disk is the unique name
-        # of the VM use to import it with.
-        vm_name = '%s (%s)' % (vi.ii.image_id, vi.datastore.name)
+        vm_name = self._get_image_template_vm_name(vi.ii.image_id, vi.datastore.name)
 
         image_size, src_folder_ds_path = images.fetch_image_ova(context,
                                vi.instance,
                                self._session,
                                vm_name,
                                vi.datastore.name,
-                               self._get_project_folder(vi.dc_info, project_id=vi.ii.owner,type_='Images'),
+                               self._get_project_folder(vi.dc_info, project_id=vi.instance.project_id, type_='Images'),
                                self._root_resource_pool)
 
-        self._move_to_cache(vi.dc_info.ref,
-                            src_folder_ds_path,
-                            vi.cache_image_folder)
-
-        try:
-            ds_util.mkdir(self._session, vi.cache_image_folder, vi.dc_info.ref)
-        except vexc.FileAlreadyExistsException:
-            pass
         # The size of the image is different from the size of the virtual disk.
         # We want to use the latter. On vSAN this is the only way to get this
         # size because there is no VMDK descriptor.
@@ -601,19 +611,16 @@ class VMwareVMOps(object):
                             vi.cache_image_folder)
 
     def _cache_vm_image(self, vi, tmp_image_ds_loc):
+        dst_path = vi.cache_image_folder.join("%s.vmdk" % vi.ii.image_id)
         try:
-            dst_path = vi.cache_image_folder.join("%s.vmdk" % vi.ii.image_id)
-            try:
-                ds_util.mkdir(self._session, vi.cache_image_folder, vi.dc_info.ref)
-            except vexc.FileAlreadyExistsException:
-                pass
-            try:
-                ds_util.disk_move(self._session, vi.dc_info.ref,
-                                  tmp_image_ds_loc, dst_path)
-            except vexc.FileAlreadyExistsException:
-                pass
-        finally:
-            self._delete_datastore_file(str(ds_obj.DatastorePath.parse(tmp_image_ds_loc).parent), vi.dc_info.ref)
+            ds_util.mkdir(self._session, vi.cache_image_folder, vi.dc_info.ref)
+        except vexc.FileAlreadyExistsException:
+            pass
+        try:
+            ds_util.disk_copy(self._session, vi.dc_info.ref,
+                              tmp_image_ds_loc, dst_path)
+        except vexc.FileAlreadyExistsException:
+            pass
 
     """def _cache_stream_optimized_image(self, vi, tmp_image_ds_loc):
         dst_path = vi.cache_image_folder.join("%s.vmdk" % vi.ii.image_id)
@@ -688,6 +695,32 @@ class VMwareVMOps(object):
             raise exception.InvalidDiskInfo(reason=reason)
         return image_prepare, image_fetch, image_cache
 
+    def _fetch_image_from_other_datastores(self, vi):
+        dc_all_datastores = ds_util.get_available_datastores(self._session, dc_ref=vi.dc_info.ref)
+        dc_other_datastores = [ds for ds in dc_all_datastores if dict(ds.ref) != dict(vi.datastore.ref)]
+
+        client_factory = self._session.vim.client.factory
+        tmp_vi = copy.copy(vi)
+        for ds in dc_other_datastores:
+            tmp_vi.datastore = ds
+            other_templ_vm_ref = self._find_image_template_vm(tmp_vi)
+            if other_templ_vm_ref:
+                rel_spec = vm_util.relocate_vm_spec(client_factory,
+                                                    res_pool=self._root_resource_pool,
+                                                    disk_move_type="moveAllDiskBackingsAndDisallowSharing",
+                                                    datastore=vi.datastore.ref)
+                clone_spec = vm_util.clone_vm_spec(client_factory, rel_spec, template=True)
+                templ_vm_clone_task = self._session._call_method(
+                    self._session.vim,
+                    "CloneVM_Task",
+                    other_templ_vm_ref,
+                    folder=self._get_project_folder(vi.dc_info, project_id=vi.instance.project_id, type_='Images'),
+                    name=self._get_image_template_vm_name(vi.ii.image_id, vi.datastore.name),
+                    spec=clone_spec)
+                task_info = self._session._wait_for_task(templ_vm_clone_task)
+                templ_vm_ref = task_info.result
+                return templ_vm_ref
+
     def _fetch_image_if_missing(self, context, vi):
         image_prepare, image_fetch, image_cache = self._get_image_callbacks(vi)
         LOG.debug("Processing image %s", vi.ii.image_id, instance=vi.instance)
@@ -696,9 +729,18 @@ class VMwareVMOps(object):
                             lock_file_prefix='nova-vmware-fetch_image'):
             self.check_cache_folder(vi.datastore.name, vi.datastore.ref)
             ds_browser = self._get_ds_browser(vi.datastore.ref)
-            if not ds_util.file_exists(self._session, ds_browser,
-                                       vi.cache_image_folder,
-                                       vi.cache_image_path.basename):
+            image_available = ds_util.file_exists(self._session, ds_browser, vi.cache_image_folder,
+                                                  vi.cache_image_path.basename)
+
+            if not image_available and CONF.vmware.image_as_template:
+                templ_vm_ref = self._find_image_template_vm(vi)
+                image_available = (templ_vm_ref is not None)
+
+                if not image_available and CONF.vmware.fetch_image_from_other_datastores:
+                    templ_vm_ref = self._fetch_image_from_other_datastores(vi)
+                    image_available = (templ_vm_ref is not None)
+
+            if not image_available:
                 LOG.debug("Preparing fetch location", instance=vi.instance)
                 tmp_dir_loc, tmp_image_ds_loc = image_prepare(vi)
                 LOG.debug("Fetch image to %s", tmp_image_ds_loc,
@@ -799,6 +841,129 @@ class VMwareVMOps(object):
         if new_size is not None:
             vi.ii.file_size = new_size
 
+    def _create_image_template(self, context, vi, extra_specs):
+        metadata = self._get_instance_metadata(context, vi.instance)
+
+        max_attempts = 2
+        for i in six.moves.xrange(max_attempts):
+            try:
+                templ_vm_ref = self.build_virtual_machine(vi.instance,
+                                                    context,
+                                                    vi.ii,
+                                                    vi.dc_info,
+                                                    vi.datastore,
+                                                    None,
+                                                    extra_specs,
+                                                    metadata,
+                                                    folder_type='Images',
+                                                    vm_name=self._get_image_template_vm_name(vi.ii.image_id, vi.datastore.name))
+
+                self._imagecache.enlist_image(
+                        vi.ii.image_id, vi.datastore, vi.dc_info.ref)
+                self._fetch_image_if_missing(context, vi)
+
+                if vi.ii.is_iso:
+                    self._use_iso_image(templ_vm_ref, vi)
+                elif vi.ii.linked_clone:
+                    self._use_disk_image_as_linked_clone(templ_vm_ref, vi)
+                else:
+                    self._use_disk_image_as_full_clone(templ_vm_ref, vi)
+
+                vm_util.mark_vm_as_template(self._session, vi.instance, templ_vm_ref)
+
+                return templ_vm_ref
+            except Exception as create_templ_exc:
+                is_last_attempt = (i == max_attempts - 1)
+                with excutils.save_and_reraise_exception(reraise=is_last_attempt):
+                    LOG.error('Creating VM template for image failed with error: %s',
+                              create_templ_exc, instance=vi.instance)
+                    try:
+                        vm_util.destroy_vm(self._session, vi.instance)
+                    except Exception as destroy_templ_exc:
+                        LOG.error('Cleaning up VM template for image failed with error: %s',
+                                  destroy_templ_exc, instance=vi.instance)
+
+    def _build_template_vm_inventory_path(self, vi):
+        vm_folder_name = self._session._call_method(vutil,
+                                                    "get_object_property",
+                                                    vi.dc_info.vmFolder,
+                                                    "name")
+        images_folder_path = self._get_project_folder_path(vi.instance.project_id, 'Images')
+        templ_vm_name = self._get_image_template_vm_name(vi.ii.image_id, vi.datastore.name)
+        templ_vm_inventory_path = '%s/%s/%s/%s' % (vi.dc_info.name, vm_folder_name, images_folder_path, templ_vm_name)
+        return templ_vm_inventory_path
+
+    def _find_image_template_vm(self, vi):
+        templ_vm_inventory_path = self._build_template_vm_inventory_path(vi)
+        templ_vm_ref = vm_util.find_by_inventory_path(self._session, templ_vm_inventory_path)
+
+        return templ_vm_ref
+
+    def _get_vm_template_for_image(self, context, instance, image_info, extra_specs):
+        templ_instance = copy.deepcopy(instance)
+        # Use image UUID instead of instance UUID for creating the VM template.
+        templ_instance.uuid = templ_instance.image_ref
+
+        with lockutils.lock(templ_instance.uuid,
+                            lock_file_prefix='nova-vmware-image-template'):
+
+            # Create template with the smallest root disk size that can hold the image so that
+            # it can be extended during instantiation (after clone) to match the flavor
+            templ_instance.flavor.root_gb = int(math.ceil(
+                float(image_info.file_size) / units.Gi / templ_instance.flavor.root_gb
+            ))
+
+            vi = self._get_vm_config_info(templ_instance, image_info, extra_specs)
+
+            self._imagecache.enlist_image(
+                    vi.ii.image_id, vi.datastore, vi.dc_info.ref)
+            self._fetch_image_if_missing(context, vi)
+
+            templ_vm_ref = self._find_image_template_vm(vi)
+
+            if not templ_vm_ref and CONF.vmware.fetch_image_from_other_datastores:
+                templ_vm_ref = self._fetch_image_from_other_datastores(vi)
+
+            if not templ_vm_ref:
+                templ_vm_ref = self._create_image_template(context, vi, extra_specs)
+
+            return templ_vm_ref
+
+    def _create_instance_from_image_template(self, context, client_factory, templ_vm_ref, vi,
+                                             extra_specs, network_info):
+        rel_spec = vm_util.relocate_vm_spec(client_factory,
+                                            res_pool=self._root_resource_pool,
+                                            disk_move_type="moveAllDiskBackingsAndDisallowSharing")
+        clone_spec = vm_util.clone_vm_spec(client_factory, rel_spec)
+        vm_clone_task = self._session._call_method(
+            self._session.vim,
+            "CloneVM_Task",
+            templ_vm_ref,
+            folder=self._get_project_folder(vi.dc_info, project_id=vi.instance.project_id, type_='Instances'),
+            name=vi.instance.uuid,
+            spec=clone_spec)
+        task_info = self._session._wait_for_task(vm_clone_task)
+        vm_ref = task_info.result
+
+        root_vmdk_info = vm_util.get_vmdk_info(self._session, vm_ref, uuid=vi.instance.uuid)
+        self._extend_if_required(vi.dc_info, vi.ii, vi.instance, root_vmdk_info.path)
+
+        metadata = self._get_instance_metadata(context, vi.instance)
+        reconfig_spec = vm_util.get_vm_resize_spec(client_factory,
+                                                   int(vi.instance.vcpus), int(vi.instance.memory_mb),
+                                                   extra_specs, metadata=metadata)
+        reconfig_spec.instanceUuid = vi.instance.uuid
+        vif_infos = vmwarevif.get_vif_info(self._session,
+                                           self._cluster,
+                                           utils.is_neutron(),
+                                           vi.ii.vif_model,
+                                           network_info)
+        vm_util.append_vif_infos_to_config_spec(client_factory, reconfig_spec, vif_infos, extra_specs.vif_limits)
+
+        vm_util.reconfigure_vm(self._session, vm_ref, reconfig_spec)
+
+        return vm_ref
+
     def spawn(self, context, instance, image_meta, injected_files,
               admin_password, network_info, block_device_info=None):
 
@@ -812,17 +977,20 @@ class VMwareVMOps(object):
         vi = self._get_vm_config_info(instance, image_info,
                                       extra_specs)
 
-        metadata = self._get_instance_metadata(context, instance)
-        # Creates the virtual machine. The virtual machine reference returned
-        # is unique within Virtual Center.
-        vm_ref = self.build_virtual_machine(instance,
-                                            context,
-                                            image_info,
-                                            vi.dc_info,
-                                            vi.datastore,
-                                            network_info,
-                                            extra_specs,
-                                            metadata)
+        if instance.image_ref and CONF.vmware.image_as_template:
+            templ_vm_ref = self._get_vm_template_for_image(context, instance, image_info, extra_specs)
+            vm_ref = self._create_instance_from_image_template(context, client_factory, templ_vm_ref, vi,
+                                                               extra_specs, network_info)
+        else:
+            metadata = self._get_instance_metadata(context, instance)
+            vm_ref = self.build_virtual_machine(instance,
+                                                context,
+                                                image_info,
+                                                vi.dc_info,
+                                                vi.datastore,
+                                                network_info,
+                                                extra_specs,
+                                                metadata)
 
         # Cache the vm_ref. This saves a remote call to the VC. This uses the
         # instance uuid.
@@ -846,7 +1014,7 @@ class VMwareVMOps(object):
             block_device_mapping = driver.block_device_info_get_mapping(
                 block_device_info)
 
-        if instance.image_ref:
+        if instance.image_ref and not CONF.vmware.image_as_template:
             self._imagecache.enlist_image(
                     image_info.image_id, vi.datastore, vi.dc_info.ref)
             self._fetch_image_if_missing(context, vi)


### PR DESCRIPTION
- Import image as VM template per datastore.
- First look on other datastores before fetching the image.
- Create instances by cloning the VM template.