### PR TITLE
Fix resize instance cross cluster issues

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3410,6 +3410,11 @@ class API(base.Base):
                       instance=instance)
             new_instance_type = current_instance_type
         else:
+            if CONF.always_resize_on_same_host:
+                LOG.info('Setting resize to the same host')
+                host_name = instance.host
+                node = objects.ComputeNode.get_first_node_by_host_for_old_compat(
+                    context, host_name, use_slave=True)
             new_instance_type = flavors.get_flavor_by_flavor_id(
                     flavor_id, read_deleted="no")
             if (new_instance_type.get('root_gb') == 0 and

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3452,12 +3452,12 @@ class API(base.Base):
         instance.update(extra_instance_updates)
         instance.save(expected_task_state=[None])
 
-        filter_properties = {'ignore_hosts': []}
+        filter_properties = {'ignore_hosts': [], 'force_hosts': []}
 
-        if not CONF.allow_resize_to_same_host:
+        if CONF.always_resize_on_same_host:
+            filter_properties['force_hosts'].append(instance.host)
+        elif not CONF.allow_resize_to_same_host:
             filter_properties['ignore_hosts'].append(instance.host)
-        else:
-            filter_properties['force_nodes'] = [instance.node]
 
         if self.cell_type == 'api':
             # Create migration record.
@@ -3480,6 +3480,7 @@ class API(base.Base):
             request_spec = objects.RequestSpec.get_by_instance_uuid(
                 context, instance.uuid)
             request_spec.ignore_hosts = filter_properties['ignore_hosts']
+            request_spec.force_hosts = filter_properties['force_hosts']
         except exception.RequestSpecNotFound:
             # Some old instances can still have no RequestSpec object attached
             # to them, we need to support the old way
@@ -3494,7 +3495,6 @@ class API(base.Base):
         # resource consumption for this operation is written to the database
         # by compute.
         scheduler_hint = {'filter_properties': filter_properties}
-
         if request_spec:
             if host_name is None:
                 # If 'host_name' is not specified,
@@ -3509,6 +3509,7 @@ class API(base.Base):
                 # that is clear to the caller.
                 request_spec.requested_destination = objects.Destination(
                     host=node.host, node=node.hypervisor_hostname)
+
 
         self.compute_task_api.resize_instance(context, instance,
                 extra_instance_updates, scheduler_hint=scheduler_hint,

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3457,12 +3457,12 @@ class API(base.Base):
         instance.update(extra_instance_updates)
         instance.save(expected_task_state=[None])
 
-        filter_properties = {'ignore_hosts': [], 'force_hosts': []}
+        filter_properties = {'ignore_hosts': []}
 
-        if CONF.always_resize_on_same_host:
-            filter_properties['force_hosts'].append(instance.host)
-        elif not CONF.allow_resize_to_same_host:
+        if not CONF.allow_resize_to_same_host:
             filter_properties['ignore_hosts'].append(instance.host)
+        else:
+            filter_properties['force_nodes'] = [instance.node]
 
         if self.cell_type == 'api':
             # Create migration record.
@@ -3485,7 +3485,6 @@ class API(base.Base):
             request_spec = objects.RequestSpec.get_by_instance_uuid(
                 context, instance.uuid)
             request_spec.ignore_hosts = filter_properties['ignore_hosts']
-            request_spec.force_hosts = filter_properties['force_hosts']
         except exception.RequestSpecNotFound:
             # Some old instances can still have no RequestSpec object attached
             # to them, we need to support the old way

--- a/nova/conductor/tasks/migrate.py
+++ b/nova/conductor/tasks/migrate.py
@@ -180,11 +180,10 @@ class MigrationTask(base.TaskBase):
             scheduler_utils.populate_retry(legacy_props,
                                            self.instance.uuid)
 
-        if not CONF.always_resize_on_same_host:
-            # NOTE(sbauza): Force_hosts/nodes needs to be reset
-            # if we want to make sure that the next destination
-            # is not forced to be the original host
-            self.request_spec.reset_forced_destinations()
+        # NOTE(sbauza): Force_hosts/nodes needs to be reset
+        # if we want to make sure that the next destination
+        # is not forced to be the original host
+        self.request_spec.reset_forced_destinations()
 
         # NOTE(danms): Right now we only support migrate to the same
         # cell as the current instance, so request that the scheduler

--- a/nova/conductor/tasks/migrate.py
+++ b/nova/conductor/tasks/migrate.py
@@ -15,6 +15,7 @@ from oslo_serialization import jsonutils
 
 from nova import availability_zones
 from nova.conductor.tasks import base
+import nova.conf
 from nova import exception
 from nova.i18n import _
 from nova import objects
@@ -23,6 +24,7 @@ from nova.scheduler import utils as scheduler_utils
 
 LOG = logging.getLogger(__name__)
 
+CONF = nova.conf.CONF
 
 def replace_allocation_with_migration(context, instance, migration):
     """Replace instance's allocation with one for a migration.
@@ -178,10 +180,11 @@ class MigrationTask(base.TaskBase):
             scheduler_utils.populate_retry(legacy_props,
                                            self.instance.uuid)
 
-        # NOTE(sbauza): Force_hosts/nodes needs to be reset
-        # if we want to make sure that the next destination
-        # is not forced to be the original host
-        self.request_spec.reset_forced_destinations()
+        if not CONF.always_resize_on_same_host:
+            # NOTE(sbauza): Force_hosts/nodes needs to be reset
+            # if we want to make sure that the next destination
+            # is not forced to be the original host
+            self.request_spec.reset_forced_destinations()
 
         # NOTE(danms): Right now we only support migrate to the same
         # cell as the current instance, so request that the scheduler

--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -53,6 +53,12 @@ to resize to the same host. Setting this option to true will add
 the same host to the destination options. Also set to true
 if you allow the ServerGroupAffinityFilter and need to resize.
 """),
+cfg.BoolOpt('always_resize_on_same_host',
+        default=False,
+        help="""
+This flag prevents instance to be moved to another compute node
+during resize of an instance. 
+"""),
     cfg.ListOpt('non_inheritable_image_properties',
         default=['cache_in_nova', 'bittorrent',
                  'img_signature_hash_method', 'img_signature',


### PR DESCRIPTION
This fix adds configuration flag for avoiding migrations across
clusters. Setting `always_resize_on_same_host` config option
will put the instance host in `force_hosts` resulting in
resize the instance on the same host.