### PR TITLE
Make stop on unexpected power state configurable

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -7262,10 +7262,38 @@ class ComputeManager(manager.Manager):
         if vm_state in (vm_states.BUILDING,
                         vm_states.RESCUED,
                         vm_states.RESIZED,
-                        vm_states.SUSPENDED,
                         vm_states.ERROR):
             # TODO(maoy): we ignore these vm_state for now.
             pass
+        elif vm_state == vm_states.SUSPENDED:
+            if not CONF.sync_power_state_unexpected_call_stop:
+                if vm_power_state in (power_state.SHUTDOWN,
+                                      power_state.CRASHED):
+                    LOG.warning("Instance shutdown by itself. "
+                                "Current vm_state: %(vm_state)s, "
+                                "current task_state: %(task_state)s, "
+                                "original DB power_state: %(db_power_state)s, "
+                                "current VM power_state: %(vm_power_state)s",
+                                {'vm_state': vm_state,
+                                 'task_state': db_instance.task_state,
+                                 'db_power_state': orig_db_power_state,
+                                 'vm_power_state': vm_power_state},
+                                instance=db_instance)
+                    db_instance.vm_state = vm_state.STOPPED
+                    db_instance.save()
+                elif vm_power_state == power_state.RUNNING:
+                    LOG.WARNING("Instance started running by itself. "
+                                "Current vm_state: %(vm_state)s, "
+                                "current task_state: %(task_state)s, "
+                                "original DB power_state: %(db_power_state)s, "
+                                "current VM power_state: %(vm_power_state)s",
+                                {'vm_state': vm_state,
+                                 'task_state': db_instance.task_state,
+                                 'db_power_state': orig_db_power_state,
+                                 'vm_power_state': vm_power_state},
+                                instance=db_instance)
+                    db_instance.vm_state = vm_state.ACTIVE
+                    db_instance.save()
         elif vm_state == vm_states.ACTIVE:
             # The only rational power state should be RUNNING
             if vm_power_state in (power_state.SHUTDOWN,

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -7324,6 +7324,8 @@ class ComputeManager(manager.Manager):
                     LOG.warning("Instance is suspended unexpectedly. Not "
                                 "calling the stop API. Action disabled via by "
                                 "config.", instance=db_instance)
+                    db_instance.vm_state = vm_states.SUSPENDED
+                    db_instance.save()
             elif vm_power_state == power_state.PAUSED:
                 # Note(maoy): a VM may get into the paused state not only
                 # because the user request via API calls, but also
@@ -7393,6 +7395,8 @@ class ComputeManager(manager.Manager):
                     LOG.warning("Paused instance shutdown by itself. Not "
                                 "calling stop API. Action disabled by config.",
                                 instance=db_instance)
+                    db_instance.vm_state = vm_states.STOPPED
+                    db_instance.save()
         elif vm_state in (vm_states.SOFT_DELETED,
                           vm_states.DELETED):
             if vm_power_state not in (power_state.NOSTATE,

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -7270,39 +7270,58 @@ class ComputeManager(manager.Manager):
             # The only rational power state should be RUNNING
             if vm_power_state in (power_state.SHUTDOWN,
                                   power_state.CRASHED):
-                LOG.warning("Instance shutdown by itself. Calling the "
-                            "stop API. Current vm_state: %(vm_state)s, "
-                            "current task_state: %(task_state)s, "
-                            "original DB power_state: %(db_power_state)s, "
-                            "current VM power_state: %(vm_power_state)s",
-                            {'vm_state': vm_state,
-                             'task_state': db_instance.task_state,
-                             'db_power_state': orig_db_power_state,
-                             'vm_power_state': vm_power_state},
-                            instance=db_instance)
-                try:
-                    # Note(maoy): here we call the API instead of
-                    # brutally updating the vm_state in the database
-                    # to allow all the hooks and checks to be performed.
-                    if db_instance.shutdown_terminate:
-                        self.compute_api.delete(context, db_instance)
-                    else:
-                        self.compute_api.stop(context, db_instance)
-                except Exception:
-                    # Note(maoy): there is no need to propagate the error
-                    # because the same power_state will be retrieved next
-                    # time and retried.
-                    # For example, there might be another task scheduled.
-                    LOG.exception("error during stop() in sync_power_state.",
-                                  instance=db_instance)
+                if CONF.sync_power_state_unexpected_call_stop:
+                    LOG.warning("Instance shutdown by itself. Calling the "
+                                "stop API. Current vm_state: %(vm_state)s, "
+                                "current task_state: %(task_state)s, "
+                                "original DB power_state: %(db_power_state)s, "
+                                "current VM power_state: %(vm_power_state)s",
+                                {'vm_state': vm_state,
+                                 'task_state': db_instance.task_state,
+                                 'db_power_state': orig_db_power_state,
+                                 'vm_power_state': vm_power_state},
+                                instance=db_instance)
+                    try:
+                        # Note(maoy): here we call the API instead of
+                        # brutally updating the vm_state in the database
+                        # to allow all the hooks and checks to be performed.
+                        if db_instance.shutdown_terminate:
+                            self.compute_api.delete(context, db_instance)
+                        else:
+                            self.compute_api.stop(context, db_instance)
+                    except Exception:
+                        # Note(maoy): there is no need to propagate the error
+                        # because the same power_state will be retrieved next
+                        # time and retried.
+                        # For example, there might be another task scheduled.
+                        msg = "error during stop() in sync_power_state."
+                        LOG.exception(msg, instance=db_instance)
+                else:
+                    LOG.warning("Instance shutdown by itself. Not calling the "
+                                "stop API. Action disabled by config. "
+                                "Hypervisor-HA will take care. "
+                                "Current vm_state: %(vm_state)s, "
+                                "current task_state: %(task_state)s, "
+                                "original DB power_state: %(db_power_state)s, "
+                                "current VM power_state: %(vm_power_state)s",
+                                {'vm_state': vm_state,
+                                 'task_state': db_instance.task_state,
+                                 'db_power_state': orig_db_power_state,
+                                 'vm_power_state': vm_power_state},
+                                instance=db_instance)
             elif vm_power_state == power_state.SUSPENDED:
-                LOG.warning("Instance is suspended unexpectedly. Calling "
-                            "the stop API.", instance=db_instance)
-                try:
-                    self.compute_api.stop(context, db_instance)
-                except Exception:
-                    LOG.exception("error during stop() in sync_power_state.",
-                                  instance=db_instance)
+                if CONF.sync_power_state_unexpected_call_stop:
+                    LOG.warning("Instance is suspended unexpectedly. Calling "
+                                "the stop API.", instance=db_instance)
+                    try:
+                        self.compute_api.stop(context, db_instance)
+                    except Exception:
+                        msg = "error during stop() in sync_power_state."
+                        LOG.exception(msg, instance=db_instance)
+                else:
+                    LOG.warning("Instance is suspended unexpectedly. Not "
+                                "calling the stop API. Action disabled via by "
+                                "config.", instance=db_instance)
             elif vm_power_state == power_state.PAUSED:
                 # Note(maoy): a VM may get into the paused state not only
                 # because the user request via API calls, but also
@@ -7344,13 +7363,18 @@ class ComputeManager(manager.Manager):
         elif vm_state == vm_states.PAUSED:
             if vm_power_state in (power_state.SHUTDOWN,
                                   power_state.CRASHED):
-                LOG.warning("Paused instance shutdown by itself. Calling "
-                            "the stop API.", instance=db_instance)
-                try:
-                    self.compute_api.force_stop(context, db_instance)
-                except Exception:
-                    LOG.exception("error during stop() in sync_power_state.",
-                                  instance=db_instance)
+                if CONF.sync_power_state_unexpected_call_stop:
+                    LOG.warning("Paused instance shutdown by itself. Calling "
+                                "the stop API.", instance=db_instance)
+                    try:
+                        self.compute_api.force_stop(context, db_instance)
+                    except Exception:
+                        msg = "error during stop() in sync_power_state."
+                        LOG.exception(msg, instance=db_instance)
+                else:
+                    LOG.warning("Paused instance shutdown by itself. Not "
+                                "calling stop API. Action disabled by config.",
+                                instance=db_instance)
         elif vm_state in (vm_states.SOFT_DELETED,
                           vm_states.DELETED):
             if vm_power_state not in (power_state.NOSTATE,

--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -639,6 +639,14 @@ Number of greenthreads available for spawning virtual machines.
 
 Possible values:
 * Any positive integer representing greenthreads count.
+"""), cfg.BoolOpt('sync_power_state_unexpected_call_stop',
+        default=True,
+        help="""
+Disable calling stop on servers, that are unexpectedly reported as shutdown
+
+If the hypervisor supports automatic HA, it will bring up the instance again on
+another host, so calling stop might actually be harmful, because nova will
+enforce the shutdown when the host is brought up by HA.
 """),
 ]
 


### PR DESCRIPTION
Nova regularly checks the power state of every VM on the hypervisor. The
default behaviour for VMs not matching the requested power state is to
call the stop API. But since vmware hypervisors are actually a cluster
of hypervisors that do HA on their own. In the process of doing HA
failover, especially if that failover fails for some time e.g. because
of a still held lock, VMs are reported as SHUTDOWN by the API. If we
call the stop API then, nova will shut down the VM once it's RUNNING
again, because the stop API sets the expected/user-wanted VM state to
SHUTDOWN. This would effectively disable the VMware HA.

Therefore, we're introducing a new setting
`sync_power_state_unexpected_call_stop` which can be used to disable the
call to the stop API.