### PR TITLE
Fix vm group deletion

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1644,14 +1644,16 @@ class VMwareAPIVMTestCase(test.TestCase,
         instances = self.conn.list_instances()
         self.assertEqual(0, len(instances))
 
+    @mock.patch('nova.virt.vmwareapi.cluster_util.fetch_cluster_properties')
     @mock.patch('nova.virt.vmwareapi.cluster_util.delete_vm_group')
-    @mock.patch('nova.virt.vmwareapi.vm_util._get_server_group')
+    @mock.patch('nova.virt.vmwareapi.vm_util._get_server_groups')
     @mock.patch('nova.virt.vmwareapi.vm_util.update_cluster_placement')
     @mock.patch('nova.virt.vmwareapi.cluster_util.get_cluster_property')
     def test_destroy_with_vm_group(self, mock_get_cluster_prop,
                                            mock_update_placement,
                                            mock_get_sg,
-                                           mock_delete_group):
+                                           mock_delete_group,
+                                           mock_fetch_cluster_props):
         """Test deletion of a vm group when the deleted vm is the last in
         the vm group
         """
@@ -1659,7 +1661,7 @@ class VMwareAPIVMTestCase(test.TestCase,
         fake_server_group = collections.namedtuple('GroupInfo', ['uuid',
                                                                 'policies'])
         fake_server_group.uuid = 'test_group'
-        mock_get_sg.return_value = fake_server_group
+        mock_get_sg.return_value = [fake_server_group]
         fake_factory = vmwareapi_fake.FakeFactory()
 
         fake_cluster_config_info = fake_factory.create(

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1652,8 +1652,8 @@ class VMwareAPIVMTestCase(test.TestCase,
                                            mock_update_placement,
                                            mock_get_sg,
                                            mock_delete_group):
-        """ Test deletion of a vm group when the deleted vm is the last in
-            the vm group
+        """Test deletion of a vm group when the deleted vm is the last in
+        the vm group
         """
         self._create_vm()
         fake_server_group = collections.namedtuple('GroupInfo', ['uuid',

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -63,14 +63,14 @@ from nova import safe_utils
 
 profiler = importutils.try_import('osprofiler.profiler')
 
-
+SYNCHRONIZED_NOVA_PREFIX = 'nova-'
 CONF = nova.conf.CONF
 
 LOG = logging.getLogger(__name__)
 
 _IS_NEUTRON = None
 
-synchronized = lockutils.synchronized_with_prefix('nova-')
+synchronized = lockutils.synchronized_with_prefix(SYNCHRONIZED_NOVA_PREFIX)
 
 SM_IMAGE_PROP_PREFIX = "image_"
 SM_INHERITABLE_KEYS = (

--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -68,6 +68,14 @@ def _create_host_group_spec(client_factory, name, host_refs, operation="add",
     return group_spec
 
 
+def get_cluster_property(session, prop_list, cluster):
+    cluster_config = session._call_method(
+        vutil, "get_object_property", cluster,
+        prop_list)
+
+    return cluster_config
+
+
 def _get_vm_group(cluster_config, group_info):
     if not hasattr(cluster_config, 'group'):
         return

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -22,7 +22,6 @@ import collections
 import copy
 import functools
 
-from oslo_concurrency import lockutils
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 from oslo_utils import excutils
@@ -708,13 +707,6 @@ def _get_device_disk_type(device):
         else:
             return constants.DEFAULT_DISK_TYPE
 
-
-def get_cluster_property(session, prop_list, cluster):
-    cluster_config = session._call_method(
-        vutil, "get_object_property", cluster,
-        prop_list)
-
-    return cluster_config
 
 def get_vmdk_info(session, vm_ref, uuid=None):
     """Returns information for the primary VMDK attached to the given VM."""

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1428,11 +1428,9 @@ def update_cluster_placement(session, context, instance, cluster, vm_ref):
     if not server_group_infos:
         return
 
-    with lockutils.lock(server_group_infos[0].uuid,
-                        lock_file_prefix='nova-vmware-server-group'):
-        cluster_util.update_placement(session,
-                                      cluster,
-                                      vm_ref, server_group_infos)
+    cluster_util.update_placement(session,
+                                  cluster,
+                                  vm_ref, server_group_infos)
 
 
 def get_host_ref(session, cluster=None):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1549,7 +1549,6 @@ class VMwareVMOps(object):
                             vm_groups.append(group.name)
                             break
 
-
             lst_properties = ["config.files.vmPathName", "runtime.powerState",
                               "datastore"]
             props = self._session._call_method(vutil,
@@ -1575,7 +1574,6 @@ class VMwareVMOps(object):
                                            "UnregisterVM", vm_ref)
                 LOG.debug("Unregistered the VM", instance=instance)
 
-
                 with lockutils.lock('vmware-vm-group-policy',
                         lock_file_prefix=utils.SYNCHRONIZED_NOVA_PREFIX):
                     cluster_config = cluster_util.get_cluster_property(
@@ -1587,13 +1585,13 @@ class VMwareVMOps(object):
                             if group.name == group_info.uuid:
                                 if not hasattr(group, 'vm'):
                                     try:
-                                        LOG.debug("Deleting VM group %s" %
+                                        LOG.debug("Deleting VM group %s",
                                                   group_info.uuid)
                                         cluster_util.delete_vm_group(
                                             self._session, self._cluster,
                                             group)
                                         LOG.debug("VM group %s deleted"
-                                                  " successfully" % group.name)
+                                                  " successfully", group.name)
                                     except Exception as e:
                                         LOG.warning("Deleting VM group %s "
                                                 "failed with the following"

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1548,6 +1548,7 @@ class VMwareVMOps(object):
                             vm_groups.append(group.name)
                             break
 
+
             lst_properties = ["config.files.vmPathName", "runtime.powerState",
                               "datastore"]
             props = self._session._call_method(vutil,
@@ -1575,16 +1576,17 @@ class VMwareVMOps(object):
 
                 with lockutils.lock(server_group_infos[0].uuid,
                                 lock_file_prefix='nova-vmware-server-group'):
-                    cluster_config = vm_util.get_cluster_property(
+                    cluster_config = cluster_util.get_cluster_property(
                         self._session, "configurationEx", self._cluster)
-                    # Check if the unregistered vm is the last vm in it's group
+                    # Check if the unregistered vm is the last vm in its group
                     for group in cluster_config.group:
-                        if group.name not in vm_groups:
-                            continue
-                        if not hasattr(group, 'vm'):
-                            cluster_util.delete_vm_group(
-                                self._session, cluster.obj,
-                                group)
+                        for group_info in server_group_infos:
+                            if group.name == group_info.uuid:
+                                if not hasattr(group, 'vm'):
+                                    cluster_util.delete_vm_group(
+                                        self._session, self._cluster,
+                                        group)
+                                break
 
             except Exception as excep:
                 LOG.warning("In vmwareapi:vmops:_destroy_instance, got "

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1529,6 +1529,7 @@ class VMwareVMOps(object):
     def _destroy_instance(self, context, instance, destroy_disks=True):
         # Destroy a VM instance
         try:
+            config_info_ex = None
             vm_ref = vm_util.get_vm_ref(self._session, instance)
 
             server_group_infos = vm_util._get_server_groups(context, instance)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1529,26 +1529,8 @@ class VMwareVMOps(object):
     def _destroy_instance(self, context, instance, destroy_disks=True):
         # Destroy a VM instance
         try:
-            config_info_ex = None
             vm_ref = vm_util.get_vm_ref(self._session, instance)
-
             server_group_infos = vm_util._get_server_groups(context, instance)
-            if server_group_infos:
-                cluster = cluster_util.fetch_cluster_properties(self._session,
-                                                                       vm_ref)
-                config_info_ex = cluster.propSet[0].val
-
-            vm_groups = []
-
-            if hasattr(config_info_ex, 'group'):
-                for group in config_info_ex.group:
-                    if not hasattr(group, 'vm'):
-                        continue
-                    for vm in group.vm:
-                        if vm.value == vm_ref.value:
-                            vm_groups.append(group.name)
-                            break
-
             lst_properties = ["config.files.vmPathName", "runtime.powerState",
                               "datastore"]
             props = self._session._call_method(vutil,

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1574,7 +1574,9 @@ class VMwareVMOps(object):
                                            "UnregisterVM", vm_ref)
                 LOG.debug("Unregistered the VM", instance=instance)
 
-                with lockutils.lock('vmware-vm-group-policy'):
+
+                with lockutils.lock('vmware-vm-group-policy',
+                        lock_file_prefix=utils.SYNCHRONIZED_NOVA_PREFIX):
                     cluster_config = cluster_util.get_cluster_property(
                         self._session, "configurationEx", self._cluster)
                     # Check if the unregistered vm is the last vm in its


### PR DESCRIPTION
Removed check if the vm to delete is the last one in the group and
replace it with poll cluster group values so we can check if there
is any instance left in the current vm group. If no instances left
in the group delete the group.