### PR TITLE
Soft-affinity only means same cluster

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -137,12 +137,13 @@ def update_placement(session, cluster, vm_ref, group_info):
         if group_info.policies:
             # VM group does not exist on cluster
             policy = group_info.policies[0]
-            rule_name = "%s-%s" % (group_info.uuid, policy)
-            rule = _get_rule(cluster_config, rule_name)
-            operation = "edit" if rule else "add"
-            config_spec.rulesSpec = _create_cluster_rules_spec(
-                client_factory, rule_name, [vm_ref], policy=policy,
-                operation=operation, rule=rule)
+            if policy != 'soft-affinity':
+                rule_name = "%s-%s" % (group_info.uuid, policy)
+                rule = _get_rule(cluster_config, rule_name)
+                operation = "edit" if rule else "add"
+                config_spec.rulesSpec = _create_cluster_rules_spec(
+                    client_factory, rule_name, [vm_ref], policy=policy,
+                    operation=operation, rule=rule)
 
     reconfigure_cluster(session, cluster, config_spec)
 


### PR DESCRIPTION
Until now, affinity and soft-affinity meant the same thing from the
vcenter side, because the same rules were created in the vcenter by the
openstack vmware driver.

This commit now changes the meaning of soft-affinity: no rule will be
created in the vcenter for soft-affinity, thus making the affinity work
only on nova-compute basis and not on ESXi host basis.