### PR TITLE
[api] Don't remove ANSI from console output

### DIFF
--- a/nova/api/openstack/compute/console_output.py
+++ b/nova/api/openstack/compute/console_output.py
@@ -60,11 +60,4 @@ class ConsoleOutputController(wsgi.Controller):
         except NotImplementedError:
             common.raise_feature_not_supported()
 
-        # XML output is not correctly escaped, so remove invalid characters
-        # NOTE(cyeoh): We don't support XML output with V2.1, but for
-        # backwards compatibility reasons we continue to filter the output
-        # We should remove this in the future
-        remove_re = re.compile('[\x00-\x08\x0B-\x1F]')
-        output = remove_re.sub('', output)
-
         return {'output': output}

--- a/nova/tests/unit/api/openstack/compute/test_console_output.py
+++ b/nova/tests/unit/api/openstack/compute/test_console_output.py
@@ -95,14 +95,6 @@ class ConsoleOutputExtensionTestV21(test.NoDBTestCase):
         output = self._get_console_output(length_dict={'length': '3'})
         self.assertEqual({'output': '2\n3\n4'}, output)
 
-    def test_get_console_output_filtered_characters(self):
-        self.stub_out('nova.compute.api.API.get_console_output',
-                      fake_get_console_output_all_characters)
-        output = self._get_console_output()
-        expect = (string.digits + string.ascii_letters +
-                  string.punctuation + ' \t\n')
-        self.assertEqual({'output': expect}, output)
-
     def test_get_text_console_no_instance(self):
         self.stub_out('nova.compute.api.API.get', fake_get_not_found)
         body = {'os-getConsoleOutput': {}}


### PR DESCRIPTION
As the comment states, it's only relevant for XML and should be removed
in the future. The future is now, as we want fully colored logs :D