### PR TITLE
Fix unit tests for spawn VMs on prepared empty host

### DIFF
--- a/nova/tests/unit/notifications/objects/test_notification.py
+++ b/nova/tests/unit/notifications/objects/test_notification.py
@@ -402,7 +402,7 @@ notification_object_data = {
     'IpPayload': '1.0-8ecf567a99e516d4af094439a7632d34',
     'KeypairNotification': '1.0-a73147b93b520ff0061865849d3dfa56',
     'KeypairPayload': '1.0-6daebbbde0e1bf35c1556b1ecd9385c1',
-    'NotificationPublisher': '2.2-b6ad48126247e10b46b6b0240e52e614',
+    'NotificationPublisher': '2.2-ff8ef16673817ca7a3ea69c689e260c6',
     'ServerGroupNotification': '1.0-a73147b93b520ff0061865849d3dfa56',
     'ServerGroupPayload': '1.0-eb4bd1738b4670cfe1b7c30344c143c3',
     'ServiceStatusNotification': '1.0-a73147b93b520ff0061865849d3dfa56',

--- a/nova/tests/unit/virt/vmwareapi/test_configdrive.py
+++ b/nova/tests/unit/virt/vmwareapi/test_configdrive.py
@@ -125,9 +125,10 @@ class ConfigDriveTestCase(test.TestCase):
         vmwareapi_fake.cleanup()
         nova.tests.unit.image.fake.FakeImageService_reset()
 
+    @mock.patch('nova.virt.vmwareapi.vm_util.vm_needs_special_spawning')
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata',
                        return_value='fake_metadata')
-    def _spawn_vm(self, fake_get_instance_meta,
+    def _spawn_vm(self, fake_get_instance_meta, mock_vm_special_spawning,
                   injected_files=None, admin_password=None,
                   block_device_info=None):
 

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -21,6 +21,7 @@ Test suite for VMwareAPI.
 
 import collections
 import datetime
+import fixtures
 
 from eventlet import greenthread
 import mock
@@ -38,6 +39,7 @@ from nova.compute import power_state
 from nova.compute import task_states
 from nova.compute import vm_states
 import nova.conf
+
 from nova import context
 from nova import exception
 from nova.image import glance
@@ -250,6 +252,19 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.fake_image_uuid = self.image.id
         nova.tests.unit.image.fake.stub_out_image_service(self)
         self.vnc_host = 'ha-host'
+
+        """ Monkey patch for vm_util.vm_needs_special_spawning
+        Currently set to return `True` since most of the methods are calling
+        vm_util.update_cluster_placement which calls _get_server_groups. This
+        is done in order to prevent mocking the tests using spawn.
+        """
+        self.useFixture(
+            fixtures.MonkeyPatch(
+                'nova.virt.vmwareapi.vm_util.vm_needs_special_spawning',
+                self._fake_vm_needs_special_spawning))
+
+    def _fake_vm_needs_special_spawning(self, *args, **kwargs):
+        return True
 
     def tearDown(self):
         super(VMwareAPIVMTestCase, self).tearDown()

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1573,6 +1573,7 @@ class VMwareVMOpsTestCase(test.TestCase):
         recorded_methods = [c[1][1] for c in mock_call_method.mock_calls]
         self.assertEqual(expected_methods, recorded_methods)
 
+    @mock.patch('nova.virt.vmwareapi.vm_util.vm_needs_special_spawning')
     @mock.patch.object(vmops.VMwareVMOps, '_create_folders',
                        return_value='fake_vm_folder')
     @mock.patch(
@@ -1615,10 +1616,10 @@ class VMwareVMOpsTestCase(test.TestCase):
                    mock_configure_config_drive,
                    mock_update_vnic_index,
                    mock_create_folders,
+                   mock_special_spawning,
                    block_device_info=None,
                    extra_specs=None,
                    config_drive=False):
-
         if extra_specs is None:
             extra_specs = vm_util.ExtraSpecs()
 
@@ -2051,9 +2052,11 @@ class VMwareVMOpsTestCase(test.TestCase):
     def test_create_swap_with_no_bdi(self):
         self._test_create_swap_from_instance(None)
 
+    @mock.patch('nova.virt.vmwareapi.vm_util.vm_needs_special_spawning')
     @mock.patch.object(vmops.VMwareVMOps, '_create_folders',
                        return_value='fake_vm_folder')
-    def test_build_virtual_machine(self, mock_create_folder):
+    def test_build_virtual_machine(self, mock_create_folder,
+                                   mock_special_spawning):
         image_id = nova.tests.unit.image.fake.get_valid_image_id()
         image = images.VMwareImage(image_id=image_id)
 


### PR DESCRIPTION
This is regarding the change in _get_server_groups inside
vm_util.py where we are checking if instance needs special
spawning.
Commit - 5c80f53b