### PR TITLE
[api] Better error message for invalid baremetal flavor

### DIFF
--- a/nova/api/openstack/compute/servers.py
+++ b/nova/api/openstack/compute/servers.py
@@ -632,6 +632,11 @@ class ServersController(wsgi.Controller):
                 exception.NoUniqueMatch,
                 exception.MultiattachSupportNotYetAvailable) as error:
             raise exc.HTTPConflict(explanation=error.format_message())
+        except exception.InvalidQuotaMethodUsage as error:
+            if ' instances_' in error.message:
+                msg = "Invalid baremetal flavor for this region."
+                raise exc.HTTPBadRequest(explanation=msg)
+            raise
 
         # If the caller wanted a reservation_id, return it
         if return_reservation_id:


### PR DESCRIPTION
If we don't have any node supporting a specific baremetal flavor, we
don't have a quota resource for it, which makes requests trying to
create a server with that flavor die in a bad way (HTTP 500):

  Unexpected exception in API method: InvalidQuotaMethodUsage: Wrong quota method check used on resource instances_zh1emx1.large

Which looks like this to the user:

  $ os server create --flavor zh0hpe1.large --key bla --image 0c5135e7-eb1a-49bb-9945-2d82a72353c6 test-joker-bare-1 --network cc-demo_private
  Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
  <class 'nova.exception.InvalidQuotaMethodUsage'> (HTTP 500) (Request-ID: req-020b17cd-206d-4763-951b-4ace5f335321)

We now catch the exception and provide a better error-message:

  $ os server create --flavor zh0hpe1.large --key bla --image 0c5135e7-eb1a-49bb-9945-2d82a72353c6 test-joker-bare-1 --network cc-demo_private
  Invalid baremetal flavor for this region. (HTTP 400) (Request-ID: req-0c9f2f46-36c6-4978-9eda-94010eb853ac

Change-Id: I9a03ac4a04db827498144fcc0a2fa01e8a7e989b