### PR TITLE
Fix tests for "Cherry-Pick: Force refresh instance info_cache during …

### DIFF
--- a/nova/tests/unit/api/openstack/compute/test_virtual_interfaces.py
+++ b/nova/tests/unit/api/openstack/compute/test_virtual_interfaces.py
@@ -121,18 +121,6 @@ class ServerVirtualInterfaceTestV21(test.NoDBTestCase):
                                          'fake_uuid',
                                          expected_attrs=None)
 
-    def test_list_vifs_neutron_notimplemented(self):
-        """Tests that a 400 is returned when using neutron as the backend"""
-        # unset the get_vifs_by_instance stub from setUp
-        self.get_vifs_by_instance_patcher.stop()
-        self.flags(use_neutron=True)
-        # reset the controller to use the neutron network API
-        self._set_controller()
-        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
-        self.assertRaises(webob.exc.HTTPBadRequest,
-                          self.controller.index, req, FAKE_UUID)
-        self.get_vifs_by_instance_patcher.start()
-
 
 class ServerVirtualInterfaceTestV212(ServerVirtualInterfaceTestV21):
     wsgi_api_version = '2.12'


### PR DESCRIPTION
…heal (#138)"

Since upstream removed the REST API [1] that's tested here, the backport
did not fix that test. The tests checks for a function being not
implemented, while the commit implemented exactly that function. We
remove the test as it doesn't make sense for us to implement it, if it
gets removed anyways.

[1] "Remove support for /os-virtual-interfaces REST API"
    with Change-Id: Id7f94a643e5d7b8a842c0f4a5c9f796d6566b365

Change-Id: Id591a752b1d0d2e3535d584f47e549ad2807604f