### PR TITLE
reservations reduce hypervisor-details values

### DIFF
--- a/nova/compute/resource_tracker.py
+++ b/nova/compute/resource_tracker.py
@@ -622,6 +622,17 @@ class ResourceTracker(object):
         compute_node.cpu_allocation_ratio = self.cpu_allocation_ratio
         compute_node.disk_allocation_ratio = self.disk_allocation_ratio
 
+        # apply the reservations so that limes's quota can see them
+        resources = copy.deepcopy(resources)
+        resources['vcpus'] = resources.get('vcpus', 0) - \
+                             resources.get('vcpus_reserved',
+                                           CONF.reserved_host_cpus)
+        resources['memory_mb'] = resources.get('memory_mb', 0) - \
+                                 resources.get('memory_mb_reserved',
+                                               CONF.reserved_host_memory_mb)
+        resources['local_gb'] = resources.get('local_gb', 0) - \
+                                CONF.reserved_host_disk_mb / 1024
+
         # now copy rest to compute_node
         compute_node.update_from_virt_driver(resources)
 
@@ -727,8 +738,7 @@ class ResourceTracker(object):
                             'flavor', 'migration_context'])
 
         # Now calculate usage based on instance utilization:
-        self._update_usage_from_instances(context, instances, nodename,
-                                          resources)
+        self._update_usage_from_instances(context, instances, nodename)
 
         # Grab all in-progress migrations:
         migrations = objects.MigrationList.get_in_progress_by_host_and_node(
@@ -1133,8 +1143,7 @@ class ResourceTracker(object):
         else:
             cn.pci_device_pools = objects.PciDevicePoolList()
 
-    def _update_usage_from_instances(self, context, instances, nodename,
-                                     resources):
+    def _update_usage_from_instances(self, context, instances, nodename):
         """Calculate resource usage based on instance utilization.  This is
         different than the hypervisor's view as it will account for all
         instances assigned to the local compute host, even if they are not
@@ -1144,11 +1153,9 @@ class ResourceTracker(object):
 
         cn = self.compute_nodes[nodename]
         # set some initial values, reserve room for host/hypervisor:
-        cn.local_gb_used = CONF.reserved_host_disk_mb / 1024
-        cn.memory_mb_used = resources.get('memory_mb_reserved',
-                                          CONF.reserved_host_memory_mb)
-        cn.vcpus_used = resources.get('vcpus_reserved',
-                                      CONF.reserved_host_cpus)
+        cn.local_gb_used = 0
+        cn.memory_mb_used = 0
+        cn.vcpus_used = 0
         cn.free_ram_mb = (cn.memory_mb - cn.memory_mb_used)
         cn.free_disk_gb = (cn.local_gb - cn.local_gb_used)
         cn.current_workload = 0

--- a/nova/tests/unit/compute/test_resource_tracker.py
+++ b/nova/tests/unit/compute/test_resource_tracker.py
@@ -593,15 +593,15 @@ class TestUpdateAvailableResources(BaseTestCase):
         get_cn_mock.assert_called_once_with(mock.ANY, _HOSTNAME, _NODENAME)
         expected_resources = copy.deepcopy(_COMPUTE_NODE_FIXTURES[0])
         vals = {
-            'free_disk_gb': 5,  # 6GB avail - 1 GB reserved
-            'local_gb': 6,
-            'free_ram_mb': 0,  # 512MB avail - 512MB reserved
-            'memory_mb_used': 512,  # 0MB used + 512MB reserved
-            'vcpus_used': 1,
-            'local_gb_used': 1,  # 0GB used + 1 GB reserved
-            'memory_mb': 512,
+            'free_disk_gb': 5,  # local_gb
+            'local_gb': 5,  # 6GB avail - 1 GB reserved
+            'free_ram_mb': 0,  # memory_mb
+            'memory_mb_used': 0,  # 0MB used
+            'vcpus_used': 0,
+            'local_gb_used': 0,  # 0GB used
+            'memory_mb': 0,     # 512MB avail - 512MB reserved
             'current_workload': 0,
-            'vcpus': 4,
+            'vcpus': 3,     # 4 CPUs - 1 CPU reserved
             'running_vms': 0
         }
         _update_compute_node(expected_resources, **vals)
@@ -639,15 +639,15 @@ class TestUpdateAvailableResources(BaseTestCase):
         get_cn_mock.assert_called_once_with(mock.ANY, _HOSTNAME, _NODENAME)
         expected_resources = copy.deepcopy(_COMPUTE_NODE_FIXTURES[0])
         vals = {
-            'free_disk_gb': 5,  # 6GB avail - 1 GB reserved
-            'local_gb': 6,
-            'free_ram_mb': 384,  # 512MB avail - 128MB reserved
-            'memory_mb_used': 128,  # 0MB used + 128MB reserved
-            'vcpus_used': 2,
-            'local_gb_used': 1,  # 0GB used + 1 GB reserved
-            'memory_mb': 512,
+            'free_disk_gb': 5,  # local_gb
+            'local_gb': 5,  # 6GB avail - 1 GB reserved
+            'free_ram_mb': 384,  # memory_mb
+            'memory_mb_used': 0,  # 0MB used
+            'vcpus_used': 0,
+            'local_gb_used': 0,  # 0GB used
+            'memory_mb': 384,   # 512MB avail - 128MB reserved
             'current_workload': 0,
-            'vcpus': 4,
+            'vcpus': 2,     # 4 vcpus - 2 reserved
             'running_vms': 0
         }
         _update_compute_node(expected_resources, **vals)
@@ -2833,6 +2833,9 @@ class TestUpdateUsageFromInstance(BaseTestCase):
         self.flags(reserved_host_memory_mb=2048)
         self.flags(reserved_host_disk_mb=(11 * 1024))
         cn = objects.ComputeNode(memory_mb=1024, local_gb=10)
+        resources = {'hypervisor_hostname': 'foo', 'memory_mb': 1024,
+                     'local_gb': 10}
+        self.rt._copy_resources(cn, resources)
         self.rt.compute_nodes['foo'] = cn
 
         @mock.patch.object(self.rt,
@@ -2841,7 +2844,7 @@ class TestUpdateUsageFromInstance(BaseTestCase):
         @mock.patch('nova.objects.Service.get_minimum_version',
                     return_value=22)
         def test(version_mock, uufi, rdia):
-            self.rt._update_usage_from_instances('ctxt', [], 'foo', {})
+            self.rt._update_usage_from_instances('ctxt', [], 'foo')
 
         test()
 
@@ -2858,7 +2861,7 @@ class TestUpdateUsageFromInstance(BaseTestCase):
                     return_value=22)
         def test(version_mock, uufi, rdia):
             self.rt._update_usage_from_instances('ctxt', [self.instance],
-                                                 _NODENAME, {})
+                                                 _NODENAME)
 
             uufi.assert_called_once_with('ctxt', self.instance, _NODENAME,
                                          require_allocation_refresh=True)
@@ -2875,7 +2878,7 @@ class TestUpdateUsageFromInstance(BaseTestCase):
                     return_value=22)
         def test(version_mock, uufi, rdia):
             self.rt._update_usage_from_instances('ctxt', [self.instance],
-                                                 _NODENAME, {})
+                                                 _NODENAME)
 
             uufi.assert_called_once_with('ctxt', self.instance, _NODENAME,
                                          require_allocation_refresh=False)


### PR DESCRIPTION
We don't show the total values for RAM/CPU anymore, but only the ones
reduced by the reserved resources. We need this, because limes retrieves
the full quota capacity from the total values.