### PR TITLE
[scheduler] Add prefer-resize-to-same-host weigher 

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -416,6 +416,25 @@ Possible values:
 * An integer or float value, where the value corresponds to the multipler
   ratio for this weigher.
 """),
+    cfg.FloatOpt("prefer_same_host_resize_weight_multiplier",
+        default=1.0,
+        help="""
+Prefer scheduling on same-host on resize weight multiplier.
+
+This option determines how strongly the previous host should be considered for
+scheduling a resizing instance. A positive value will result in the scheduler
+preferring the same host that the instance was previously running on. A
+negative value would prefer all other hosts over the instance's previous host.
+
+This option is only used by the FilterScheduler and its subclasses; if you use
+a different scheduler, this option has no effect. Also note that this setting
+only affects scheduling if the 'resize_same_host' weigher is enabled.
+
+Possible values:
+
+* An integer or float value, where the value corresponds to the multipler
+  ratio for this weigher.
+"""),
     cfg.FloatOpt("disk_weight_multiplier",
         default=1.0,
         deprecated_group="DEFAULT",

--- a/nova/scheduler/weights/resize_same_host.py
+++ b/nova/scheduler/weights/resize_same_host.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2020 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Prefer resize to same host weigher. Resizing an instance gives the current host
+a higher priority.
+
+This weigher ignores any instances which are:
+ * new instances (or unshelving)
+ * not resizing (a.k.a. migrating or rebuilding)
+ * baremetal
+"""
+import nova.conf
+from nova.exception import ObjectActionError
+from nova.scheduler import utils
+from nova.scheduler import weights
+from nova.utils import is_baremetal_flavor
+import six
+
+CONF = nova.conf.CONF
+
+
+class PreferSameHostOnResizeWeigher(weights.BaseHostWeigher):
+    minval = 0
+
+    def weight_multiplier(self):
+        """Override the weight multiplier."""
+        return CONF.filter_scheduler.prefer_same_host_resize_weight_multiplier
+
+    def _is_resize(self, cur_flavor, dest_flavor):
+        """Return True if `cur_flavor` is different from `dest_flavor`.
+        Return False otherwise.
+        """
+        try:
+            return cur_flavor.id != dest_flavor.id
+        except ObjectActionError as e:
+            if 'obj_load_attr' in six.text_type(e):
+                # Note(jakob): If for some weird reason, id cannot be found,
+                # assume it's a resize. There is not much to break by
+                # preferring the same host.
+                return True
+            raise e
+
+    def _weigh_object(self, host_state, request_spec):
+        """Return 1 for about-to-be-resized instances where the host is the
+        instance's current host. Return 0 otherwise.
+        """
+        if (request_spec.instance_uuid not in host_state.instances
+                or utils.request_is_rebuild(request_spec)):
+            return 0.0
+
+        instance = host_state.instances[request_spec.instance_uuid]
+        if (is_baremetal_flavor(instance.flavor)
+                or is_baremetal_flavor(request_spec.flavor)):
+            return 0.0
+
+        if self._is_resize(instance.flavor, request_spec.flavor):
+            return 1.0
+        return 0.0

--- a/nova/tests/unit/scheduler/weights/test_weights_resize_same_host.py
+++ b/nova/tests/unit/scheduler/weights/test_weights_resize_same_host.py
@@ -1,0 +1,120 @@
+# Copyright 2020 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Tests for scheduler prefer-resize-to-same-host weigher.
+"""
+from nova import objects
+from nova.scheduler import weights
+from nova.scheduler.weights import resize_same_host
+from nova import test
+from nova.tests.unit.scheduler import fakes
+from nova.tests import uuidsentinel
+
+
+class PreferSameHostOnResizeWeigherTestCase(test.NoDBTestCase):
+    def setUp(self):
+        super(PreferSameHostOnResizeWeigherTestCase, self).setUp()
+        self.weight_handler = weights.HostWeightHandler()
+        self.weighers = [resize_same_host.PreferSameHostOnResizeWeigher()]
+
+        flavor_big = objects.Flavor(id=1, name='big',
+                                    memory_mb=1024 * 512, extra_specs={})
+        flavor_small = objects.Flavor(id=2, name='small',
+                                      memory_mb=1024 * 256, extra_specs={})
+        baremetal_extra_specs = {'capabilities:cpu_arch': 'x86_64',
+                                 'quota:separate': 'true'}
+        flavor_bm_big = objects.Flavor(id=3, name='bm_big',
+                                       memory_mb=1024 * 512,
+                                       extra_specs=baremetal_extra_specs)
+        flavor_bm_small = objects.Flavor(id=4, name='bm_small',
+                                         memory_mb=1024 * 256,
+                                         extra_specs=baremetal_extra_specs)
+        old_instance = objects.Instance(host='same_host',
+                                        uuid=uuidsentinel.fake_instance,
+                                        flavor=flavor_small)
+        new_instance = objects.Instance(uuid=uuidsentinel.fake_new_instance,
+                                        flavor=flavor_small)
+        bm_instance = objects.Instance(host='same_host',
+                                       uuid=uuidsentinel.fake_bm_instance,
+                                       flavor=flavor_bm_small)
+        self.hosts = [
+            fakes.FakeHostState('same_host', 'n1', {}, [old_instance,
+                                                        bm_instance]),
+            fakes.FakeHostState('other_host', 'n2', {}, []),
+        ]
+        self.request_specs = {
+            'to-big': objects.RequestSpec(instance_uuid=old_instance.uuid,
+                                          flavor=flavor_big),
+            'to-small': objects.RequestSpec(instance_uuid=old_instance.uuid,
+                                            flavor=flavor_small),
+            'rebuild': objects.RequestSpec(instance_uuid=old_instance.uuid,
+                                           flavor=flavor_big,
+                                           scheduler_hints={
+                                               '_nova_check_type': ['rebuild']
+                                           }),
+            'new': objects.RequestSpec(instance_uuid=new_instance.uuid),
+            'resize-bm': objects.RequestSpec(instance_uuid=bm_instance.uuid,
+                                             flavor=flavor_bm_big)
+        }
+
+    def test_prefer_resize_to_same_host(self):
+        self.flags(prefer_same_host_resize_weight_multiplier=1.0,
+                   group='filter_scheduler')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, self.request_specs['to-big'])
+        self.assertEqual(1.0, weighed_hosts[0].weight)
+        self.assertEqual(0.0, weighed_hosts[1].weight)
+        self.assertEqual('same_host', weighed_hosts[0].obj.host)
+
+    def test_prefer_resize_to_different_host(self):
+        self.flags(prefer_same_host_resize_weight_multiplier=-1.0,
+                   group='filter_scheduler')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, self.request_specs['to-big'])
+        self.assertEqual(0.0, weighed_hosts[0].weight)
+        self.assertEqual(-1.0, weighed_hosts[1].weight)
+        self.assertEqual('other_host', weighed_hosts[0].obj.host)
+
+    def test_ignore_non_resizing_instance(self):
+        self.flags(prefer_same_host_resize_weight_multiplier=1.0,
+                   group='filter_scheduler')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, self.request_specs['to-small'])
+        self.assertEqual(0.0, weighed_hosts[0].weight)
+        self.assertEqual(0.0, weighed_hosts[1].weight)
+
+    def test_ignore_rebuilding_instance(self):
+        self.flags(prefer_same_host_resize_weight_multiplier=1.0,
+                   group='filter_scheduler')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, self.request_specs['rebuild'])
+        self.assertEqual(0.0, weighed_hosts[0].weight)
+        self.assertEqual(0.0, weighed_hosts[1].weight)
+
+    def test_ignore_scheduling_new_instance(self):
+        self.flags(prefer_same_host_resize_weight_multiplier=1.0,
+                   group='filter_scheduler')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, self.request_specs['new'])
+        self.assertEqual(0.0, weighed_hosts[0].weight)
+        self.assertEqual(0.0, weighed_hosts[1].weight)
+
+    def test_ignore_baremetal_instance(self):
+        self.flags(prefer_same_host_resize_weight_multiplier=1.0,
+                   group='filter_scheduler')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, self.request_specs['resize-bm'])
+        self.assertEqual(0.0, weighed_hosts[0].weight)
+        self.assertEqual(0.0, weighed_hosts[1].weight)


### PR DESCRIPTION
When an instance is resized, it is rescheduled. So far the scheduler considers all hosts equally when scheduling an instance, the current host of the instance is not special.

It is arguably desirable to keep instances on the same host if possible and keep instance migrations between hosts to a minimum.

This change addresses this by introducing a prefer-resize-to-same-host weigher, which weighs the host the instance is currently running on higher than all others. This only comes into play if the filters have included the current host in their output. Notably this change does not in any way "add" the resources used by the instance to the available host resources, in short, the current host would need enough space for "another", resized, instance to be eligible.

Fixes CCM-13235