### PR TITLE
[scheduler] Add a filter for vcenter shards

### DIFF
--- a/nova/scheduler/filters/shard_filter.py
+++ b/nova/scheduler/filters/shard_filter.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2019 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import time
+
+from keystoneauth1 import exceptions as kse
+from keystoneauth1 import loading as ks_loading
+from oslo_log import log as logging
+
+import nova.conf
+from nova.scheduler import filters
+from nova.scheduler.filters import utils
+from nova import utils as nova_utils
+
+LOG = logging.getLogger(__name__)
+
+CONF = nova.conf.CONF
+
+_SERVICE_AUTH = None
+
+
+class ShardFilter(filters.BaseHostFilter):
+    """Filter hosts based on the vcenter-shard configured in their aggregate
+    and the vcenter-shards configured in the project's tags in keystone. They
+    have to overlap for a host to pass this filter.
+    """
+
+    _PROJECT_SHARD_CACHE = {}
+    _PROJECT_SHARD_CACHE_RETENTION_TIME = 10 * 60
+    _SHARD_PREFIX = 'vc-'
+    _AGGREGATE_SHARD_KEY = 'vcenter-shard'
+
+    def _update_cache(self):
+        """Ask keystone for the list of projects to save the interesting tags
+        of each project in the cache
+        """
+        global _SERVICE_AUTH
+
+        if _SERVICE_AUTH is None:
+            _SERVICE_AUTH = ks_loading.load_auth_from_conf_options(
+                                CONF,
+                                group=
+                                nova.conf.service_token.SERVICE_USER_GROUP)
+            if _SERVICE_AUTH is None:
+                # This indicates a misconfiguration so log a warning and
+                # return the user_auth.
+                LOG.error('Unable to load auth from [service_user] '
+                          'configuration. Ensure "auth_type" is set.')
+                return
+
+        adap = nova_utils.get_ksa_adapter(
+            'identity', ksa_auth=_SERVICE_AUTH,
+            min_version=(3, 0), max_version=(3, 'latest'))
+
+        url = '/projects'
+        while url:
+            try:
+                resp = adap.get(url, raise_exc=False)
+            except kse.EndpointNotFound:
+                LOG.error(
+                    "Keystone identity service version 3.0 was not found. "
+                    "This might be because your endpoint points to the v2.0 "
+                    "versioned endpoint which is not supported. Please fix "
+                    "this.")
+                return
+            except kse.ClientException:
+                LOG.error("Unable to contact keystone to update project tags "
+                          "cache")
+                return
+
+            resp.raise_for_status()
+
+            data = resp.json()
+            for project in data['projects']:
+                project_id = project['id']
+                shards = [t for t in project['tags']
+                          if t.startswith(self._SHARD_PREFIX)]
+                self._PROJECT_SHARD_CACHE[project_id] = shards
+
+            url = data['links']['next']
+
+        self._PROJECT_SHARD_CACHE['last_modified'] = time.time()
+
+    @nova_utils.synchronized('update-shard-cache')
+    def _get_shards(self, project_id):
+        """Return a set of shards for a project or None
+
+        This should be quite fast except if we update the cache. Since we only
+        need one thread updating the cache, we let the other threads wait here.
+        """
+        # expire the cache 10min after last write
+        last_modified = self._PROJECT_SHARD_CACHE.get('last_modified', 0)
+        time_diff = time.time() - last_modified
+        if time_diff > self._PROJECT_SHARD_CACHE_RETENTION_TIME:
+            self._PROJECT_SHARD_CACHE = {}
+
+        if project_id not in self._PROJECT_SHARD_CACHE:
+            self._update_cache()
+
+        return self._PROJECT_SHARD_CACHE.get(project_id)
+
+    def host_passes(self, host_state, spec_obj):
+        # ignore baremetal
+        if nova_utils.is_baremetal_flavor(spec_obj.flavor):
+            return True
+
+        project_id = spec_obj.project_id
+
+        shards = self._get_shards(project_id)
+        if shards is None:
+            LOG.error('Failure retrieving shards for project %(project_id)s.',
+                      {'project_id': project_id})
+            return False
+
+        if not len(shards):
+            LOG.error('Project %(project_id)s is not assigned to any shard.',
+                      {'project_id': project_id})
+            return False
+
+        metadata = utils.aggregate_metadata_get_by_host(host_state,
+                                                key=self._AGGREGATE_SHARD_KEY)
+        if metadata == {}:
+            LOG.error('%(host_state)s is not in an aggregate having '
+                      '%(shard_key)s assigned.',
+                      {'host_state': host_state,
+                       'shard_key': self._AGGREGATE_SHARD_KEY})
+            return False
+
+        configured_shards_set = metadata.get(self._AGGREGATE_SHARD_KEY)
+        if not configured_shards_set:
+            LOG.error('%(host_state)s is in an aggregate with empty '
+                      '%(shard_key)s.',
+                      {'host_state': host_state,
+                       'shard_key': self._AGGREGATE_SHARD_KEY})
+            return False
+
+        if configured_shards_set & set(shards):
+            LOG.debug('%(host_state)s shard %(host_shard)s found in project '
+                      'shards %(project_shards)s.',
+                      {'host_state': host_state,
+                       'host_shard': configured_shards_set,
+                       'project_shards': shards})
+            return True
+        else:
+            LOG.debug('%(host_state)s shard %(host_shard)s not found in '
+                      'project shards %(project_shards)s.',
+                      {'host_state': host_state,
+                       'host_shard': configured_shards_set,
+                       'project_shards': shards})
+            return False

--- a/nova/tests/unit/scheduler/filters/test_shard_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_shard_filter.py
@@ -102,35 +102,31 @@ class TestShardFilter(test.NoDBTestCase):
         agg_mock.return_value = {}
         self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
 
-    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
-    def test_shard_host_no_shards_in_aggregate(self, agg_mock):
-        host = fakes.FakeHostState('host1', 'compute', {})
+    def test_shard_host_no_shards_in_aggregate(self):
+        aggs = [objects.Aggregate(id=1, name='some-az-a')]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             flavor=objects.Flavor(extra_specs={}))
 
-        agg_mock.return_value = {self.filt_cls._AGGREGATE_SHARD_KEY:
-                                 set([])}
         self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
 
-    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
-    def test_shard_project_shard_match_host_shard(self, agg_mock):
-        host = fakes.FakeHostState('host1', 'compute', {})
+    def test_shard_project_shard_match_host_shard(self):
+        aggs = [objects.Aggregate(id=1, name='some-az-a'),
+                objects.Aggregate(id=1, name='vc-a-0')]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             flavor=objects.Flavor(extra_specs={}))
 
-        agg_mock.return_value = {self.filt_cls._AGGREGATE_SHARD_KEY:
-                                 set(['vc-a-0'])}
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
-    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
-    def test_shard_project_shard_do_not_match_host_shard(self, agg_mock):
-        host = fakes.FakeHostState('host1', 'compute', {})
+    def test_shard_project_shard_do_not_match_host_shard(self):
+        aggs = [objects.Aggregate(id=1, name='some-az-a'),
+                objects.Aggregate(id=1, name='vc-a-1')]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             flavor=objects.Flavor(extra_specs={}))
 
-        agg_mock.return_value = {self.filt_cls._AGGREGATE_SHARD_KEY:
-                                 set(['vc-a-1'])}
         self.assertFalse(self.filt_cls.host_passes(host, spec_obj))

--- a/nova/tests/unit/scheduler/filters/test_shard_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_shard_filter.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2019 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import time
+
+import mock
+
+from nova import objects
+from nova.scheduler.filters import shard_filter
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+class TestShardFilter(test.NoDBTestCase):
+
+    def setUp(self):
+        super(TestShardFilter, self).setUp()
+        self.filt_cls = shard_filter.ShardFilter()
+        self.filt_cls._PROJECT_SHARD_CACHE = {
+            'foo': ['vc-a-0', 'vc-b-0'],
+            'last_modified': time.time()
+        }
+
+    @mock.patch('nova.scheduler.filters.shard_filter.'
+                'ShardFilter._update_cache')
+    def test_get_shards_cache_timeout(self, mock_update_cache):
+        def set_cache():
+            self.filt_cls._PROJECT_SHARD_CACHE = {
+                'foo': ['vc-a-1']
+            }
+        mock_update_cache.side_effect = set_cache
+
+        project_id = 'foo'
+        mod = time.time() - self.filt_cls._PROJECT_SHARD_CACHE_RETENTION_TIME
+
+        self.assertEqual(self.filt_cls._get_shards(project_id),
+                                                   ['vc-a-0', 'vc-b-0'])
+
+        self.filt_cls._PROJECT_SHARD_CACHE['last_modified'] = mod
+        self.assertEqual(self.filt_cls._get_shards(project_id), ['vc-a-1'])
+
+    @mock.patch('nova.scheduler.filters.shard_filter.'
+                'ShardFilter._update_cache')
+    def test_get_shards_project_not_included(self, mock_update_cache):
+        def set_cache():
+            self.filt_cls._PROJECT_SHARD_CACHE = {
+                'bar': ['vc-a-1', 'vc-b-0']
+            }
+        mock_update_cache.side_effect = set_cache
+
+        self.assertEqual(self.filt_cls._get_shards('bar'),
+                         ['vc-a-1', 'vc-b-0'])
+        mock_update_cache.assert_called_once()
+
+    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
+    def test_shard_baremetal_passes(self, agg_mock):
+        host = fakes.FakeHostState('host1', 'compute', {})
+        extra_specs = {'capabilities:cpu_arch': 'x86_64'}
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='foo',
+            flavor=objects.Flavor(extra_specs=extra_specs))
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    @mock.patch('nova.scheduler.filters.shard_filter.'
+                'ShardFilter._update_cache')
+    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
+    def test_shard_project_not_found(self, agg_mock, mock_update_cache):
+        host = fakes.FakeHostState('host1', 'compute', {})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='bar',
+            flavor=objects.Flavor(extra_specs={}))
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
+    def test_shard_project_no_shards(self, agg_mock):
+        host = fakes.FakeHostState('host1', 'compute', {})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='foo',
+            flavor=objects.Flavor(extra_specs={}))
+
+        self.filt_cls._PROJECT_SHARD_CACHE['foo'] = []
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
+    def test_shard_host_no_shard_aggregate(self, agg_mock):
+        host = fakes.FakeHostState('host1', 'compute', {})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='foo',
+            flavor=objects.Flavor(extra_specs={}))
+
+        agg_mock.return_value = {}
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
+    def test_shard_host_no_shards_in_aggregate(self, agg_mock):
+        host = fakes.FakeHostState('host1', 'compute', {})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='foo',
+            flavor=objects.Flavor(extra_specs={}))
+
+        agg_mock.return_value = {self.filt_cls._AGGREGATE_SHARD_KEY:
+                                 set([])}
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
+    def test_shard_project_shard_match_host_shard(self, agg_mock):
+        host = fakes.FakeHostState('host1', 'compute', {})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='foo',
+            flavor=objects.Flavor(extra_specs={}))
+
+        agg_mock.return_value = {self.filt_cls._AGGREGATE_SHARD_KEY:
+                                 set(['vc-a-0'])}
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
+    def test_shard_project_shard_do_not_match_host_shard(self, agg_mock):
+        host = fakes.FakeHostState('host1', 'compute', {})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='foo',
+            flavor=objects.Flavor(extra_specs={}))
+
+        agg_mock.return_value = {self.filt_cls._AGGREGATE_SHARD_KEY:
+                                 set(['vc-a-1'])}
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))


### PR DESCRIPTION
We need those shards to scale further in an availability-zone. We shard
on project level by adding the appropriate tags to the project in
keystone.

This filter should only allow a host to pass if it's in an aggregate
having the requesting project's shard assigned.