### PR TITLE
Property collector cache

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -7153,6 +7153,7 @@ class ComputeManager(manager.Manager):
                          'num_vm_instances': num_vm_instances})
 
         def _sync(db_instance):
+            LOG.debug('SYNC POWER STATE ================================================================>')
             # NOTE(melwitt): This must be synchronized as we query state from
             #                two separate sources, the driver and the database.
             #                They are set (in stop_instance) and read, in sync.

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -7153,7 +7153,6 @@ class ComputeManager(manager.Manager):
                          'num_vm_instances': num_vm_instances})
 
         def _sync(db_instance):
-            LOG.debug('SYNC POWER STATE ================================================================>')
             # NOTE(melwitt): This must be synchronized as we query state from
             #                two separate sources, the driver and the database.
             #                They are set (in stop_instance) and read, in sync.

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1661,6 +1661,8 @@ def power_on_instance(session, instance, vm_ref=None):
 
     if vm_ref is None:
         vm_ref = get_vm_ref(session, instance)
+        if vm_ref.value in _VM_VALUE_CACHE:
+            _VM_VALUE_CACHE[vm_ref.value].pop("runtime.powerState", None)
 
     LOG.debug("Powering on the VM", instance=instance)
     try:
@@ -1721,7 +1723,8 @@ def power_off_instance(session, instance, vm_ref=None):
 
     if vm_ref is None:
         vm_ref = get_vm_ref(session, instance)
-
+        if vm_ref.value in _VM_VALUE_CACHE:
+            _VM_VALUE_CACHE[vm_ref.value].pop("runtime.powerState", None)
     LOG.debug("Powering off the VM", instance=instance)
     try:
         poweroff_task = session._call_method(session.vim,

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -27,6 +27,9 @@ import re
 import six
 import time
 
+from eventlet import spawn as spawn_background_task
+from oslo_concurrency.lockutils import synchronized
+
 import cluster_util
 import decorator
 from oslo_concurrency import lockutils
@@ -154,6 +157,7 @@ class VMwareVMOps(object):
         self._imagecache = imagecache.ImageCacheManager(self._session,
                                                         self._base_folder)
         self._network_api = network.API()
+        spawn_background_task(self.update_cached_instances)
 
     def _get_base_folder(self):
         # Enable more than one compute node to run on the same host
@@ -1758,7 +1762,7 @@ class VMwareVMOps(object):
             return
 
         vm_util.power_off_instance(self._session, instance)
-        self.update_cached_instances()
+        #self.update_cached_instances()
 
     def _clean_shutdown(self, instance, timeout, retry_interval):
         """Perform a soft shutdown on the VM.
@@ -1817,7 +1821,7 @@ class VMwareVMOps(object):
                           "summary.guest.toolsRunningStatus",
                          ]
 
-        self.update_cached_instances()
+        #self.update_cached_instances()
         vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
 
         if set(vm_props.keys()).issuperset(lst_properties):
@@ -1829,7 +1833,7 @@ class VMwareVMOps(object):
 
     def power_on(self, instance):
         vm_util.power_on_instance(self._session, instance)
-        self.update_cached_instances()
+        #self.update_cached_instances()
 
     def _update_instance_progress(self, context, instance, step, total_steps):
         """Update instance progress percent to reflect current step number
@@ -2078,8 +2082,8 @@ class VMwareVMOps(object):
         """Return data about the VM instance."""
         lst_properties = ["runtime.powerState"]
 
-        if not vm_util._VM_VALUE_CACHE:
-            self.update_cached_instances()
+        # if not vm_util._VM_VALUE_CACHE:
+        #     self.update_cached_instances()
 
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
@@ -2534,7 +2538,7 @@ class VMwareVMOps(object):
         if not CONF.vmware.use_property_collector:
             lst_vm_names = self._list_instances_in_cluster()
         else:
-            self.update_cached_instances()
+            #self.update_cached_instances()
             lst_vm_names = [item["config.instanceUuid"]
                             for item in vm_util._VM_VALUE_CACHE.values()
                             if "config.instanceUuid" in item and item.get(
@@ -2609,76 +2613,80 @@ class VMwareVMOps(object):
             else:
                 yield change.name, val
 
-    @utils.synchronized("vmware.update_cache")
+    @synchronized('update_cache')
     def update_cached_instances(self):
-        if not CONF.vmware.use_property_collector:
-            return
-
         vim = self._session.vim
-        options = self._session.vim.client.factory.create("ns0:WaitOptions")
-        options.maxWaitSeconds = 0
-
+        options = None
         if self._property_collector is None:
-            pc = vim.service_content.propertyCollector
-            self._property_collector = self._session._call_method(
-                self._session.vim,
-                "CreatePropertyCollector", pc)
+            self._property_collector = vim.service_content.propertyCollector
             vim.CreateFilter(self._property_collector,
-                spec=self._get_vm_monitor_spec(vim),
-                partialUpdates=False)
-
-        update_set = vim.WaitForUpdatesEx(self._property_collector,
-            version=self._property_collector_version,
-            options=options)
-
+                             spec=self._get_vm_monitor_spec(vim),
+                             partialUpdates=False)
+        update_set = vim.WaitForUpdatesEx(self._property_collector, version="",
+                                          options=options)
         while update_set:
-            self._property_collector_version = update_set.version
-            if update_set.filterSet and update_set.filterSet[0].objectSet:
-                for update in update_set.filterSet[0].objectSet:
-                    vm_ref = update.obj
-                    if vm_ref["_type"] != "VirtualMachine":
-                        continue
-                    values = vm_util._VM_VALUE_CACHE[vm_ref.value]
-
-                    if update.kind == "leave":
-                        instance_uuid = values.get("config.instanceUuid")
-                        vm_util.vm_ref_cache_delete(instance_uuid)
-                        vm_util.vm_value_cache_delete(vm_ref)
-                        LOG.debug("Removed instance %s (%s) from cache...",
-                                  instance_uuid, vm_ref.value)
-                    else:
-                        changes = dict(self._parse_change_set(
-                                                update.changeSet))
-                        LOG.debug("%s.%s.%s: %s", vm_ref["_type"], update.kind,
-                                  vm_ref.value, changes)
-                        if not (changes.get("config.managedBy") or
-                                values.get("config.managedBy")):
-                            LOG.debug("%s Not managed by nova", vm_ref.value)
-                            continue
-
-                        instance_uuid = changes.get("config.instanceUuid")
-
-                        if update.kind == "enter":
-                            vm_util.vm_ref_cache_update(instance_uuid, vm_ref)
-                        elif update.kind == "modify":
-                            old_instance_uuid = values.get(
-                                        "config.instanceUuid")
-                            new_instance_uuid = changes.get(
-                                        "config.instanceUuid")
-
-                            if old_instance_uuid != new_instance_uuid:
-                                vm_util.vm_ref_cache_delete(
-                                    old_instance_uuid)
-                                vm_util.vm_ref_cache_update(
-                                    instance_uuid, vm_ref)
-
-                        values.update(changes)
-                        LOG.debug("%s.%s.%s -> %s", vm_ref["_type"],
-                                  update.kind, vm_ref.value, values)
-
+            self.process_update_set(update_set)
             update_set = vim.WaitForUpdatesEx(self._property_collector,
-                version=self._property_collector_version,
-                options=options)
+                                      version=self._property_collector_version,
+                                      options=options)
+
+    def process_update_set(self, update_set):
+        self._property_collector_version = update_set.version
+        if update_set.filterSet and update_set.filterSet[0].objectSet:
+            for update in update_set.filterSet[0].objectSet:
+                if update.obj['_type'] == "VirtualMachine":
+                    if update.kind == "leave":
+                        self.handle_leave_event(update)
+                    else:
+                        if update.kind == "enter":
+                            self.handle_enter_event(update)
+                        elif update.kind == "modify":
+                            self.handle_modify_event(update)
+
+    def set_val_cache(self, key, name, val):
+        vm_util._VM_VALUE_CACHE[key][name] = val
+
+    def handle_leave_event(self, update):
+        LOG.info("Removing instance from cache...")
+        cache_id_to_delete = vm_util._VM_VALUE_CACHE.get(
+            update.obj.value, {}).get('config.instanceUuid')
+        vm_util.vm_ref_cache_delete(cache_id_to_delete)
+        vm_util.vm_value_cache_delete(update.obj.value)
+
+    def handle_enter_event(self, update):
+        LOG.debug('HANDLE ENTER =============================================> ')
+
+        for change in update.changeSet:
+            if change.op == 'assign':
+                if hasattr(update.changeSet[0], 'val') and \
+                        hasattr(update.changeSet[1], 'val'):
+                    self.set_val_cache(update.obj.value,
+                                       change.name,
+                                       change.val)
+        if hasattr(update.changeSet[0], 'val') and \
+                hasattr(update.changeSet[1], 'val'):
+            if update.changeSet[1].val.extensionKey == constants.EXTENSION_KEY:
+                LOG.info("Adding vm to cache...")
+                vm_util.vm_ref_cache_update(update.changeSet[0].val,
+                                            update.obj)
+
+    def handle_modify_event(self, update):
+        LOG.debug('HANDLE MODIFY =============================================> ')
+        if update.changeSet[0].name == "config.instanceUuid":
+            for change in update.changeSet:
+                if change['op'] == 'assign':
+                    self.set_val_cache(update.obj.value,
+                                       change.name,
+                                       change.val)
+            if update.changeSet[1].val.extensionKey == constants.EXTENSION_KEY:
+                vm_util.vm_ref_cache_update(update.changeSet[0].val,
+                                            update.obj)
+        else:
+            for change in update.changeSet:
+                if change['op'] == 'assign':
+                    self.set_val_cache(update.obj.value,
+                                       change.name,
+                                       change.val)
 
     def _get_vm_monitor_spec(self, vim):
         traversal_spec_vm = vutil.build_traversal_spec(
@@ -2706,12 +2714,7 @@ class VMwareVMOps(object):
         property_spec_vm = vutil.build_property_spec(
             vim.client.factory,
             "VirtualMachine",
-            ["config.instanceUuid",
-             "config.managedBy",
-             "runtime.powerState",
-             "summary.guest.toolsStatus",
-             "summary.guest.toolsRunningStatus",
-            ])
+            ["config.instanceUuid", "config.managedBy", "runtime.powerState"])
         property_filter_spec = vutil.build_property_filter_spec(
             vim.client.factory,
             [property_spec, property_spec_vm],

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1762,7 +1762,6 @@ class VMwareVMOps(object):
             return
 
         vm_util.power_off_instance(self._session, instance)
-        #self.update_cached_instances()
 
     def _clean_shutdown(self, instance, timeout, retry_interval):
         """Perform a soft shutdown on the VM.
@@ -1821,7 +1820,6 @@ class VMwareVMOps(object):
                           "summary.guest.toolsRunningStatus",
                          ]
 
-        #self.update_cached_instances()
         vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
 
         if set(vm_props.keys()).issuperset(lst_properties):
@@ -1833,7 +1831,6 @@ class VMwareVMOps(object):
 
     def power_on(self, instance):
         vm_util.power_on_instance(self._session, instance)
-        #self.update_cached_instances()
 
     def _update_instance_progress(self, context, instance, step, total_steps):
         """Update instance progress percent to reflect current step number
@@ -2081,9 +2078,6 @@ class VMwareVMOps(object):
     def get_info(self, instance):
         """Return data about the VM instance."""
         lst_properties = ["runtime.powerState"]
-
-        # if not vm_util._VM_VALUE_CACHE:
-        #     self.update_cached_instances()
 
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
@@ -2538,7 +2532,6 @@ class VMwareVMOps(object):
         if not CONF.vmware.use_property_collector:
             lst_vm_names = self._list_instances_in_cluster()
         else:
-            #self.update_cached_instances()
             lst_vm_names = [item["config.instanceUuid"]
                             for item in vm_util._VM_VALUE_CACHE.values()
                             if "config.instanceUuid" in item and item.get(
@@ -2638,7 +2631,6 @@ class VMwareVMOps(object):
                 version = update_set.version
 
             except Exception as e:
-                LOG.debug("TEST ================================================>")
                 LOG.error(e)
 
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2684,9 +2684,10 @@ class VMwareVMOps(object):
                     self.set_val_cache(update.obj.value,
                                        change.name,
                                        change.val)
-            if update.changeSet[1].val.extensionKey == constants.EXTENSION_KEY:
-                vm_util.vm_ref_cache_update(update.changeSet[0].val,
-                                            update.obj)
+            if len(update.changeSet) > 1:
+                if update.changeSet[1].val.extensionKey == constants.EXTENSION_KEY:
+                    vm_util.vm_ref_cache_update(update.changeSet[0].val,
+                                                update.obj)
         else:
             for change in update.changeSet:
                 if change['op'] == 'assign':

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2623,7 +2623,6 @@ class VMwareVMOps(object):
                 update_set = vim.WaitForUpdatesEx(self._property_collector,
                                                   version=version,
                                                   options=options)
-                LOG.debug('Update set: %s' % update_set)
                 if update_set is None:
                     continue
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2653,7 +2653,6 @@ class VMwareVMOps(object):
 
     def handle_leave_event(self, update):
         LOG.info("Removing instance from cache...")
-        LOG.info("Handle Leave event: %s" % update.changeSet)
         cache_id_to_delete = vm_util._VM_VALUE_CACHE.get(
             update.obj.value, {}).get('config.instanceUuid')
         vm_util.vm_ref_cache_delete(cache_id_to_delete)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2657,8 +2657,6 @@ class VMwareVMOps(object):
         vm_util.vm_value_cache_delete(update.obj.value)
 
     def handle_enter_event(self, update):
-        LOG.debug('Handle Enter event: %s' % update.changeSet)
-
         for change in update.changeSet:
             if change.op == 'assign':
                 if hasattr(update.changeSet[0], 'val') and \
@@ -2674,7 +2672,6 @@ class VMwareVMOps(object):
                                             update.obj)
 
     def handle_modify_event(self, update):
-        LOG.debug('Handle Modify event %s' % update.changeSet)
         if update.changeSet[0].name == "config.instanceUuid":
             for change in update.changeSet:
                 LOG.debug('Value found: %s' % change)
@@ -2684,9 +2681,12 @@ class VMwareVMOps(object):
                                        change.name,
                                        change.val)
             if len(update.changeSet) > 1:
-                if update.changeSet[1].val.extensionKey == constants.EXTENSION_KEY:
-                    vm_util.vm_ref_cache_update(update.changeSet[0].val,
-                                                update.obj)
+                if hasattr(update.changeSet[0], 'val') and \
+                        hasattr(update.changeSet[1], 'val'):
+                    if update.changeSet[1].val.extensionKey ==\
+                            constants.EXTENSION_KEY:
+                        vm_util.vm_ref_cache_update(update.changeSet[0].val,
+                                                    update.obj)
         else:
             for change in update.changeSet:
                 if change['op'] == 'assign':

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2626,14 +2626,21 @@ class VMwareVMOps(object):
                              partialUpdates=False)
 
         while True:
-            update_set = vim.WaitForUpdatesEx(self._property_collector,
-                                              version=version,
-                                              options=options)
-            if update_set is None:
-                continue
+            try:
+                update_set = vim.WaitForUpdatesEx(self._property_collector,
+                                                  version=version,
+                                                  options=options)
+                LOG.debug('Update set: %s' % update_set)
+                if update_set is None:
+                    continue
 
-            self.process_update_set(update_set)
-            version = update_set.version
+                self.process_update_set(update_set)
+                version = update_set.version
+
+            except Exception as e:
+                LOG.debug("TEST ================================================>")
+                LOG.error(e)
+
 
 
     def process_update_set(self, update_set):
@@ -2659,7 +2666,7 @@ class VMwareVMOps(object):
         vm_util.vm_value_cache_delete(update.obj.value)
 
     def handle_enter_event(self, update):
-        LOG.debug('Handle Enter event : %s' % update.changeSet)
+        LOG.debug('Handle Enter event: %s' % update.changeSet)
 
         for change in update.changeSet:
             if change.op == 'assign':
@@ -2679,6 +2686,8 @@ class VMwareVMOps(object):
         LOG.debug('Handle Modify event %s' % update.changeSet)
         if update.changeSet[0].name == "config.instanceUuid":
             for change in update.changeSet:
+                LOG.debug('Value found: %s' % change)
+
                 if change['op'] == 'assign':
                     self.set_val_cache(update.obj.value,
                                        change.name,


### PR DESCRIPTION
Reverted poll task for collecting instance info into the cache and reverted to the initial idea of property collector intercepting events in VC and storing properties of the instance into the cache. Due to issues with possible collision between the periodic task _sync_power_states and the arbitary time in which the property collector is bringing the queued changes we have inconsistencies in the power states of the instances. So one approach presented here is to remove the cached "powerState" in power_on/off methods which should cause the following scenarios: 
-We poll the power-state before we get a change from the property-collector, then it should trigger a load from the vsphere-api
-We receive the update on time from power-off/on task in the property-collector, then the value is updated in the cache