### PR TITLE
Cherry-Pick: Making instance/migration listing skipping down cells co…

### DIFF
--- a/nova/compute/multi_cell_list.py
+++ b/nova/compute/multi_cell_list.py
@@ -19,9 +19,14 @@ import six
 
 from oslo_log import log as logging
 
+import nova.conf
 from nova import context
+from nova import exception
+from nova.i18n import _
 
 LOG = logging.getLogger(__name__)
+
+CONF = nova.conf.CONF
 
 
 class RecordSortContext(object):
@@ -255,6 +260,10 @@ class CrossCellLister(object):
         for cell_uuid in list(results):
             if results[cell_uuid] in (context.did_not_respond_sentinel,
                                       context.raised_exception_sentinel):
+                if not CONF.api.list_records_by_skipping_down_cells:
+                    raise exception.NovaException(
+                        _('Cell %s is not responding but configuration '
+                          'indicates that we should fail.') % cell_uuid)
                 LOG.warning("Cell %s is not responding and hence skipped "
                             "from the results.", cell_uuid)
                 results.pop(cell_uuid)

--- a/nova/conf/api.py
+++ b/nova/conf/api.py
@@ -272,7 +272,15 @@ allow_instance_snapshots_opts = [
 Operators can turn off the ability for a user to take snapshots of their
 instances by setting this option to False. When disabled, any attempt to
 take a snapshot will result in a HTTP 400 response ("Bad Request").
-""")
+"""),
+    cfg.BoolOpt("list_records_by_skipping_down_cells",
+        default=True,
+        help="""
+When set to False, this will cause the API to return a 500 error if there is an
+infrastructure failure like non-responsive cells. If you want the API to skip
+the down cells and return the results from the up cells set this option to
+True.
+"""),
 ]
 
 # NOTE(edleafe): I would like to import the value directly from

--- a/releasenotes/notes/records-list-skip-down-cells-84d995e75c77c041.yaml
+++ b/releasenotes/notes/records-list-skip-down-cells-84d995e75c77c041.yaml
@@ -1,0 +1,16 @@
+---
+other:
+  - |
+    In case of infrastructure failures like non-responsive cells, prior to
+    `change e3534d`_ we raised an API 500 error. However currently when
+    listing instances or migrations, we skip that cell and display results from
+    the up cells with the aim of increasing availability at the expense of
+    accuracy. If the old behaviour is desired, a new flag called
+    ``CONF.api.list_records_by_skipping_down_cells`` has been added which can
+    be set to False to mimic the old behavior. Both of these potential
+    behaviors will be unified in an upcoming microversion done through the
+    `blueprint handling-down-cell`_  where minimal constructs would be returned
+    for the down cell instances instead of raising 500s or skipping down cells.
+
+    .. _change e3534d : https://review.openstack.org/#/q/I308b494ab07f6936bef94f4c9da45e9473e3534d
+    .. _blueprint handling-down-cell: https://blueprints.launchpad.net/nova/+spec/handling-down-cell


### PR DESCRIPTION
…nfigurable

Presently if a cell is down, the instances in that cell are
skipped from results. Sometimes this may not be desirable for
operators as it may confuse the users who saw more instances in
their previous listing than now. This patch adds a new api config
option called list_records_by_skipping_down_cells which can be set to
False (True by default) if the operator desires to just return an
API error altogether if the user has any instance in the down cell
instead of skipping. This is essentially a configurable revert of
change I308b494ab07f6936bef94f4c9da45e9473e3534d for bug 1726301 so
that operators can opt into the 500 response behaviour during listing.

Change-Id: Id749761c58d4e1bc001b745d49b6ff0f3732e133
Related-Bug: #1726301