### PR TITLE
[scheduler] Add BigVmFlavorHostSizeFilter

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -687,6 +687,15 @@ defining whether the flavor should be used filling a full or half a host.
 
 The default behavior is to allow scheduling on a host if either full or half
 the host gets filled by the VM.
+"""),
+    cfg.DictOpt(
+        "bigvm_host_size_filter_host_fractions",
+        default={'full': 1},
+        help="""
+This dict defines what fractions of a host we support and how it's named in
+case the flavor.extra_specs attribute is used. The value provided for a name is
+multiplied by the hypervisor memory. So to support half-host sizes, you would
+use 0.5.
 """),]
 
 metrics_group = cfg.OptGroup(name="metrics",

--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -676,7 +676,18 @@ Possible values:
 Related options:
 
 * aggregate_image_properties_isolation_namespace
-""")]
+"""),
+    cfg.BoolOpt(
+        "bigvm_host_size_filter_uses_flavor_extra_specs",
+        default=False,
+        help="""
+Enabling this requires a big VM flavor to have an extra_specs property (see
+BigVmFlavorHostSizeFilter._EXTRA_SPECS_KEY) set to either "full" or "half"
+defining whether the flavor should be used filling a full or half a host.
+
+The default behavior is to allow scheduling on a host if either full or half
+the host gets filled by the VM.
+"""),]
 
 metrics_group = cfg.OptGroup(name="metrics",
                              title="Metrics parameters",

--- a/nova/scheduler/filters/bigvm_filter.py
+++ b/nova/scheduler/filters/bigvm_filter.py
@@ -111,15 +111,32 @@ class BigVmFlavorHostSizeFilter(BigVmBaseFilter):
     values to account for reserved values.
     """
     _EXTRA_SPECS_KEY = 'host_fraction'
-    _EXTRA_SPECS_FULL_HOST = 'full'
-    _EXTRA_SPECS_HALF_HOST = 'half'
     _HV_SIZE_TOLERANCE_PERCENT = 10
+
+    def _get_supported_fractions(self, hypervisor_ram_mb):
+        supported_fractions = {}
+        config_fractions = CONF.filter_scheduler.\
+                                        bigvm_host_size_filter_host_fractions
+        for name, ratio in config_fractions.items():
+            if ratio > 1:
+                LOG.error('Amount of memory cannot exceed hypervisor memory. '
+                          'Wrong configuration in filter_scheduler.'
+                          'bigvm_host_size_filter_host_fractions: '
+                          '%(config_dict).',
+                          {'config_dict': config_fractions})
+                return False
+            supported_fractions[name] = hypervisor_ram_mb * ratio
+
+        return supported_fractions
 
     def _memory_match_with_tolerance(self, memory_mb, requested_ram_mb):
         tolerance = memory_mb * self._HV_SIZE_TOLERANCE_PERCENT / 100.0
         return memory_mb - tolerance <= requested_ram_mb <= memory_mb
 
-    def _check_flavor_extra_specs(self, host_state, flavor, hypervisor_ram_mb, requested_ram_mb):
+    def _check_flavor_extra_specs(self, host_state, flavor, supported_fractions, requested_ram_mb):
+        """Use a flavor attribute to define the fraction of the host this VM
+        should match.
+        """
         # get the flavor property
         # TODO: Do we really have to have a property defining half/full-size? Why?
         extra_specs = flavor.extra_specs
@@ -134,10 +151,6 @@ class BigVmFlavorHostSizeFilter(BigVmBaseFilter):
             return False
 
         host_fraction = extra_specs[self._EXTRA_SPECS_KEY]
-        supported_fractions = {
-            self._EXTRA_SPECS_FULL_HOST: hypervisor_ram_mb,
-            self._EXTRA_SPECS_HALF_HOST: hypervisor_ram_mb / 2.0
-        }
         if host_fraction not in supported_fractions:
             LOG.warning('Flavor attribute %(specs_key)s does not have a '
                         'supported value (%(specs_value)s). Cannot schedule on '
@@ -145,9 +158,23 @@ class BigVmFlavorHostSizeFilter(BigVmBaseFilter):
                         {'host_state': host_state,
                          'specs_key': self._EXTRA_SPECS_KEY,
                          'specs_value': host_fraction})
+            return False
 
         memory_mb = supported_fractions[host_fraction]
         return self._memory_match_with_tolerance(memory_mb, requested_ram_mb)
+
+    def _check_no_flavor_extra_specs(self, host_state, supported_fractions, requested_ram_mb):
+        """Check if the VM matches any of the configured fractions."""
+        for fraction_ram_mb in supported_fractions.values():
+            if self._memory_match_with_tolerance(fraction_ram_mb, requested_ram_mb):
+                return True
+
+        LOG.info('%(host_state)s does not match %(requested_ram_mb)s for any '
+                 'of configured fraction %(supported_fractions)s.',
+                 {'host_state': host_state,
+                  'requested_ram_mb': requested_ram_mb,
+                  'supported_fractions': supported_fractions})
+        return False
 
     def host_passes(self, host_state, spec_obj):
         requested_ram_mb = spec_obj.memory_mb
@@ -162,13 +189,11 @@ class BigVmFlavorHostSizeFilter(BigVmBaseFilter):
                       {'host_state': host_state})
             return False
 
+        supported_fractions = self._get_supported_fractions(hypervisor_ram_mb)
+
         flavor_specs_enabled = CONF.filter_scheduler.\
                                bigvm_host_size_filter_uses_flavor_extra_specs
         if flavor_specs_enabled:
-            return self._check_flavor_extra_specs(host_state, spec_obj.flavor, hypervisor_ram_mb, requested_ram_mb)
+            return self._check_flavor_extra_specs(host_state, spec_obj.flavor, supported_fractions, requested_ram_mb)
         else:
-            if self._memory_match_with_tolerance(hypervisor_ram_mb, requested_ram_mb):
-                return True
-            if self._memory_match_with_tolerance(hypervisor_ram_mb / 2.0, requested_ram_mb):
-                return True
-            return False
+            return self._check_no_flavor_extra_specs(host_state, supported_fractions, requested_ram_mb)

--- a/nova/tests/unit/scheduler/filters/test_bigvm_filters.py
+++ b/nova/tests/unit/scheduler/filters/test_bigvm_filters.py
@@ -241,6 +241,8 @@ class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
 
     def test_big_vm_with_matching_half_size(self):
         """Test automatic full size matching."""
+        CONF.set_override('bigvm_host_size_filter_host_fractions',
+                          {'full': 1, 'half': 0.5}, 'filter_scheduler')
         spec_obj = objects.RequestSpec(
             flavor=objects.Flavor(memory_mb=CONF.bigvm_mb, extra_specs={}))
         host = fakes.FakeHostState('host1', 'compute',
@@ -248,8 +250,21 @@ class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
         self.filt_cls._HV_SIZE_CACHE[host.uuid] = CONF.bigvm_mb * 2 + 1024
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
+    def test_big_vm_with_half_size_not_defined(self):
+        """Test automatic full size matching."""
+        CONF.set_override('bigvm_host_size_filter_host_fractions',
+                          {'full': 1}, 'filter_scheduler')
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb, extra_specs={}))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.filt_cls._HV_SIZE_CACHE[host.uuid] = CONF.bigvm_mb * 2 + 1024
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
     def test_big_vm_without_matching_size(self):
         """Fails both half and full size test"""
+        CONF.set_override('bigvm_host_size_filter_host_fractions',
+                          {'full': 1, 'half': 0.5}, 'filter_scheduler')
         spec_obj = objects.RequestSpec(
             flavor=objects.Flavor(memory_mb=CONF.bigvm_mb, extra_specs={}))
         host = fakes.FakeHostState('host1', 'compute',
@@ -272,6 +287,8 @@ class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
         """invalid value in extra specs makes it unscheduleable"""
         CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
                           True, 'filter_scheduler')
+        CONF.set_override('bigvm_host_size_filter_host_fractions',
+                          {'full': 1, 'half': 0.5}, 'filter_scheduler')
         spec_obj = objects.RequestSpec(
             flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
                                   extra_specs={'host_fraction': 'any'},
@@ -284,6 +301,8 @@ class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
         """test specified full size"""
         CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
                           True, 'filter_scheduler')
+        CONF.set_override('bigvm_host_size_filter_host_fractions',
+                          {'full': 1, 'half': 0.5}, 'filter_scheduler')
         spec_obj = objects.RequestSpec(
             flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
                                   extra_specs={'host_fraction': 'full'},
@@ -296,6 +315,8 @@ class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
         """test specified full size"""
         CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
                           True, 'filter_scheduler')
+        CONF.set_override('bigvm_host_size_filter_host_fractions',
+                          {'full': 1, 'half': 0.5}, 'filter_scheduler')
         spec_obj = objects.RequestSpec(
             flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
                                   extra_specs={'host_fraction': 'full'},
@@ -309,6 +330,8 @@ class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
         """test specified half size"""
         CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
                           True, 'filter_scheduler')
+        CONF.set_override('bigvm_host_size_filter_host_fractions',
+                          {'full': 1, 'half': 0.5}, 'filter_scheduler')
         spec_obj = objects.RequestSpec(
             flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
                                   extra_specs={'host_fraction': 'half'},
@@ -322,6 +345,8 @@ class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
         """test specified half size"""
         CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
                           True, 'filter_scheduler')
+        CONF.set_override('bigvm_host_size_filter_host_fractions',
+                          {'full': 1, 'half': 0.5}, 'filter_scheduler')
         spec_obj = objects.RequestSpec(
             flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
                                   extra_specs={'host_fraction': 'half'},

--- a/nova/tests/unit/scheduler/filters/test_bigvm_filters.py
+++ b/nova/tests/unit/scheduler/filters/test_bigvm_filters.py
@@ -178,3 +178,154 @@ class TestBigVmClusterUtilizationFilter(test.NoDBTestCase):
                  'free_ram_mb': total_ram - (total_ram * hv_percent / 100.0),
                  'total_usable_ram_mb': total_ram})
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+
+class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
+    def setUp(self):
+        super(TestBigVmFlavorHostSizeFilter, self).setUp()
+        self.hv_size = CONF.bigvm_mb + 1024
+        self.filt_cls = bigvm_filter.BigVmFlavorHostSizeFilter()
+        self.filt_cls._HV_SIZE_CACHE = {
+            uuidsentinel.host1: self.hv_size,
+            'last_modified': time.time()
+        }
+
+    def test_big_vm_with_small_vm_passes(self):
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=1024, extra_specs={}))
+        host = fakes.FakeHostState('host1', 'compute', {})
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_baremetal_instance_passes(self):
+        extra_specs = {'capabilities:cpu_arch': 'x86_64'}
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
+                                  extra_specs=extra_specs))
+        host = fakes.FakeHostState('host1', 'compute', {})
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_big_vm_without_hv_size(self):
+        """If there's no inventory for this host, it should not even have
+        passed placement API checks, so we stop it here.
+        """
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb, extra_specs={}))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.filt_cls._HV_SIZE_CACHE[host.uuid] = None
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_memory_match_with_tolerance(self):
+        """We only accept tolerance below not above the given value."""
+
+        def call(a, b):
+            return self.filt_cls._memory_match_with_tolerance(a, b)
+
+        self.filt_cls._HV_SIZE_TOLERANCE_PERCENT = 10
+        self.assertTrue(call(1024, 1024 - 1024 * 0.1))
+        self.assertFalse(call(1024, 1024 - 1024 * 0.1 - 1))
+        self.assertTrue(call(1024, 1024))
+        self.assertFalse(call(1024, 1025))
+
+        self.filt_cls._HV_SIZE_TOLERANCE_PERCENT = 50
+        self.assertTrue(call(1024, 512))
+        self.assertFalse(call(1024, 511))
+
+    def test_big_vm_with_matching_full_size(self):
+        """Test automatic full size matching."""
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb, extra_specs={}))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_big_vm_with_matching_half_size(self):
+        """Test automatic full size matching."""
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb, extra_specs={}))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.filt_cls._HV_SIZE_CACHE[host.uuid] = CONF.bigvm_mb * 2 + 1024
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_big_vm_without_matching_size(self):
+        """Fails both half and full size test"""
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb, extra_specs={}))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.filt_cls._HV_SIZE_CACHE[host.uuid] = CONF.bigvm_mb * 1.5 + 1024
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_extra_specs_without_key(self):
+        """If we don't have the extra spec set, we fail"""
+        CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
+                          True, 'filter_scheduler')
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb, extra_specs={},
+                                  name='random-name'))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_extra_specs_invalid_value(self):
+        """invalid value in extra specs makes it unscheduleable"""
+        CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
+                          True, 'filter_scheduler')
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
+                                  extra_specs={'host_fraction': 'any'},
+                                  name='random-name'))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_extra_specs_full_positive(self):
+        """test specified full size"""
+        CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
+                          True, 'filter_scheduler')
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
+                                  extra_specs={'host_fraction': 'full'},
+                                  name='random-name'))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_extra_specs_full_negative(self):
+        """test specified full size"""
+        CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
+                          True, 'filter_scheduler')
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
+                                  extra_specs={'host_fraction': 'full'},
+                                  name='random-name'))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.filt_cls._HV_SIZE_CACHE[host.uuid] = CONF.bigvm_mb * 2 + 1024
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_extra_specs_half_positive(self):
+        """test specified half size"""
+        CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
+                          True, 'filter_scheduler')
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
+                                  extra_specs={'host_fraction': 'half'},
+                                  name='random-name'))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.filt_cls._HV_SIZE_CACHE[host.uuid] = CONF.bigvm_mb * 2 + 1024
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_extra_specs_half_negative(self):
+        """test specified half size"""
+        CONF.set_override('bigvm_host_size_filter_uses_flavor_extra_specs',
+                          True, 'filter_scheduler')
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
+                                  extra_specs={'host_fraction': 'half'},
+                                  name='random-name'))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))


### PR DESCRIPTION
This filter is supposed to only let full- or half-node size big VMs on a
host. This is our quickfix to get some NUMA-alignment for big VMs going
until the vmwareapi driver properly supports NUMA-aware scheduling.