### PR TITLE
FIX: fallback to DEFAULT_VIF_MODEL if the image_meta doesn't have it

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2115,7 +2115,8 @@ class VMwareVMOps(object):
         # Iterate over the network adapters and update the backing
         if network_info:
             spec.deviceChange = []
-            vif_model = image_meta.properties.hw_vif_model
+            vif_model = image_meta.properties.get('hw_vif_model',
+                                                  constants.DEFAULT_VIF_MODEL)
             hardware_devices = self._session._call_method(
                                                     vutil,
                                                     "get_object_property",


### PR DESCRIPTION
There might be images not having the 'hw_vif_model' in its
properties. Since we always need the vif_model when dealing with
network device changes, we must fallback to the DEFAULT_VIF_MODEL.