### PR TITLE
Add option to reserve all memory

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -105,6 +105,13 @@ Specifies the server where the Virtual Serial Port Concentrator is
 storing console log files and responding to get requests.
 If defined it will override serial_log_dir.
 """),
+    cfg.BoolOpt('reserve_all_memory',
+                default=False,
+                help="""
+If true, it is not possible to over-commit memory in the vCenter, but there's
+also no swap file pre-created on the ephemeral storage. Swap still works, but
+is hot-created.
+""")
 ]
 
 vmwareapi_opts = [

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -293,6 +293,8 @@ def get_vm_create_spec(client_factory, instance, data_store_name,
             client_factory, extra_specs.memory_limits,
             'ns0:ResourceAllocationInfo')
 
+    config_spec.memoryReservationLockedToMax = CONF.vmware.reserve_all_memory
+
     if extra_specs.firmware:
         config_spec.firmware = extra_specs.firmware
 


### PR DESCRIPTION
If we don't reserve all memory, there's a swap file pre-created for
every VM on the ephemeral storage - even if it's unused.

But this option comes at the price of not being able to over-commit
memory.

Related issue: CCM-9589