### PR TITLE
[vmware] Add DRS override for "big" VMs

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -327,6 +327,16 @@ instances as clone from template.
 Before fetching from Glance an image missing on the datastore first look for it
 on other datastores and clone it from there if available.
 """),
+    cfg.IntOpt('drs_partially_automated_memory_mb',
+               default=1024 ** 2,   # 1 TB
+               min=0,
+               help="""
+Create a DRS override entry in the cluster config for instances with at least
+this amount of memory. The override will enable initial placement but prohibit
+the DRS from moving the machines for re-balancing. That's necessary, because
+they're big and most probably running HANA, which doesn't play well with
+vMotion.
+"""),
 ]
 
 ALL_VMWARE_OPTS = (vmwareapi_vif_opts +

--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -218,3 +218,26 @@ def _is_drs_enabled(session, cluster):
             return drs_config["enabled"]
 
     return False
+
+
+def update_cluster_drs_vm_override(session, cluster, vm_ref, behavior,
+                                    enabled=True):
+    """Add/Update `ClusterDrsVmConfigSpec` for a VM.
+
+    `behavior` can be any `DrsBehaviour` as string.
+    """
+    client_factory = session.vim.client.factory
+
+    drs_vm_info = client_factory.create('ns0:ClusterDrsVmConfigInfo')
+    drs_vm_info.behavior = behavior
+    drs_vm_info.enabled = enabled
+    drs_vm_info.key = vm_ref
+
+    drs_vm_spec = client_factory.create('ns0:ClusterDrsVmConfigSpec')
+    drs_vm_spec.info = drs_vm_info
+    drs_vm_spec.operation = 'add'
+
+    config_spec = client_factory.create('ns0:ClusterConfigSpecEx')
+    config_spec.drsVmConfigSpec = [drs_vm_spec]
+
+    reconfigure_cluster(session, cluster, config_spec)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1146,6 +1146,16 @@ class VMwareVMOps(object):
         # 'uuid' of the instance
         vm_util.rename_vm(self._session, vm_ref, instance)
 
+        # Make sure we don't automatically move around "big" VMs
+        memory_mb = int(instance.memory_mb)
+        if memory_mb >= CONF.vmware.drs_partially_automated_memory_mb:
+            LOG.debug("Adding DRS override 'partiallyAutomated' for big VM.",
+                      instance=instance)
+            cluster_util.update_cluster_drs_vm_override(self._session,
+                                                        self._cluster,
+                                                        vm_ref,
+                                                        'partiallyAutomated')
+
         vm_util.power_on_instance(self._session, instance, vm_ref=vm_ref)
 
     def _is_bdm_valid(self, block_device_mapping):


### PR DESCRIPTION
Since DRS doesn't play well with large differences in VM size and HANA
doesn't play well with vMotion, we're disabling automatic re-balancing
actions for "big" VMs by the DRS. On spawn, we add a
`ClusterDrsVmConfigSpec` for instances having more than by default 1 TB
of memory - configurable via `drs_partially_automated_memory_mb`
configuration variable. The vCenter deletes the overrides automatically
when a VM is deleted.

One can view current overrides in the vCenter UI via $cluster (e.g.
productionbb098) -> Configure -> VM Overrides.

We're always adding the rule in `update_cluster_drs_vm_override`,
because we only call it in the driver's `spawn` method which seems to be
called only when a new vm object is created. Therefore, there should not
be any existing rule for the VM.