### PR TITLE
[vmware] Allow get_mks_console in RESCUED and RESCUED state

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -283,7 +283,8 @@ class VMwareVCDriver(driver.ComputeDriver):
         return self._vmops.get_vnc_console(instance)
 
     def get_mks_console(self, context, instance):
-        if instance.vm_state == vm_states.ACTIVE:
+        valid_states = (vm_states.ACTIVE, vm_states.RESCUED, vm_states.RESIZED)
+        if instance.vm_state in valid_states:
             return self._vmops.get_mks_console(instance)
         raise exception.ConsoleTypeUnavailable(console_type='mks')
 


### PR DESCRIPTION
Instead of just allowing to access a VM in state ACTIVE, it also makes
sense to access a VM currently running a rescue image and a VM running
after being resized.

Change-Id: If9f7a84ed06b438072378aa67ac0dd3b33b0c01e