### PR TITLE
[vmware] Fix VM group deletion

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1633,7 +1633,8 @@ class VMwareAPIVMTestCase(test.TestCase,
                           self.instance, 'dev2')]
             self.assertEqual(exp_detach_calls, detach_volume.call_args_list)
 
-    def test_destroy(self):
+    @mock.patch('nova.virt.vmwareapi.cluster_util.fetch_cluster_properties')
+    def test_destroy(self, mock_fetch):
         self._create_vm()
         info = self._get_info()
         self._check_vm_info(info, power_state.RUNNING)
@@ -1644,7 +1645,8 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.assertEqual(0, len(instances))
         self.assertIsNone(vm_util.vm_ref_cache_get(self.uuid))
 
-    def test_destroy_no_datastore(self):
+    @mock.patch('nova.virt.vmwareapi.cluster_util.fetch_cluster_properties')
+    def test_destroy_no_datastore(self, mock_fetch):
         self._create_vm()
         info = self._get_info()
         self._check_vm_info(info, power_state.RUNNING)
@@ -1656,6 +1658,44 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.conn.destroy(self.context, self.instance, self.network_info)
         instances = self.conn.list_instances()
         self.assertEqual(0, len(instances))
+
+    @mock.patch('nova.virt.vmwareapi.cluster_util.fetch_cluster_properties')
+    @mock.patch('nova.virt.vmwareapi.cluster_util.delete_vm_group')
+    @mock.patch('nova.virt.vmwareapi.vm_util._get_server_groups')
+    @mock.patch('nova.virt.vmwareapi.vm_util.update_cluster_placement')
+    def test_destroy_with_vm_group(self, mock_update_placement,
+                                         mock_get_sg,
+                                         mock_delete_group,
+                                         mock_fetch_cluster_props):
+        """Test deletion of a vm group when the deleted vm is the last in
+        the vm group
+        """
+        self._create_vm()
+        fake_server_group = collections.namedtuple('GroupInfo', ['uuid',
+                                                                'policies'])
+        fake_server_group.uuid = 'test_group'
+        mock_get_sg.return_value = [fake_server_group]
+        fake_factory = vmwareapi_fake.FakeFactory()
+
+        fake_cluster_config_info = fake_factory.create(
+            'ns0:ClusterConfigInfoEx')
+        group = fake_factory.create('ns0:ClusterVmGroup')
+        group.name = 'test_group'
+        group_info = fake_factory.create('ns0:ClusterGroupInfo')
+        group_info = group
+
+        fake_cluster_config_info.group = [group_info]
+
+        def fake_call_method(module, method, *args, **kwargs):
+            if method == "get_object_property" and "configurationEx" in args:
+                return fake_cluster_config_info
+            else:
+                return self.call_method(module, method, *args, **kwargs)
+        with (mock.patch.object(
+                self.conn._session, '_call_method', fake_call_method)):
+
+            self.conn.destroy(self.context, self.instance, self.network_info)
+            mock_delete_group.assert_called_once()
 
     def test_destroy_non_existent(self):
         self.destroy_disks = True
@@ -2070,7 +2110,8 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.assertEqual('iscsi-name', connector['initiator'])
         self.assertIn('instance', connector)
 
-    def test_connection_info_get_after_destroy(self):
+    @mock.patch('nova.virt.vmwareapi.cluster_util.fetch_cluster_properties')
+    def test_connection_info_get_after_destroy(self, mock_fetch):
         self._create_vm()
         self.conn.destroy(self.context, self.instance, self.network_info)
         connector = self.conn.get_volume_connector(self.instance)

--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -306,3 +306,28 @@ def update_cluster_drs_vm_override(session, cluster, vm_ref, operation='add',
     config_spec.drsVmConfigSpec = [drs_vm_spec]
 
     reconfigure_cluster(session, cluster, config_spec)
+
+
+@utils.synchronized('vmware-vm-group-policy')
+def clean_empty_vm_groups(session, cluster, group_names=None):
+    """Delete all empty server groups
+
+    Optionally filter the server groups to delete by `group_names`.
+    """
+    cluster_config = session._call_method(vutil,
+        "get_object_property", cluster, "configurationEx")
+
+    for group in cluster_config.group:
+        if group_names is not None and group.name not in group_names:
+            continue
+
+        # hostgroup or not empty
+        if hasattr(group, 'host') or hasattr(group, 'vm') and group.vm:
+            continue
+
+        try:
+            LOG.debug("Deleting VM group %s", group.name)
+            delete_vm_group(session, cluster, group)
+            LOG.debug("VM group %s deleted successfully", group.name)
+        except Exception as e:
+            LOG.warning("Deleting VM group %s failed: %s", group.name, e)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1540,26 +1540,7 @@ class VMwareVMOps(object):
         # Destroy a VM instance
         try:
             vm_ref = vm_util.get_vm_ref(self._session, instance)
-
             server_group_infos = vm_util._get_server_groups(context, instance)
-            if server_group_infos:
-                cluster = cluster_util.fetch_cluster_properties(self._session,
-                                                                       vm_ref)
-                config_info_ex = cluster.propSet[0].val
-
-                if hasattr(config_info_ex, 'group'):
-                    for key, group in enumerate(config_info_ex.group):
-                        if not hasattr(group, 'vm'):
-                            continue
-
-                        for vm in group.vm:
-                            if vm.value == vm_ref.value and len(group.vm) == 1:
-                                cluster_util.delete_vm_group(
-                                            self._session, cluster.obj,
-                                            config_info_ex.group[key])
-                                break
-                        break
-
             lst_properties = ["config.files.vmPathName", "runtime.powerState",
                               "datastore"]
             props = self._session._call_method(vutil,
@@ -1588,6 +1569,13 @@ class VMwareVMOps(object):
                 LOG.warning("In vmwareapi:vmops:_destroy_instance, got "
                             "this exception while un-registering the VM: %s",
                             excep, instance=instance)
+
+            # Delete the VM groups it was in, if they're empty now
+            server_group_uuids = set(group_info.uuid
+                                     for group_info in server_group_infos)
+            cluster_util.clean_empty_vm_groups(self._session, self._cluster,
+                                               server_group_uuids)
+
             # Delete the folder holding the VM related content on
             # the datastore.
             if destroy_disks and vm_ds_path:


### PR DESCRIPTION
Add function to clean empty VM groups and call it with the groups a VM
was in as a filter after unregistering the VM. Unregistering the VM
removes the VM from the group, but only if we re-retrieve the groups
from the vCenter. Before cleaning, we take the same lock that's used for
updating/creating VM groups, so we don't delete a group we're just
trying to add to again with a parallel task.

Co-Authored-By: Martin Midolesov <mmidolesov@vmware.com>

Change-Id: I12d71204b1afd741974cecae73f2e46df1e6d949