### PR TITLE
[vmware] Add configurable reservations per hostgroup

### DIFF
--- a/nova/compute/resource_tracker.py
+++ b/nova/compute/resource_tracker.py
@@ -727,7 +727,8 @@ class ResourceTracker(object):
                             'flavor', 'migration_context'])
 
         # Now calculate usage based on instance utilization:
-        self._update_usage_from_instances(context, instances, nodename)
+        self._update_usage_from_instances(context, instances, nodename,
+                                          resources)
 
         # Grab all in-progress migrations:
         migrations = objects.MigrationList.get_in_progress_by_host_and_node(
@@ -1132,7 +1133,8 @@ class ResourceTracker(object):
         else:
             cn.pci_device_pools = objects.PciDevicePoolList()
 
-    def _update_usage_from_instances(self, context, instances, nodename):
+    def _update_usage_from_instances(self, context, instances, nodename,
+                                     resources):
         """Calculate resource usage based on instance utilization.  This is
         different than the hypervisor's view as it will account for all
         instances assigned to the local compute host, even if they are not
@@ -1143,8 +1145,10 @@ class ResourceTracker(object):
         cn = self.compute_nodes[nodename]
         # set some initial values, reserve room for host/hypervisor:
         cn.local_gb_used = CONF.reserved_host_disk_mb / 1024
-        cn.memory_mb_used = CONF.reserved_host_memory_mb
-        cn.vcpus_used = CONF.reserved_host_cpus
+        cn.memory_mb_used = resources.get('memory_mb_reserved',
+                                          CONF.reserved_host_memory_mb)
+        cn.vcpus_used = resources.get('vcpus_reserved',
+                                      CONF.reserved_host_cpus)
         cn.free_ram_mb = (cn.memory_mb - cn.memory_mb_used)
         cn.free_disk_gb = (cn.local_gb - cn.local_gb_used)
         cn.current_workload = 0

--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -114,7 +114,32 @@ is hot-created.
 
 For big VMs as determined by the `bigvm_mb` setting, this setting is not used.
 Big VMs always reserve all their memory.
-""")
+"""),
+    cfg.StrOpt('hostgroup_reservations_json_file',
+        help="""
+Specifies the path to a JSON file containing vcpus and memory reservations per
+hostgroup. HVs found to be in a hostgroup specified in this dict will report
+the amount of vcpus/memory as reserved to the placement API. This enables us to
+specify different reservations for HANA-used HVs and for "normal" HVs. The
+special key `__default__` holds values applied if there is no specification for
+an HV's hostgroup. It defaults to 0.
+
+There are two ways to specify a hostgroup's values: as static numbers and as
+percent. Static numbers take precedence over percent if both are present.
+Additionally, values are inherited from the `__default__` group if not present
+for a group. To prohibt inheriting a value, explicitly set it to `null`.
+
+Example configuration could be:
+ {"__default__": {"memory_percent": 10, "vcpus": 10},
+  "hana_hosts": {"memory_mb": 16384, "vcpus": 5},
+  "normal_hosts": {"vcpus": null, "vcpus_percent": 2}}
+
+If there are cluster-wide reservations defined via `reserved_host_cpus` or
+`reserved_host_memory_mb`, they are added to the sum of the hostgroup-defined
+ones.
+
+NOTE: Percentage values will be rounded down to the next full vcpu/MB.
+"""),
 ]
 
 vmwareapi_opts = [

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2300,6 +2300,52 @@ class VMwareAPIVMTestCase(test.TestCase,
         }
         self.assertEqual(expected, inv)
 
+    @mock.patch('nova.virt.vmwareapi.vm_util.get_stats_from_cluster')
+    @mock.patch('nova.virt.vmwareapi.ds_util.get_available_datastores')
+    def test_get_inventory_hostgroup_reservations(self, mock_get_avail_ds,
+                                                  mock_get_stats):
+        """reservations by hostgroup are added to the ones per cluster"""
+        ds1 = ds_obj.Datastore(ref='fake-ref', name='datastore1',
+                               capacity=10 * units.Gi, freespace=3 * units.Gi)
+        ds2 = ds_obj.Datastore(ref='fake-ref', name='datastore2',
+                               capacity=35 * units.Gi, freespace=25 * units.Gi)
+        ds3 = ds_obj.Datastore(ref='fake-ref', name='datastore3',
+                               capacity=50 * units.Gi, freespace=15 * units.Gi)
+        mock_get_avail_ds.return_value = [ds1, ds2, ds3]
+        mock_get_stats.return_value = {
+            'cpu': {'vcpus': 32,
+                    'max_vcpus_per_host': 16,
+                    'reserved_vcpus': 2},
+            'mem': {'total': 2048,
+                    'free': 2048,
+                    'max_mem_mb_per_host': 1024,
+                    'reserved_memory_mb': 512}}
+        inv = self.conn.get_inventory(self.node_name)
+        expected = {
+            fields.ResourceClass.VCPU: {
+                'total': 32,
+                'reserved': 2,
+                'min_unit': 1,
+                'max_unit': 16,
+                'step_size': 1,
+            },
+            fields.ResourceClass.MEMORY_MB: {
+                'total': 2048,
+                'reserved': 1024,
+                'min_unit': 1,
+                'max_unit': 1024,
+                'step_size': 1,
+            },
+            fields.ResourceClass.DISK_GB: {
+                'total': 95,
+                'reserved': 0,
+                'min_unit': 1,
+                'max_unit': 25,
+                'step_size': 1,
+            },
+        }
+        self.assertEqual(expected, inv)
+
     def test_invalid_datastore_regex(self):
 
         # Tests if we raise an exception for Invalid Regular Expression in

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2253,10 +2253,13 @@ class VMwareAPIVMTestCase(test.TestCase,
     def test_get_available_resource(self):
         stats = self.conn.get_available_resource(self.node_name)
         self.assertEqual(32, stats['vcpus'])
+        self.assertEqual(CONF.reserved_host_cpus, stats['vcpus_reserved'])
         self.assertEqual(1024, stats['local_gb'])
         self.assertEqual(1024 - 500, stats['local_gb_used'])
         self.assertEqual(2048, stats['memory_mb'])
         self.assertEqual(1000, stats['memory_mb_used'])
+        self.assertEqual(CONF.reserved_host_memory_mb,
+                         stats['memory_mb_reserved'])
         self.assertEqual('VMware vCenter Server', stats['hypervisor_type'])
         self.assertEqual(5001000, stats['hypervisor_version'])
         self.assertEqual(self.node_name, stats['hypervisor_hostname'])
@@ -2609,8 +2612,9 @@ class VMwareAPIVMTestCase(test.TestCase,
         service = self._create_service(disabled=False, host='fake-mini')
         mock_service.return_value = service
 
-        fake_stats = {'cpu': {'vcpus': 4},
-                      'mem': {'total': '8194', 'free': '2048'}}
+        fake_stats = {'cpu': {'vcpus': 4, 'reserved_vcpus': 0},
+                      'mem': {'total': '8194', 'free': '2048',
+                              'reserved_memory_mb': 0}}
         with test.nested(
             mock.patch.object(vm_util, 'get_stats_from_cluster',
                               side_effect=[vexc.VimConnectionException('fake'),

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 import collections
+import io
 
 import mock
 from oslo_utils import units
@@ -23,7 +24,9 @@ from oslo_vmware import exceptions as vexc
 from oslo_vmware.objects import datastore as ds_obj
 from oslo_vmware import pbm
 from oslo_vmware import vim_util as vutil
+import six
 
+import nova.conf
 from nova import exception
 from nova.network import model as network_model
 from nova import test
@@ -33,6 +36,8 @@ from nova.tests.unit.virt.vmwareapi import stubs
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import driver
 from nova.virt.vmwareapi import vm_util
+
+CONF = nova.conf.CONF
 
 
 class partialObject(object):
@@ -57,7 +62,8 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
     def _test_get_stats_from_cluster(self, connection_state="connected",
                                      maintenance_mode=False,
                                      failover_policy=None,
-                                     failover_hosts_filtered=0):
+                                     failover_hosts_filtered=0,
+                                     expected_stats=None):
         ManagedObjectRefs = [fake.ManagedObjectReference("HostSystem",
                                                          "host1"),
                              fake.ManagedObjectReference("HostSystem",
@@ -103,8 +109,10 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                                       val=quickstats_2)]
 
         fake_objects = {
-            'host1': fake.ObjectContent("prop_list_host1", prop_list_host_1),
-            'host2': fake.ObjectContent("prop_list_host1", prop_list_host_2)
+            'host1':
+                fake.ObjectContent(ManagedObjectRefs[0], prop_list_host_1),
+            'host2':
+                fake.ObjectContent(ManagedObjectRefs[1], prop_list_host_2)
         }
 
         def fake_call_method(*args):
@@ -126,12 +134,15 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
             else:
                 num_hosts = 1
             num_hosts -= failover_hosts_filtered
-            expected_stats = {'cpu': {'vcpus': num_hosts * 16,
-                                      'max_vcpus_per_host': 16},
-                              'mem': {'total': num_hosts * 4096,
-                                      'free': num_hosts * 4096 -
-                                              num_hosts * 512,
-                                      'max_mem_mb_per_host': 4096}}
+            if expected_stats is None:
+                expected_stats = {'cpu': {'vcpus': num_hosts * 16,
+                                          'max_vcpus_per_host': 16,
+                                          'reserved_vcpus': 0},
+                                  'mem': {'total': num_hosts * 4096,
+                                          'free': num_hosts * 4096 -
+                                                  num_hosts * 512,
+                                          'max_mem_mb_per_host': 4096,
+                                          'reserved_memory_mb': 0}}
             self.assertEqual(expected_stats, result)
 
     def test_get_stats_from_cluster_hosts_connected_and_active(self):
@@ -173,10 +184,137 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         self._test_get_stats_from_cluster(failover_policy=policy,
                                           failover_hosts_filtered=0)
 
+    @mock.patch('nova.virt.vmwareapi.vm_util._get_host_reservations_map')
+    def test_get_stats_from_cluster_reservations(self, mock_map):
+        CONF.set_override('hostgroup_reservations_json_file', '/some/path',
+                          'vmware')
+        mock_map.return_value = {
+            "host1": {
+                'memory_mb': 256,
+                'vcpus': 4},
+            "host2": {
+                'memory_mb': 512,
+                'vcpus': 2}}
+
+        expected = {'cpu': {'vcpus': 2 * 16,
+                                  'max_vcpus_per_host': 14,  # by host2 counts
+                                  'reserved_vcpus': 4 + 2},  # both hosts
+                          'mem': {'total': 2 * 4096,
+                                  'free': 2 * 4096 -
+                                          2 * 512,
+                                  'max_mem_mb_per_host': 4096 - 256,    # host1
+                                  'reserved_memory_mb': 512 + 256}}     # both
+        self._test_get_stats_from_cluster(expected_stats=expected)
+
+    def test_get_host_reservations_empty(self):
+        host = fake.ManagedObjectReference('HostSystem', 'host1')
+        mapping = {}
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 0, 'memory_mb': 0}
+        self.assertEqual(expected, result)
+
+        mapping = {'host2': {'vcpus': 5}}
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 0, 'memory_mb': 0}
+        self.assertEqual(expected, result)
+
+    def test_get_host_reservations_with_default(self):
+        host = fake.ManagedObjectReference('HostSystem', 'host1')
+        mapping = {'__default__': {'vcpus': 2, 'memory_mb': 96}}
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 2, 'memory_mb': 96}
+        self.assertEqual(expected, result)
+
+    def test_get_host_reservations_with_some_default(self):
+        host = fake.ManagedObjectReference('HostSystem', 'host1')
+        mapping = {'__default__': {'vcpus': 2, 'memory_mb': 96},
+                   'host1': {'vcpus': 1}}
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 1, 'memory_mb': 96}
+        self.assertEqual(expected, result)
+
+        mapping = {'__default__': {'vcpus': 2, 'memory_mb': 96},
+                   'host1': {'memory_mb': 2048}}
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 2, 'memory_mb': 2048}
+        self.assertEqual(expected, result)
+
+    def test_get_host_reservations_priority(self):
+        host = fake.ManagedObjectReference('HostSystem', 'host1')
+        mapping = {'__default__': {'vcpus_percent': 10, 'memory_percent': 50},
+                   'host1': {'vcpus': 1}}
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 1, 'memory_mb': 2048}
+        self.assertEqual(expected, result)
+
+        mapping['host1']['memory_mb'] = 96
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 1, 'memory_mb': 96}
+        self.assertEqual(expected, result)
+
+    def test_get_host_reservations_override(self):
+        host = fake.ManagedObjectReference('HostSystem', 'host1')
+        mapping = {'__default__': {'vcpus': 5},
+                   'host1': {'vcpus_percent': 10}}
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 5, 'memory_mb': 0}
+        self.assertEqual(expected, result)
+
+        mapping['host1']['vcpus'] = None
+        result = vm_util._get_host_reservations(mapping, host, 32, 4096)
+        expected = {'vcpus': 3, 'memory_mb': 0}
+        self.assertEqual(expected, result)
+
     def test_get_host_ref_no_hosts_in_cluster(self):
         self.assertRaises(exception.NoValidHost,
                           vm_util.get_host_ref,
                           fake.FakeObjectRetrievalSession(""), 'fake_cluster')
+
+    def test_get_host_reservations_map_no_action(self):
+        self.assertEqual({}, vm_util._get_host_reservations_map())
+
+    @mock.patch.object(six.moves.builtins, 'open')
+    def test_get_host_reservations_map_default_only(self, mock_open):
+        CONF.set_override('hostgroup_reservations_json_file', '/some/path',
+                          'vmware')
+        reservations = '{"__default__": {"vcpus": 2, "memory_mb": 512}, ' \
+                         '"foo": {"vcpus": 7}}'
+        response = io.StringIO(six.text_type(reservations))
+        mock_open.return_value = response
+        expected = {'__default__': {'vcpus': 2, 'memory_mb': 512}}
+        self.assertEqual(expected, vm_util._get_host_reservations_map())
+
+    @mock.patch.object(six.moves.builtins, 'open')
+    def test_get_host_reservations_map(self, mock_open):
+        CONF.set_override('hostgroup_reservations_json_file', '/some/path',
+                          'vmware')
+        reservations = '{"__default__": {"vcpus": 2, "memory_mb": 512}, ' \
+                         '"foo": {"vcpus": 7, "vcpus_percent": 10, ' \
+                         '"memory_mb": 1024}}'
+        response = io.StringIO(six.text_type(reservations))
+        mock_open.return_value = response
+
+        class Group(object):
+            def __init__(self, name, host=None):
+                self.name = name
+                if host is not None:
+                    self.host = host
+
+        host1 = fake.ManagedObjectReference('HostSystem', 'host1')
+        host2 = fake.ManagedObjectReference('HostSystem', 'host2')
+        host3 = fake.ManagedObjectReference('HostSystem', 'host3')
+
+        groups = [
+            Group('vmgroup'),
+            Group('hostgroup1', host=[host1]),
+            Group('foo', host=[host2, host3])]
+
+        expected = {'__default__': {'vcpus': 2, 'memory_mb': 512},
+                    'host2': {'vcpus': 7, 'vcpus_percent': 10,
+                              'memory_mb': 1024},
+                    'host3': {'vcpus': 7, 'vcpus_percent': 10,
+                              'memory_mb': 1024}}
+        self.assertEqual(expected, vm_util._get_host_reservations_map(groups))
 
     def test_get_resize_spec(self):
         vcpus = 2

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -460,17 +460,21 @@ class VMwareVCDriver(driver.ComputeDriver):
             }
         }
         if stats['cpu']['max_vcpus_per_host'] > 0:
+            reserved_vcpus = stats['cpu'].get('reserved_vcpus', 0)
+            reserved_vcpus += CONF.reserved_host_cpus
             result.update({obj_fields.ResourceClass.VCPU: {
                 'total': stats['cpu']['vcpus'],
-                'reserved': CONF.reserved_host_cpus,
+                'reserved': reserved_vcpus,
                 'min_unit': 1,
                 'max_unit': stats['cpu']['max_vcpus_per_host'],
                 'step_size': 1,
             }})
         if stats['mem']['max_mem_mb_per_host'] > 0:
+            reserved_memory_mb = stats['mem'].get('reserved_memory_mb', 0)
+            reserved_memory_mb += CONF.reserved_host_memory_mb
             result.update({obj_fields.ResourceClass.MEMORY_MB: {
                 'total': stats['mem']['total'],
-                'reserved': CONF.reserved_host_memory_mb,
+                'reserved': reserved_memory_mb,
                 'min_unit': 1,
                 'max_unit': stats['mem']['max_mem_mb_per_host'],
                 'step_size': 1,

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -341,6 +341,10 @@ class VMwareVCDriver(driver.ComputeDriver):
                'memory_mb_used': host_stats['host_memory_total'] -
                                  host_stats['host_memory_free'],
                'local_gb_used': host_stats['disk_used'],
+               'vcpus_reserved': CONF.reserved_host_cpus +
+                                 host_stats['vcpus_reserved'],
+               'memory_mb_reserved': CONF.reserved_host_memory_mb +
+                                     host_stats['host_memory_reserved'],
                'hypervisor_type': host_stats['hypervisor_type'],
                'hypervisor_version': host_stats['hypervisor_version'],
                'hypervisor_hostname': host_stats['hypervisor_hostname'],

--- a/nova/virt/vmwareapi/host.py
+++ b/nova/virt/vmwareapi/host.py
@@ -94,11 +94,13 @@ class VCState(object):
             return data
 
         data["vcpus"] = stats['cpu']['vcpus']
+        data["vcpus_reserved"] = stats['cpu']['reserved_vcpus']
         data["disk_total"] = capacity / units.Gi
         data["disk_available"] = freespace / units.Gi
         data["disk_used"] = data["disk_total"] - data["disk_available"]
         data["host_memory_total"] = stats['mem']['total']
         data["host_memory_free"] = stats['mem']['free']
+        data['host_memory_reserved'] = stats['mem']['reserved_memory_mb']
         data["hypervisor_type"] = about_info.name
         data["hypervisor_version"] = versionutils.convert_version_to_int(
                 str(about_info.version))

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -23,6 +23,7 @@ import copy
 import functools
 
 from oslo_log import log as logging
+from oslo_serialization import jsonutils
 from oslo_utils import excutils
 from oslo_utils import units
 from oslo_vmware import exceptions as vexc
@@ -67,6 +68,8 @@ _FOLDER_PATH_REF_MAPPING = {}
 # unnecessary communication with the backend.
 _VM_REFS_CACHE = {}
 _VM_VALUE_CACHE = collections.defaultdict(dict)
+
+_HOST_RESERVATIONS_DEFAULT_KEY = '__default__'
 
 
 class Limits(object):
@@ -1239,16 +1242,99 @@ def get_vm_state(session, instance):
     return constants.POWER_STATES[vm_state]
 
 
+def _get_host_reservations(host_reservations_map, host_moref, host_vcpus,
+                           host_memory_mb):
+    """Compute the number of vcpus and memory in MB reserved for the host from
+    the configured reservations or the default.
+
+    For every host, both vcpus and memory can be given as static number or in
+    percent, with static number taking priority.
+    """
+    reservations = {
+        'vcpus': 0,
+        'memory_mb': 0
+    }
+
+    default_key = _HOST_RESERVATIONS_DEFAULT_KEY
+    host_reservations = host_reservations_map.get(default_key, {})
+    group_reservations = host_reservations_map.get(host_moref.value, {})
+    for key in ['vcpus', 'vcpus_percent', 'memory_mb', 'memory_percent']:
+        if key in group_reservations:
+            host_reservations[key] = group_reservations[key]
+    if not host_reservations:
+        return reservations
+
+    # compute the number of vcpus
+    if host_reservations.get('vcpus') is not None:
+        vcpus = max(0, host_reservations['vcpus'])
+        reservations['vcpus'] = min(host_vcpus, vcpus)
+    elif host_reservations.get('vcpus_percent') is not None:
+        percent = max(0, min(100, host_reservations['vcpus_percent']))
+        # This will round down.
+        reservations['vcpus'] = host_vcpus * percent // 100
+
+    # compute the memory in MB
+    if host_reservations.get('memory_mb') is not None:
+        memory_mb = max(0, host_reservations['memory_mb'])
+        reservations['memory_mb'] = min(host_memory_mb, memory_mb)
+    elif host_reservations.get('memory_percent') is not None:
+        percent = max(0, min(100, host_reservations['memory_percent']))
+        # This will round down.
+        reservations['memory_mb'] = host_memory_mb * percent // 100
+
+    return reservations
+
+
+def _get_host_reservations_map(groups=None):
+    """return a mapping from hosts to reservations
+
+    Reservations are read from CONF.vmware.hostgroup_reservations_json_file,
+    which is mapping from hostgroup to reservation. We thus look up the
+    hostgroups we find in the mapping and create a mapping from each host in
+    that hostgroup to the reservation.
+    """
+    if groups is None:
+        groups = []
+
+    if not CONF.vmware.hostgroup_reservations_json_file:
+        return {}
+
+    with open(CONF.vmware.hostgroup_reservations_json_file) as f:
+        reservations = jsonutils.load(f)
+
+    hrm = {}
+
+    default = reservations.get(_HOST_RESERVATIONS_DEFAULT_KEY)
+    if default is not None:
+        hrm[_HOST_RESERVATIONS_DEFAULT_KEY] = default
+
+    for group in groups:
+        if not hasattr(group, 'host'):
+            continue
+
+        if group.name not in reservations:
+            continue
+
+        for host_moref in group.host:
+            reservation = reservations[group.name]
+            hrm[host_moref.value] = reservation
+    return hrm
+
+
 def get_stats_from_cluster(session, cluster):
     """Get the aggregate resource stats of a cluster."""
     vcpus = 0
     max_vcpus_per_host = 0
+    reserved_vcpus = 0
     used_mem_mb = 0
     total_mem_mb = 0
     max_mem_mb_per_host = 0
+    reserved_memory_mb = 0
     # Get the Host and Resource Pool Managed Object Refs
     props = ["host", "resourcePool",
              "configuration.dasConfig.admissionControlPolicy"]
+    if CONF.vmware.hostgroup_reservations_json_file:
+        props.append("configurationEx")
     prop_dict = session._call_method(vutil,
                                      "get_object_properties_dict",
                                      cluster,
@@ -1259,6 +1345,9 @@ def get_stats_from_cluster(session, cluster):
         policy = prop_dict.get(key)
         if policy and hasattr(policy, 'failoverHosts'):
             failover_hosts = set(h.value for h in policy.failoverHosts)
+
+        group_ret = prop_dict.get('configurationEx', {}).get('group')
+        host_reservations_map = _get_host_reservations_map(group_ret)
 
         host_ret = prop_dict.get('host')
         if host_ret:
@@ -1280,16 +1369,25 @@ def get_stats_from_cluster(session, cluster):
                     # The overcommitment ratio is factored in by the scheduler
                     threads = hardware_summary.numCpuThreads
                     vcpus += threads
-                    max_vcpus_per_host = max(max_vcpus_per_host, threads)
                     used_mem_mb += stats_summary.overallMemoryUsage
                     mem_mb = hardware_summary.memorySize // units.Mi
                     total_mem_mb += mem_mb
-                    max_mem_mb_per_host = max(max_mem_mb_per_host, mem_mb)
+                    reserved = _get_host_reservations(
+                                        host_reservations_map, obj.obj,
+                                        threads, mem_mb)
+                    reserved_vcpus += reserved['vcpus']
+                    reserved_memory_mb += reserved['memory_mb']
+                    max_vcpus_per_host = max(max_vcpus_per_host,
+                                             threads - reserved['vcpus'])
+                    max_mem_mb_per_host = max(max_mem_mb_per_host,
+                                              mem_mb - reserved['memory_mb'])
     stats = {'cpu': {'vcpus': vcpus,
-                     'max_vcpus_per_host': max_vcpus_per_host},
+                     'max_vcpus_per_host': max_vcpus_per_host,
+                     'reserved_vcpus': reserved_vcpus},
              'mem': {'total': total_mem_mb,
                      'free': total_mem_mb - used_mem_mb,
-                     'max_mem_mb_per_host': max_mem_mb_per_host}}
+                     'max_mem_mb_per_host': max_mem_mb_per_host,
+                     'reserved_memory_mb': reserved_memory_mb}}
     return stats
 
 


### PR DESCRIPTION
This can be used to have different CPU/memory reservations for hosts
depending on the hostgroup they're in. We can also set defaults in
percent with this instead of only static values as supported by
CONF.reserved_host_memory_mb and CONF.reserved_host_cpus.

NOTE: Setting these settings too differently per hostgroup for the same
cluster might result in placement API getting confused and scheduling
being impossible, as the `max_unit` is still set to the maximum per
cluster. In case of our HANA HVs placement would therefore always
consider the HANA HVs max unit. That should be no problem as smaller VMs
should always fit.