### PR TITLE
fix for pagination with duplicate instances

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -2538,7 +2538,7 @@ class API(base.Base):
         instances = objects.InstanceList(
             objects=list(filter(filter_method,
                            build_req_instances.objects +
-                           insts.objects))[:orig_limit])
+                           insts.objects))[:limit])
 
         if filter_ip:
             instances = self._ip_filter(instances, filters, orig_limit)

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -2504,8 +2504,6 @@ class API(base.Base):
 
         build_req_instances = objects.InstanceList(
             objects=[build_req.instance for build_req in build_requests])
-        # Only subtract from limit if it is not None
-        limit = (limit - len(build_req_instances)) if limit else limit
 
         # We could arguably avoid joining on security_groups if we're using
         # neutron (which is the default) but if you're using neutron then the
@@ -2535,14 +2533,12 @@ class API(base.Base):
             return _filter
 
         filter_method = _get_unique_filter_method()
-        # Only subtract from limit if it is not None
-        limit = (limit - len(insts)) if limit else limit
         # TODO(alaski): Clean up the objects concatenation when List objects
         # support it natively.
         instances = objects.InstanceList(
             objects=list(filter(filter_method,
                            build_req_instances.objects +
-                           insts.objects)))
+                           insts.objects))[:orig_limit])
 
         if filter_ip:
             instances = self._ip_filter(instances, filters, orig_limit)

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -2544,13 +2544,6 @@ class API(base.Base):
                            build_req_instances.objects +
                            insts.objects)))
 
-        if limit is not None and len(instances) != len(build_req_instances) +\
-                len(insts):
-            raise exception.NovaException(
-                _('Duplicate instances found, '
-                  'database inconsistentency between cells and api,'
-                  ' breaks pagination'))
-
         if filter_ip:
             instances = self._ip_filter(instances, filters, orig_limit)
 

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -11474,6 +11474,28 @@ class ComputeAPIIpFilterTestCase(test.NoDBTestCase):
     @mock.patch.object(objects.BuildRequestList, 'get_by_filters')
     @mock.patch.object(objects.CellMapping, 'get_by_uuid',
             side_effect=exception.CellMappingNotFound(uuid=uuids.volume))
+    @mock.patch('nova.network.neutronv2.api.API.'
+                'has_substr_port_filtering_extension', return_value=False)
+    def test_ip_filtering_no_limit_applied(self, mock_has_port_filter_ext,
+                                           _mock_cell_map_get,
+                                           mock_buildreq_get):
+        c = context.get_admin_context()
+        # Limit is not applied before passing instances to _ip_filter
+        with mock.patch('nova.compute.instance_list.'
+                        'get_instance_objects_sorted') as m_get:
+            with mock.patch('nova.compute.api.API._ip_filter') as m_ip_filter:
+                insts = [objects.Instance(uuid=1), objects.Instance(uuid=2)]
+                m_get.return_value = objects.InstanceList(objects=insts)
+                self.compute_api.get_all(c, search_opts={'ip': '.10'}, limit=1)
+                self.assertEqual(1, m_get.call_count)
+                self.assertEqual(1, m_ip_filter.call_count)
+                args = m_ip_filter.call_args[0]
+                self.assertEqual(len(args[0]), 2, 'Instances were filtered '
+                                 'before getting passed to _ip_filter()')
+
+    @mock.patch.object(objects.BuildRequestList, 'get_by_filters')
+    @mock.patch.object(objects.CellMapping, 'get_by_uuid',
+            side_effect=exception.CellMappingNotFound(uuid=uuids.volume))
     def test_ip_filtering_pass_limit_to_db(self, _mock_cell_map_get,
                                            mock_buildreq_get):
         c = context.get_admin_context()

--- a/nova/tests/unit/compute/test_compute_api.py
+++ b/nova/tests/unit/compute/test_compute_api.py
@@ -5530,12 +5530,18 @@ class _ComputeAPIUnitTestMixIn(object):
             for i, instance in enumerate(build_req_instances + cell_instances):
                 self.assertEqual(instance, instances[i])
 
+            instances = self.compute_api.get_all(
+                self.context, search_opts={'foo': 'bar'},
+                limit=3, marker='fake-marker', sort_keys=['baz'],
+                sort_dirs=['desc'])
+            self.assertEqual(len(instances), 3)
+
     @mock.patch.object(objects.BuildRequestList, 'get_by_filters')
     @mock.patch.object(objects.CellMapping, 'get_by_uuid',
                        side_effect=exception.CellMappingNotFound(uuid='fake'))
-    def test_get_all_build_requests_decrement_limit(self,
-                                                    mock_cell_mapping_get,
-                                                    mock_buildreq_get):
+    def test_get_all_build_requests_do_not_decrement_limit(self,
+                                                        mock_cell_mapping_get,
+                                                        mock_buildreq_get):
 
         build_req_instances = self._list_of_instances(2)
         build_reqs = [objects.BuildRequest(self.context, instance=instance)
@@ -5560,7 +5566,7 @@ class _ComputeAPIUnitTestMixIn(object):
                 sort_keys=['baz'], sort_dirs=['desc'])
             fields = ['metadata', 'info_cache', 'security_groups']
             mock_inst_get.assert_called_once_with(
-                self.context, {'foo': 'bar'}, 8, None,
+                self.context, {'foo': 'bar'}, 10, None,
                 fields, ['baz'], ['desc'])
             for i, instance in enumerate(build_req_instances + cell_instances):
                 self.assertEqual(instance, instances[i])
@@ -5598,7 +5604,7 @@ class _ComputeAPIUnitTestMixIn(object):
             fields = ['metadata', 'info_cache', 'security_groups']
             mock_inst_get.assert_called_once_with(
                 mock.ANY, {'foo': 'bar'},
-                8, None,
+                10, None,
                 fields, ['baz'], ['desc'])
             for i, instance in enumerate(build_req_instances +
                                          cell_instances):
@@ -6147,12 +6153,18 @@ class Cellsv1DeprecatedTestMixIn(object):
             for i, instance in enumerate(build_req_instances + cell_instances):
                 self.assertEqual(instance, instances[i])
 
+            instances = self.compute_api.get_all(
+                self.context, search_opts={'foo': 'bar'},
+                limit=3, marker='fake-marker', sort_keys=['baz'],
+                sort_dirs=['desc'])
+            self.assertEqual(len(instances), 3)
+
     @mock.patch.object(objects.BuildRequestList, 'get_by_filters')
     @mock.patch.object(objects.CellMapping, 'get_by_uuid',
                        side_effect=exception.CellMappingNotFound(uuid='fake'))
-    def test_get_all_build_requests_decrement_limit(self,
-                                                    mock_cell_mapping_get,
-                                                    mock_buildreq_get):
+    def test_get_all_build_requests_do_not_decrement_limit(self,
+                                                        mock_cell_mapping_get,
+                                                        mock_buildreq_get):
 
         build_req_instances = self._list_of_instances(2)
         build_reqs = [objects.BuildRequest(self.context, instance=instance)
@@ -6177,7 +6189,7 @@ class Cellsv1DeprecatedTestMixIn(object):
                 sort_keys=['baz'], sort_dirs=['desc'])
             fields = ['metadata', 'info_cache', 'security_groups']
             mock_inst_get.assert_called_once_with(
-                self.context, {'foo': 'bar'}, limit=8, marker=None,
+                self.context, {'foo': 'bar'}, limit=10, marker=None,
                 fields=fields, sort_keys=['baz'], sort_dirs=['desc'])
             for i, instance in enumerate(build_req_instances + cell_instances):
                 self.assertEqual(instance, instances[i])
@@ -6227,11 +6239,11 @@ class Cellsv1DeprecatedTestMixIn(object):
                     mock_target_cell.assert_any_call(self.context, cm)
             fields = ['metadata', 'info_cache', 'security_groups']
             inst_get_calls = [mock.call(cctxt, {'foo': 'bar'},
-                                        limit=8, marker=None,
+                                        limit=10, marker=None,
                                         fields=fields, sort_keys=['baz'],
                                         sort_dirs=['desc']),
                               mock.call(mock.ANY, {'foo': 'bar'},
-                                        limit=6, marker=None,
+                                        limit=8, marker=None,
                                         fields=fields, sort_keys=['baz'],
                                         sort_dirs=['desc'])
                               ]

--- a/nova/tests/unit/compute/test_compute_api.py
+++ b/nova/tests/unit/compute/test_compute_api.py
@@ -5515,19 +5515,20 @@ class _ComputeAPIUnitTestMixIn(object):
             mock_inst_get.return_value = objects.InstanceList(
                 self.context, objects=build_req_instances[:1] + cell_instances)
 
-            self.assertRaises(exception.NovaException,
-                self.compute_api.get_all, self.context,
-                              search_opts={'foo': 'bar'},
-                limit=10, marker='fake-marker', sort_keys=['baz'],
+            instances = self.compute_api.get_all(
+                self.context, search_opts={'foo': 'bar'},
+                limit=None, marker='fake-marker', sort_keys=['baz'],
                 sort_dirs=['desc'])
 
             mock_buildreq_get.assert_called_once_with(
-                self.context, {'foo': 'bar'}, limit=10, marker='fake-marker',
+                self.context, {'foo': 'bar'}, limit=None, marker='fake-marker',
                 sort_keys=['baz'], sort_dirs=['desc'])
             fields = ['metadata', 'info_cache', 'security_groups']
             mock_inst_get.assert_called_once_with(
-                self.context, {'foo': 'bar'}, 8, None,
+                self.context, {'foo': 'bar'}, None, None,
                 fields, ['baz'], ['desc'])
+            for i, instance in enumerate(build_req_instances + cell_instances):
+                self.assertEqual(instance, instances[i])
 
     @mock.patch.object(objects.BuildRequestList, 'get_by_filters')
     @mock.patch.object(objects.CellMapping, 'get_by_uuid',
@@ -6131,19 +6132,20 @@ class Cellsv1DeprecatedTestMixIn(object):
             mock_inst_get.return_value = objects.InstanceList(
                 self.context, objects=build_req_instances[:1] + cell_instances)
 
-            self.assertRaises(exception.NovaException,
-                self.compute_api.get_all, self.context,
-                              search_opts={'foo': 'bar'},
-                limit=10, marker='fake-marker', sort_keys=['baz'],
+            instances = self.compute_api.get_all(
+                self.context, search_opts={'foo': 'bar'},
+                limit=None, marker='fake-marker', sort_keys=['baz'],
                 sort_dirs=['desc'])
 
             mock_buildreq_get.assert_called_once_with(
-                self.context, {'foo': 'bar'}, limit=10, marker='fake-marker',
+                self.context, {'foo': 'bar'}, limit=None, marker='fake-marker',
                 sort_keys=['baz'], sort_dirs=['desc'])
             fields = ['metadata', 'info_cache', 'security_groups']
             mock_inst_get.assert_called_once_with(
-                self.context, {'foo': 'bar'}, limit=8, marker=None,
+                self.context, {'foo': 'bar'}, limit=None, marker=None,
                 fields=fields, sort_keys=['baz'], sort_dirs=['desc'])
+            for i, instance in enumerate(build_req_instances + cell_instances):
+                self.assertEqual(instance, instances[i])
 
     @mock.patch.object(objects.BuildRequestList, 'get_by_filters')
     @mock.patch.object(objects.CellMapping, 'get_by_uuid',


### PR DESCRIPTION
instead of returning exception on duplicate found with pagination enabled,
we fetch the full amount of instances from cells regardless of open
buildrequests and slice the result at the end to the requested length.

The nanny can clean the orphaned build-requests at any time while maintaining sane API results.