### PR TITLE
Rename validate_vm_group function in cluster_util.py to

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -60,7 +60,7 @@ def _get_vm_group(cluster_config, group_info):
             return group
 
 
-def validate_vm_group(session, vm_ref):
+def fetch_cluster_properties(session, vm_ref):
     max_objects = 1
     vim = session.vim
     property_collector = vim.service_content.propertyCollector

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1494,7 +1494,8 @@ class VMwareVMOps(object):
 
             server_group_info = vm_util._get_server_group(context, instance)
             if server_group_info:
-                cluster = cluster_util.validate_vm_group(self._session, vm_ref)
+                cluster = cluster_util.fetch_cluster_properties(self._session,
+                                                                       vm_ref)
 
                 for key, group in enumerate(cluster.propSet[0].val.group):
                     if not hasattr(group, 'vm'):


### PR DESCRIPTION
fetch_cluster_properties

The function name is changed, since the function is fetching
cluster properties and does no validation, which creates confusion.