### PR TITLE
Removing default parameter value 'def get_available_resource(self, no…

### DIFF
--- a/nova/tests/unit/virt/ironic/test_client_wrapper.py
+++ b/nova/tests/unit/virt/ironic/test_client_wrapper.py
@@ -81,12 +81,12 @@ class IronicClientWrapperTestCase(test.NoDBTestCase):
         # nova.utils.get_ksa_adapter().get_endpoint()
         self.get_ksa_adapter.assert_called_once_with(
             'baremetal', ksa_auth=self.get_auth_plugin.return_value,
-            ksa_session='session', min_version=(1, 37),
+            ksa_session='session', min_version=(1, 46),
             max_version=(1, ksa_disc.LATEST))
         expected = {'session': 'session',
             'max_retries': CONF.ironic.api_max_retries,
             'retry_interval': CONF.ironic.api_retry_interval,
-            'os_ironic_api_version': '1.37',
+            'os_ironic_api_version': '1.46',
             'ironic_url':
                 self.get_ksa_adapter.return_value.get_endpoint.return_value}
         mock_ir_cli.assert_called_once_with(1, **expected)
@@ -106,13 +106,13 @@ class IronicClientWrapperTestCase(test.NoDBTestCase):
         # nova.utils.get_endpoint_data
         self.get_ksa_adapter.assert_called_once_with(
             'baremetal', ksa_auth=self.get_auth_plugin.return_value,
-            ksa_session='session', min_version=(1, 37),
+            ksa_session='session', min_version=(1, 46),
             max_version=(1, ksa_disc.LATEST))
         # When get_endpoint_data raises any ServiceNotFound, None is returned.
         expected = {'session': 'session',
                     'max_retries': CONF.ironic.api_max_retries,
                     'retry_interval': CONF.ironic.api_retry_interval,
-                    'os_ironic_api_version': '1.37',
+                    'os_ironic_api_version': '1.46',
                     'ironic_url': None}
         mock_ir_cli.assert_called_once_with(1, **expected)
 
@@ -130,7 +130,7 @@ class IronicClientWrapperTestCase(test.NoDBTestCase):
         expected = {'session': 'session',
                     'max_retries': CONF.ironic.api_max_retries,
                     'retry_interval': CONF.ironic.api_retry_interval,
-                    'os_ironic_api_version': '1.37',
+                    'os_ironic_api_version': '1.46',
                     'ironic_url': endpoint}
         mock_ir_cli.assert_called_once_with(1, **expected)
 

--- a/nova/virt/driver.py
+++ b/nova/virt/driver.py
@@ -877,7 +877,7 @@ class ComputeDriver(object):
         """
         raise NotImplementedError()
 
-    def get_available_resource(self, nodename=None):
+    def get_available_resource(self, nodename):
         """Retrieve resource information.
 
         This method is called when nova-compute launches, and

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -349,7 +349,7 @@ class VMwareVCDriver(driver.ComputeDriver):
                'numa_topology': None,
                }
 
-    def get_available_resource(self, nodename=None):
+    def get_available_resource(self, nodename):
         """Retrieve resource info.
 
         This method is called when nova-compute launches, and


### PR DESCRIPTION
…dename):' inside ComputeDriver; Fixed ironic unit tests;