### PR TITLE
Fixing boot from cinder volume issues

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -249,7 +249,8 @@ class VMwareVCDriver(driver.ComputeDriver):
         """
         # TODO(PhilDay): Add support for timeout (clean shutdown)
         return self._vmops.migrate_disk_and_power_off(context, instance,
-                                                      dest, flavor, block_device_info)
+                                                      dest, flavor,
+                                                      block_device_info)
 
     def confirm_migration(self, context, migration, instance, network_info):
         """Confirms a resize, destroying the source VM."""

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -249,7 +249,7 @@ class VMwareVCDriver(driver.ComputeDriver):
         """
         # TODO(PhilDay): Add support for timeout (clean shutdown)
         return self._vmops.migrate_disk_and_power_off(context, instance,
-                                                      dest, flavor)
+                                                      dest, flavor, block_device_info)
 
     def confirm_migration(self, context, migration, instance, network_info):
         """Confirms a resize, destroying the source VM."""

--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -144,12 +144,17 @@ class VMwareImage(object):
         else:
             container_format = None
 
+        if image_meta.obj_attr_is_set('owner'):
+            owner = image_meta.owner
+        else:
+            owner = None
+
         props = {
             'image_id': image_id,
             'linked_clone': linked_clone,
             'container_format': container_format,
             'vsphere_location': get_vsphere_location(context, image_id),
-            'owner': image_meta.owner
+            'owner': owner
         }
 
         if image_meta.obj_attr_is_set('size'):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1908,7 +1908,7 @@ class VMwareVMOps(object):
                                        total_steps=RESIZE_TOTAL_STEPS)
 
         # 3.Reconfigure the disk properties
-        if (not cinder_boot):
+        if not cinder_boot:
             self._resize_disk(instance, vm_ref, vmdk, flavor)
         self._update_instance_progress(context, instance,
                                        step=3,

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1874,7 +1874,6 @@ class VMwareVMOps(object):
         for disk in block_device_mapping:
             if disk.get('boot_index') == 0:
                 cinder_boot = True
-                    
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
                                      uuid=instance.uuid)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1872,7 +1872,7 @@ class VMwareVMOps(object):
             block_device_mapping = driver.block_device_info_get_mapping(
                 block_device_info)
         for disk in block_device_mapping:
-            if disk.get('boot_index') == 0 and disk.get('destination_type') == "volume":
+            if disk.get('boot_index') == 0:
                 cinder_boot = True
                     
         vm_ref = vm_util.get_vm_ref(self._session, instance)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -637,6 +637,7 @@ class VMwareVMOps(object):
         """Captures all relevant information from the spawn parameters."""
 
         if (instance.flavor.root_gb != 0 and
+                instance.image_ref and
                 image_info.file_size > instance.flavor.root_gb * units.Gi):
             reason = _("Image disk size greater than requested disk size")
             raise exception.InstanceUnacceptable(instance_id=instance.uuid,

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -601,7 +601,7 @@ class VMwareVolumeOps(object):
             volume_ref = self._get_volume_ref(data['volume'])
             # Pick the resource pool on which the instance resides. Move the
             # volume to the datastore of the instance.
-            res_pool = self._get_res_pool_of_vm(vm_ref)
-            vm_util.relocate_vm(self._session, volume_ref, res_pool, datastore)
+            #res_pool = self._get_res_pool_of_vm(vm_ref)
+            #vm_util.relocate_vm(self._session, volume_ref, res_pool, datastore)
 
         self.attach_volume(connection_info, instance, adapter_type)

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -594,14 +594,5 @@ class VMwareVolumeOps(object):
         driver_type = connection_info['driver_volume_type']
         LOG.debug("Root volume attach. Driver type: %s", driver_type,
                   instance=instance)
-        if driver_type == constants.DISK_FORMAT_VMDK:
-            vm_ref = vm_util.get_vm_ref(self._session, instance)
-            data = connection_info['data']
-            # Get the volume ref
-            volume_ref = self._get_volume_ref(data['volume'])
-            # Pick the resource pool on which the instance resides. Move the
-            # volume to the datastore of the instance.
-            #res_pool = self._get_res_pool_of_vm(vm_ref)
-            #vm_util.relocate_vm(self._session, volume_ref, res_pool, datastore)
 
         self.attach_volume(connection_info, instance, adapter_type)


### PR DESCRIPTION
Hi,
Created pull request for my boot from cinder fixes.
images.py: Fixing missing owner None reference
vmops.py: Fixing flavour is enforced on cinder boot disk.
volumeops.py: Disable SVMOTION to root disk data store, as we would like cinder volume to be intact and VVOL based even we use it as boot disk.
