### PR TITLE
Improvements for VMware image-as-template

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1090,6 +1090,66 @@ class VMwareVMOpsTestCase(test.TestCase):
                  for i in range(4)]
         fake_progress.assert_has_calls(calls)
 
+    @mock.patch.object(vm_util, 'destroy_vm')
+    @mock.patch.object(vutil, 'get_object_property')
+    @mock.patch.object(vm_util, 'TaskHistoryCollectorItems')
+    @mock.patch('oslo_utils.timeutils.is_older_than')
+    @mock.patch.object(ds_util, 'get_available_datastores')
+    def test_manage_image_cache_templates(self, mock_get_avlbl_ds,
+                                          mock_older_than,
+                                          mock_task_it,
+                                          mock_get_obj_prop,
+                                          mock_destroy_vm):
+        # any DS just to ensure dc_info is initialized
+        mock_get_avlbl_ds.return_value = [mock.Mock(
+            ref=vmwareapi_fake.ManagedObjectReference())]
+
+        expired_templ_vm_ref = vmwareapi_fake.ManagedObjectReference(
+            value='fake-vm-1')
+        used_templ_vm_ref = vmwareapi_fake.ManagedObjectReference(
+            value='fake-vm-2')
+        templ_list = mock.Mock(ManagedObjectReference = [expired_templ_vm_ref,
+                                                         used_templ_vm_ref])
+        mock_get_obj_prop.return_value = templ_list
+
+        EXPIRED = True
+
+        tasks_and_expirations = [
+            # NEW task with type IN scope
+            (mock.Mock(descriptionId="VirtualMachine.clone",
+                       entity=used_templ_vm_ref),
+             not EXPIRED),
+            # OLD task with type IN scope
+            (mock.Mock(descriptionId="ResourcePool.ImportVAppLRO",
+                       entity=expired_templ_vm_ref),
+             EXPIRED),
+            # NEW task with type OUT of scope
+            (mock.Mock(descriptionId="fake-task-description",
+                       entity=expired_templ_vm_ref),
+             not EXPIRED)
+        ]
+
+        mock_task_it.return_value = []
+        mock_older_than_results = []
+        for task, expired in tasks_and_expirations:
+            mock_task_it.return_value.append(task)
+            mock_older_than_results.append(expired)
+        mock_older_than.side_effect = mock_older_than_results
+
+        self.flags(group='vmware', image_as_template=True)
+        # any instance just to ensure calling _destroy_expired_image_templates
+        fake_instances = [self._instance]
+        with test.nested(
+                mock.patch.object(self._vmops, '_imagecache'),
+                mock.patch.object(self._vmops, '_get_project_folder',
+                                  return_value='fake-folder'),
+                mock.patch.object(self._session, '_call_method'),
+                mock.patch.object(self._session, '_wait_for_task')):
+            self._vmops.manage_image_cache(self._context, fake_instances)
+            mock_destroy_vm.assert_called_once_with(self._session,
+                                                    None,
+                                                    expired_templ_vm_ref)
+
     @mock.patch.object(vutil, 'get_inventory_path', return_value='fake_path')
     @mock.patch.object(vmops.VMwareVMOps, '_attach_cdrom_to_vm')
     @mock.patch.object(vmops.VMwareVMOps, '_create_config_drive')

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1317,10 +1317,9 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                self._image_meta)
             get_vm_config_info.assert_called_once_with(self._instance,
                 image_info, extra_specs)
-            build_virtual_machine.assert_called_once_with(self._instance,
-                                                          self._context,
-                image_info, vi.dc_info, vi.datastore, [],
-                extra_specs, self._get_metadata())
+            build_virtual_machine.assert_called_once_with(
+                self._instance, self._context, image_info, vi.datastore, [],
+                extra_specs, self._get_metadata(), 'fake_vm_folder')
             enlist_image.assert_called_once_with(image_info.image_id,
                                                  vi.datastore, vi.dc_info.ref)
             fetch_image.assert_called_once_with(self._context, vi)
@@ -1382,10 +1381,10 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                self._image_meta)
             get_vm_config_info.assert_called_once_with(self._instance,
                 image_info, extra_specs)
-            build_virtual_machine.assert_called_once_with(self._instance,
-                                                          self._context,
-                image_info, vi.dc_info, vi.datastore, [],
-                extra_specs, self._get_metadata(is_image_used=False))
+            build_virtual_machine.assert_called_once_with(
+                self._instance, self._context, image_info, vi.datastore, [],
+                extra_specs, self._get_metadata(is_image_used=False),
+                'fake_vm_folder')
             volumeops.attach_root_volume.assert_called_once_with(
                 connection_info1, self._instance, vi.datastore.ref,
                 constants.ADAPTER_TYPE_IDE)
@@ -1437,10 +1436,10 @@ class VMwareVMOpsTestCase(test.TestCase):
                                            self._image_meta)
         get_vm_config_info.assert_called_once_with(
             self._instance, image_info, extra_specs)
-        build_virtual_machine.assert_called_once_with(self._instance,
-                                                      self._context,
-            image_info, vi.dc_info, vi.datastore, [],
-            extra_specs, self._get_metadata(is_image_used=False))
+        build_virtual_machine.assert_called_once_with(
+            self._instance, self._context, image_info, vi.datastore, [],
+            extra_specs, self._get_metadata(is_image_used=False),
+            'fake_vm_folder')
 
     def test_get_ds_browser(self):
         cache = self._vmops._datastore_browser_mapping
@@ -1914,6 +1913,8 @@ class VMwareVMOpsTestCase(test.TestCase):
                                       'device_name': '/dev/sdb'}}
         self._test_spawn(block_device_info=block_device_info)
 
+    @mock.patch.object(vmops.VMwareVMOps, '_get_project_folder',
+                       return_value='fake-folder')
     @mock.patch.object(vm_util, 'rename_vm')
     @mock.patch('nova.virt.vmwareapi.vm_util.power_on_instance')
     @mock.patch.object(vmops.VMwareVMOps, '_create_and_attach_thin_disk')
@@ -1935,7 +1936,8 @@ class VMwareVMOpsTestCase(test.TestCase):
                                             use_disk_image,
                                             create_and_attach_thin_disk,
                                             power_on_instance,
-                                            rename_vm):
+                                            rename_vm,
+                                            mock_get_project_folder):
         self._instance.flavor = objects.Flavor(vcpus=1, memory_mb=512,
                                                name="m1.tiny", root_gb=1,
                                                ephemeral_gb=1, swap=512,
@@ -1975,7 +1977,7 @@ class VMwareVMOpsTestCase(test.TestCase):
             image_info, extra_specs)
         build_virtual_machine.assert_called_once_with(self._instance,
                                                       self._context,
-            image_info, vi.dc_info, vi.datastore, [], extra_specs, metadata)
+            image_info, vi.datastore, [], extra_specs, metadata, 'fake-folder')
         enlist_image.assert_called_once_with(image_info.image_id,
                                              vi.datastore, vi.dc_info.ref)
         fetch_image.assert_called_once_with(self._context, vi)
@@ -2121,11 +2123,12 @@ class VMwareVMOpsTestCase(test.TestCase):
 
         vm_ref = self._vmops.build_virtual_machine(self._instance,
                                                    self._context,
-                                                   image, self._dc_info,
+                                                   image,
                                                    self._ds,
                                                    self.network_info,
                                                    extra_specs,
-                                                   self._metadata)
+                                                   self._metadata,
+                                                   None)
 
         vm = vmwareapi_fake._get_object(vm_ref)
 

--- a/nova/virt/vmwareapi/vim_util.py
+++ b/nova/virt/vmwareapi/vim_util.py
@@ -158,3 +158,13 @@ def get_about_info(vim):
 def get_entity_name(session, entity):
     return session._call_method(vutil, 'get_object_property',
                                 entity, 'name')
+
+
+def get_array_items(array_obj):
+    """Get contained items if the object is a vSphere API array."""
+    array_prefix = 'ArrayOf'
+    if array_obj.__class__.__name__.startswith(array_prefix):
+        attr_name = array_obj.__class__.__name__.replace(array_prefix, '', 1)
+        if hasattr(array_obj, attr_name):
+            return getattr(array_obj, attr_name)
+    return array_obj

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -121,6 +121,104 @@ class ExtraSpecs(object):
         self.hw_video_ram = hw_video_ram
 
 
+class HistoryCollectorItems(object):
+
+    def __init__(self, session, history_collector, read_page_method,
+                 reverse_page_order=False, max_page_size=10):
+        self.session = session
+        self.history_collector = history_collector
+        self.read_page_method = read_page_method
+        self.reverse_page_order = reverse_page_order
+        self.max_page_size = max_page_size
+
+    def __iter__(self):
+        self._latest_page_read = False
+        self._page_items = None
+
+        if self.reverse_page_order:
+            self.session._call_method(self.session.vim,
+                                      "ResetCollector",
+                                      self.history_collector)
+        else:
+            self.session._call_method(self.session.vim,
+                                      "RewindCollector",
+                                      self.history_collector)
+
+        return self
+
+    def next(self):
+        if not self._page_items:
+            self._load_page()
+
+        if not self._page_items:
+            raise StopIteration
+        else:
+            return self._page_items.pop(0)
+
+    def _load_page(self):
+        if self.reverse_page_order and not self._latest_page_read:
+            self._load_latest_page()
+
+        if not self._page_items:
+            self._page_items = self.session._call_method(
+                self.session.vim, self.read_page_method,
+                self.history_collector, maxCount=self.max_page_size)
+
+    def _load_latest_page(self):
+        self._latest_page_read = True
+        latest_page = vutil.get_object_property(self.session.vim,
+                                                self.history_collector,
+                                                "latestPage")
+
+        self._page_items = vim_util.get_array_items(latest_page)
+
+    def destroy_collector(self):
+        if self.history_collector:
+            self.session._call_method(self.session.vim,
+                                      "DestroyCollector",
+                                      self.history_collector)
+
+
+class TaskHistoryCollectorItems(HistoryCollectorItems):
+    def __init__(self, session, task_filter_spec, reverse_page_order=False,
+                 max_page_size=10):
+        task_collector = session._call_method(
+            session.vim,
+            "CreateCollectorForTasks",
+            session.vim.service_content.taskManager,
+            filter=task_filter_spec)
+        read_page_method = ("ReadPreviousTasks" if reverse_page_order
+                            else "ReadNextTasks")
+        super(TaskHistoryCollectorItems, self).__init__(session,
+                                                        task_collector,
+                                                        read_page_method,
+                                                        reverse_page_order,
+                                                        max_page_size)
+
+    def __del__(self):
+        self.destroy_collector()
+
+
+class EventHistoryCollectorItems(HistoryCollectorItems):
+    def __init__(self, session, event_filter_spec, reverse_page_order=False,
+                 max_page_size=10):
+        event_collector = session._call_method(
+            session.vim,
+            "CreateCollectorForEvents",
+            session.vim.service_content.eventManager,
+            filter=event_filter_spec)
+        read_page_method = ("ReadPreviousEvents" if reverse_page_order
+                            else "ReadNextEvents")
+        super(EventHistoryCollectorItems, self).__init__(session,
+                                                         event_collector,
+                                                         read_page_method,
+                                                         reverse_page_order,
+                                                         max_page_size)
+
+    def __del__(self):
+        self.destroy_collector()
+
+
 def vm_value_cache_reset():
     global _VM_VALUE_CACHE
     _VM_VALUE_CACHE = {}

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -34,6 +34,7 @@ from oslo_log import log as logging
 from oslo_serialization import jsonutils
 from oslo_utils import excutils
 from oslo_utils import strutils
+from oslo_utils import timeutils
 from oslo_utils import units
 from oslo_utils import uuidutils
 from oslo_vmware import exceptions as vexc
@@ -2246,6 +2247,53 @@ class VMwareVMOps(object):
             dc_info = self.get_datacenter_ref_and_name(ds.ref)
             datastores_info.append((ds, dc_info))
         self._imagecache.update(context, instances, datastores_info)
+
+        if CONF.vmware.image_as_template:
+            self._age_cached_image_templates(dc_info, instances)
+
+    def _age_cached_image_templates(self, dc_info, instances):
+        project_ids = set()
+        for inst in instances:
+            project_ids.add(inst.project_id)
+        for project_id in project_ids:
+            folder_ref = self._get_project_folder(dc_info,
+                                                  project_id=project_id,
+                                                  type_='Images')
+            self._destroy_expired_image_templates(folder_ref)
+
+    def _destroy_expired_image_templates(self, templ_vm_folder_ref):
+        all_templ_vms = vutil.get_object_property(self._session.vim,
+                                                  templ_vm_folder_ref,
+                                                  "childEntity")
+
+        expired_templ_vms = {}
+        if all_templ_vms:
+            expired_templ_vms = {ref.value: ref for ref in
+                                 all_templ_vms.ManagedObjectReference}
+
+        client_factory = self._session.vim.client.factory
+        task_filter_spec = client_factory.create('ns0:TaskFilterSpec')
+        task_filter_spec.entity = client_factory.create(
+                                        'ns0:TaskFilterSpecByEntity')
+        task_filter_spec.entity.entity = templ_vm_folder_ref
+        task_filter_spec.entity.recursion = "children"
+
+        templ_tasks = vm_util.TaskHistoryCollectorItems(
+            self._session, task_filter_spec, reverse_page_order=True)
+
+        for ti in templ_tasks:
+            # Look for template creation or clone from template
+            if ti.descriptionId in ["ResourcePool.ImportVAppLRO",
+                                    "VirtualMachine.clone"]:
+                templ_vm_ref = ti.entity
+                if not timeutils.is_older_than(ti.queueTime,
+                        CONF.remove_unused_original_minimum_age_seconds):
+                    expired_templ_vms.pop(templ_vm_ref.value, None)
+                    if not expired_templ_vms:
+                        break
+
+        for templ_vm_ref in expired_templ_vms.values():
+            vm_util.destroy_vm(self._session, None, templ_vm_ref)
 
     def _get_valid_vms_from_retrieve_result(self, retrieve_result):
         """Returns list of valid vms from RetrieveResult object."""

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -731,19 +731,21 @@ class VMwareVMOps(object):
                             lock_file_prefix='nova-vmware-fetch_image'):
             self.check_cache_folder(vi.datastore.name, vi.datastore.ref)
             ds_browser = self._get_ds_browser(vi.datastore.ref)
-            image_available = ds_util.file_exists(self._session,
-                                                  ds_browser,
-                                                  vi.cache_image_folder,
-                                                  vi.cache_image_path.basename)
 
-            if not image_available and CONF.vmware.image_as_template:
+            if CONF.vmware.image_as_template:
                 templ_vm_ref = self._find_image_template_vm(vi)
                 image_available = (templ_vm_ref is not None)
 
-                if not image_available and\
-                        CONF.vmware.fetch_image_from_other_datastores:
+                if (not image_available and
+                        CONF.vmware.fetch_image_from_other_datastores):
                     templ_vm_ref = self._fetch_image_from_other_datastores(vi)
                     image_available = (templ_vm_ref is not None)
+            else:
+                image_available = ds_util.file_exists(
+                    self._session,
+                    ds_browser,
+                    vi.cache_image_folder,
+                    vi.cache_image_path.basename)
 
             if not image_available:
                 LOG.debug("Preparing fetch location", instance=vi.instance)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -325,9 +325,9 @@ class VMwareVMOps(object):
 
         return config_spec
 
-    def build_virtual_machine(self, instance, context, image_info,
-                              dc_info, datastore, network_info, extra_specs,
-                              metadata, folder_type='Instances', vm_name=None):
+    def build_virtual_machine(self, instance, context, image_info, datastore,
+                              network_info, extra_specs, metadata, vm_folder,
+                              vm_name=None):
         config_spec = self._get_vm_config_spec(instance,
                                                image_info,
                                                datastore,
@@ -336,12 +336,8 @@ class VMwareVMOps(object):
                                                metadata,
                                                vm_name=vm_name)
 
-        folder = self._get_project_folder(dc_info,
-                                          project_id=instance.project_id,
-                                          type_=folder_type)
-
         # Create the VM
-        vm_ref = vm_util.create_vm(self._session, instance, folder,
+        vm_ref = vm_util.create_vm(self._session, instance, vm_folder,
                                    config_spec, self._root_resource_pool)
 
         vm_util.update_cluster_placement(self._session,
@@ -501,7 +497,7 @@ class VMwareVMOps(object):
             vm_name,
             vi.datastore.name,
             self._get_project_folder(vi.dc_info,
-                                     project_id=vi.instance.project_id,
+                                     project_id=vi.ii.owner,
                                      type_='Images'),
             self._root_resource_pool)
         # The size of the image is different from the size of the virtual disk.
@@ -522,7 +518,7 @@ class VMwareVMOps(object):
                                vm_name,
                                vi.datastore.name,
                                self._get_project_folder(vi.dc_info,
-                                        project_id=vi.instance.project_id,
+                                        project_id=vi.ii.owner,
                                         type_='Images'),
                                self._root_resource_pool)
 
@@ -718,7 +714,7 @@ class VMwareVMOps(object):
                     "CloneVM_Task",
                     other_templ_vm_ref,
                     folder=self._get_project_folder(vi.dc_info,
-                                        project_id=vi.instance.project_id,
+                                        project_id=vi.ii.owner,
                                         type_='Images'),
                     name=self._get_image_template_vm_name(vi.ii.image_id,
                                                           vi.datastore.name),
@@ -857,15 +853,18 @@ class VMwareVMOps(object):
         max_attempts = 2
         for i in six.moves.range(max_attempts):
             try:
+                vm_folder = self._get_project_folder(vi.dc_info,
+                                                     project_id=vi.ii.owner,
+                                                     type_='Images')
+
                 templ_vm_ref = self.build_virtual_machine(vi.instance,
                                     context,
                                     vi.ii,
-                                    vi.dc_info,
                                     vi.datastore,
                                     None,
                                     extra_specs,
                                     metadata,
-                                    folder_type='Images',
+                                    vm_folder,
                                     vm_name=self._get_image_template_vm_name(
                                         vi.ii.image_id, vi.datastore.name))
 
@@ -905,7 +904,7 @@ class VMwareVMOps(object):
                                                     vi.dc_info.vmFolder,
                                                     "name")
         images_folder_path = self._get_project_folder_path(
-                                        vi.instance.project_id, 'Images')
+                                        vi.ii.owner, 'Images')
         templ_vm_name = self._get_image_template_vm_name(vi.ii.image_id,
                                                          vi.datastore.name)
         templ_vm_inventory_path = '%s/%s/%s/%s' % (vi.dc_info.name,
@@ -975,7 +974,7 @@ class VMwareVMOps(object):
             "CloneVM_Task",
             templ_vm_ref,
             folder=self._get_project_folder(vi.dc_info,
-                                    project_id=vi.instance.project_id,
+                                    project_id=vi.ii.owner,
                                     type_='Instances'),
             name=vi.instance.uuid,
             spec=clone_spec)
@@ -1071,14 +1070,16 @@ class VMwareVMOps(object):
                                                            network_info)
         else:
             metadata = self._get_instance_metadata(context, instance)
+            vm_folder = self._get_project_folder(
+                vi.dc_info, project_id=instance.project_id, type_='Instances')
             vm_ref = self.build_virtual_machine(instance,
                                                 context,
                                                 image_info,
-                                                vi.dc_info,
                                                 vi.datastore,
                                                 network_info,
                                                 extra_specs,
-                                                metadata)
+                                                metadata,
+                                                vm_folder)
 
         # Cache the vm_ref. This saves a remote call to the VC. This uses the
         # instance uuid.


### PR DESCRIPTION
- Implement cache expiration/cleanup for VM templates representing OpenStack images in vSphere.
- Change image caching logic so that corresponding VM template resides under the VM folder of the OpenStack project owning the image instead of the instance project folder. Thus a VM template will be reused when creating instances from the same OpenStack image into different projects instead of importing the image as separate VM templates for each project.
- Correct the logic for checking whether an image is already cached in vSphere to handle the cases of left-over items when switching between image-as-template and file-based image cache.