### PR TITLE
[vmware] Don't rely on empty image_ref for BFV detection

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -30,6 +30,7 @@ from nova import exception
 from nova.network import model as network_model
 from nova import objects
 from nova import test
+from nova.tests.unit import fake_block_device
 from nova.tests.unit import fake_flavor
 from nova.tests.unit import fake_instance
 import nova.tests.unit.image.fake
@@ -986,8 +987,7 @@ class VMwareVMOpsTestCase(test.TestCase):
         self._vmops.migrate_disk_and_power_off(self._context,
                                                self._instance,
                                                None,
-                                               flavor,
-                                               None)
+                                               flavor)
 
         fake_get_vm_ref.assert_called_once_with(self._session,
                                                 self._instance)
@@ -1004,6 +1004,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                  for i in range(4)]
         fake_progress.assert_has_calls(calls)
 
+    @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid')
     @mock.patch.object(vmops.VMwareVMOps, "_remove_ephemerals_and_swap")
     @mock.patch.object(vm_util, 'get_vmdk_info')
     @mock.patch.object(vmops.VMwareVMOps, "_resize_disk")
@@ -1015,24 +1016,52 @@ class VMwareVMOpsTestCase(test.TestCase):
                                          fake_get_vm_ref, fake_progress,
                                          fake_power_off, fake_resize_vm,
                                          fake_resize_disk, fake_get_vmdk_info,
-                                         fake_remove_ephemerals_and_swap):
+                                         fake_remove_ephemerals_and_swap,
+                                         fake_bdm_get_by_instance_uuid):
         # shrinking the root-disk should be ignored
         flavor_root_gb = self._instance.flavor.root_gb - 1
 
-        self._instance.image_ref = None
-        connection_info1 = {'data': 'fake-data1', 'serial': 'volume-fake-id1'}
-        connection_info2 = {'data': 'fake-data2', 'serial': 'volume-fake-id2'}
-        connection_info3 = {'data': 'fake-data3', 'serial': 'volume-fake-id3'}
-        bdm = [{'boot_index': 0,
-                'connection_info': connection_info1,
-                'disk_bus': constants.ADAPTER_TYPE_IDE},
-               {'boot_index': 1,
-                'connection_info': connection_info2,
-                'disk_bus': constants.DEFAULT_ADAPTER_TYPE},
-               {'boot_index': 2,
-                'connection_info': connection_info3,
-                'disk_bus': constants.ADAPTER_TYPE_LSILOGICSAS}]
-        bdi = {'block_device_mapping': bdm}
+        bdms = objects.block_device.block_device_make_list_from_dicts(
+            self._context, [
+                fake_block_device.FakeDbBlockDeviceDict(
+                    {'id': 1,
+                     'source_type': 'volume', 'destination_type': 'volume',
+                     'device_name': '/dev/sda', 'tag': "db",
+                     'volume_id': uuidsentinel.volume_1,
+                     'boot_index': 0}),
+                fake_block_device.FakeDbBlockDeviceDict(
+                    {'id': 2,
+                     'source_type': 'volume', 'destination_type': 'volume',
+                     'device_name': '/dev/hda', 'tag': "nfvfunc1",
+                     'volume_id': uuidsentinel.volume_2}),
+                fake_block_device.FakeDbBlockDeviceDict(
+                    {'id': 3,
+                     'source_type': 'volume', 'destination_type': 'volume',
+                     'device_name': '/dev/sdb', 'tag': "nfvfunc2",
+                     'volume_id': uuidsentinel.volume_3}),
+                fake_block_device.FakeDbBlockDeviceDict(
+                    {'id': 4,
+                     'source_type': 'volume', 'destination_type': 'volume',
+                     'device_name': '/dev/hdb',
+                     'volume_id': uuidsentinel.volume_4}),
+                fake_block_device.FakeDbBlockDeviceDict(
+                    {'id': 5,
+                     'source_type': 'volume', 'destination_type': 'volume',
+                     'device_name': '/dev/vda', 'tag': "nfvfunc3",
+                     'volume_id': uuidsentinel.volume_5}),
+                fake_block_device.FakeDbBlockDeviceDict(
+                    {'id': 6,
+                     'source_type': 'volume', 'destination_type': 'volume',
+                     'device_name': '/dev/vdb', 'tag': "nfvfunc4",
+                     'volume_id': uuidsentinel.volume_6}),
+                fake_block_device.FakeDbBlockDeviceDict(
+                    {'id': 7,
+                     'source_type': 'volume', 'destination_type': 'volume',
+                     'device_name': '/dev/vdc', 'tag': "nfvfunc5",
+                     'volume_id': uuidsentinel.volume_7}),
+            ]
+        )
+        fake_bdm_get_by_instance_uuid.return_value = bdms
 
         vmdk = vm_util.VmdkInfo('[fake] uuid/root.vmdk',
                                 'fake-adapter',
@@ -1045,8 +1074,7 @@ class VMwareVMOpsTestCase(test.TestCase):
         self._vmops.migrate_disk_and_power_off(self._context,
                                                self._instance,
                                                None,
-                                               flavor,
-                                               bdi)
+                                               flavor)
 
         fake_get_vm_ref.assert_called_once_with(self._session,
                                                 self._instance)

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -249,8 +249,7 @@ class VMwareVCDriver(driver.ComputeDriver):
         """
         # TODO(PhilDay): Add support for timeout (clean shutdown)
         return self._vmops.migrate_disk_and_power_off(context, instance,
-                                                      dest, flavor,
-                                                      block_device_info)
+                                                      dest, flavor)
 
     def confirm_migration(self, context, migration, instance, network_info):
         """Confirms a resize, destroying the source VM."""

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -44,6 +44,7 @@ from nova.api.metadata import base as instance_metadata
 from nova import compute
 from nova.compute import power_state
 from nova.compute import task_states
+from nova.compute import utils as compute_utils
 import nova.conf
 from nova.console import type as ctype
 from nova import context as nova_context
@@ -636,8 +637,10 @@ class VMwareVMOps(object):
     def _get_vm_config_info(self, instance, image_info, extra_specs):
         """Captures all relevant information from the spawn parameters."""
 
+        boot_from_volume = compute_utils.is_volume_backed_instance(
+                                                instance._context, instance)
         if (instance.flavor.root_gb != 0 and
-                instance.image_ref and
+                not boot_from_volume and
                 image_info.file_size > instance.flavor.root_gb * units.Gi):
             reason = _("Image disk size greater than requested disk size")
             raise exception.InstanceUnacceptable(instance_id=instance.uuid,
@@ -1050,7 +1053,11 @@ class VMwareVMOps(object):
         vi = self._get_vm_config_info(instance, image_info,
                                       extra_specs)
 
-        if instance.image_ref and CONF.vmware.image_as_template:
+        boot_from_volume = compute_utils.is_volume_backed_instance(
+                                                instance._context, instance)
+
+        if CONF.vmware.image_as_template and instance.image_ref \
+                and not boot_from_volume:
             templ_vm_ref = self._get_vm_template_for_image(context,
                                                            instance,
                                                            image_info,
@@ -1094,7 +1101,8 @@ class VMwareVMOps(object):
             block_device_mapping = driver.block_device_info_get_mapping(
                 block_device_info)
 
-        if instance.image_ref and not CONF.vmware.image_as_template:
+        if instance.image_ref and not CONF.vmware.image_as_template \
+                and not boot_from_volume:
             self._imagecache.enlist_image(
                     image_info.image_id, vi.datastore, vi.dc_info.ref)
             self._fetch_image_if_missing(context, vi)
@@ -1874,8 +1882,7 @@ class VMwareVMOps(object):
         self._create_swap(block_device_info, instance, vm_ref, dc_info,
                           datastore, folder, vmdk.adapter_type)
 
-    def migrate_disk_and_power_off(self, context, instance, dest,
-                                   flavor, block_device_info):
+    def migrate_disk_and_power_off(self, context, instance, dest, flavor):
         """Transfers the disk of a running instance in multiple phases, turning
         off the instance before the end.
         """
@@ -1883,17 +1890,11 @@ class VMwareVMOps(object):
         vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
                                      uuid=instance.uuid)
 
-        def _is_volume_backed(bdi):
-            # this contains anything with _valid_destination = 'volume',
-            # ephemerals have their own list
-            bdm = driver.block_device_info_get_mapping(bdi)
-            for disk in bdm:
-                if disk.get('boot_index') == 0:
-                    return True
-            return False
+        boot_from_volume = compute_utils.is_volume_backed_instance(context,
+                                                                   instance)
 
         # Checks if the migration needs a disk resize down.
-        if (not _is_volume_backed(block_device_info) and (
+        if (not boot_from_volume and (
             flavor.root_gb < instance.flavor.root_gb or
             (flavor.root_gb != 0 and
              flavor.root_gb < vmdk.capacity_in_bytes / units.Gi))):
@@ -1922,7 +1923,7 @@ class VMwareVMOps(object):
                                        total_steps=RESIZE_TOTAL_STEPS)
 
         # 3.Reconfigure the disk properties
-        if not _is_volume_backed(block_device_info):
+        if not boot_from_volume:
             self._resize_disk(instance, vm_ref, vmdk, flavor)
         self._update_instance_progress(context, instance,
                                        step=3,


### PR DESCRIPTION
It's possible to create a boot-from-volume instance with
instance.image_ref set to something - even something different than the
actually booted volume's image according to
https://bugs.launchpad.net/nova/+bug/1648501. Therefore, we cannot rely
on an empty image_ref for BFV detection and instead use
nova.compute.utils.is_volume_backed_instance now. This prohibits the
vmware driver from creating a disk on ephemeral store in addition to
using the volume and booting from the volume.