### PR TITLE
is_big_vm() detects baremetal like nova-scheduler

### DIFF
--- a/nova/tests/unit/scheduler/filters/test_bigvm_filters.py
+++ b/nova/tests/unit/scheduler/filters/test_bigvm_filters.py
@@ -105,9 +105,10 @@ class TestBigVmClusterUtilizationFilter(test.NoDBTestCase):
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
     def test_baremetal_instance_passes(self):
+        extra_specs = {'capabilities:cpu_arch': 'x86_64'}
         spec_obj = objects.RequestSpec(
             flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
-                                  extra_specs={'quota:separate': 'true'}))
+                                  extra_specs=extra_specs))
         host = fakes.FakeHostState('host1', 'compute', {})
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -1477,9 +1477,7 @@ def is_big_vm(memory_mb, flavor):
         return False
 
     # baremetal instances are not big
-    baremetal_match = ('quota:separate', 'true')
-    for spec in flavor.extra_specs.items():
-        if spec == baremetal_match:
-            return False
+    if 'capabilities:cpu_arch' in flavor.extra_specs:
+        return False
 
     return True


### PR DESCRIPTION
Instead of checking for the flavor attribute `quota:separate` we now use
the same flavor attribute as the scheduler: `capabilities:cpu_arch`.
This is done for consistency reasons and to make sure we can also use
separate quota for the big VMs if we want to.