### PR TITLE
[bigvm] Set host as used after resize

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -990,6 +990,7 @@ class VMwareVMOpsTestCase(test.TestCase):
 
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
+    @mock.patch.object(vmops.VMwareVMOps, '_clean_up_after_special_spawning')
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
                        return_value='fake-spec')
@@ -997,6 +998,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
     def test_resize_vm_bigvm_upsize(self, fake_drs_override, fake_is_big_vm,
                                     fake_resize_spec, fake_reconfigure,
+                                    fake_cleanup_after_special_spawning,
                                     fake_get_extra_specs, fake_get_metadata):
         # new is big, new is big, old is not
         fake_is_big_vm.side_effect = [True, True, False]
@@ -1017,9 +1019,12 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                   'vm-ref',
                                                   operation='add',
                                                   behavior=behavior)
+        expected = (self._context, int(flavor.memory_mb), flavor)
+        fake_cleanup_after_special_spawning.assert_called_once_with(*expected)
 
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
+    @mock.patch.object(vmops.VMwareVMOps, '_clean_up_after_special_spawning')
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
                        return_value='fake-spec')
@@ -1027,6 +1032,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
     def test_resize_vm_bigvm_downsize(self, fake_drs_override, fake_is_big_vm,
                                       fake_resize_spec, fake_reconfigure,
+                                      fake_cleanup_after_special_spawning,
                                       fake_get_extra_specs, fake_get_metadata):
         # new is not big, new is not big, old is big
         fake_is_big_vm.side_effect = [False, False, True]
@@ -1045,6 +1051,8 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                   self._cluster.obj,
                                                   'vm-ref',
                                                   operation='remove')
+        expected = (self._context, int(flavor.memory_mb), flavor)
+        fake_cleanup_after_special_spawning.assert_called_once_with(*expected)
 
     @mock.patch.object(vmops.VMwareVMOps, '_extend_virtual_disk')
     @mock.patch.object(ds_util, 'disk_move')

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1179,9 +1179,13 @@ class VMwareVMOps(object):
 
         vm_util.power_on_instance(self._session, instance, vm_ref=vm_ref)
 
-        # clean up after special spawning behavior
-        if utils.vm_needs_special_spawning(int(instance.memory_mb),
-                                           instance.flavor):
+        self._clean_up_after_special_spawning(context, instance.memory_mb,
+                                              instance.flavor)
+
+    def _clean_up_after_special_spawning(self, context, instance_memory_mb,
+                                         instance_flavor):
+        if utils.vm_needs_special_spawning(int(instance_memory_mb),
+                                           instance_flavor):
             # we're using a child resource provider, so we don't have to change
             # the drivers' report-code to keep the CUSTOM_BIGVM resource, but
             # instead can independently add it or remove it on a cluster
@@ -1196,7 +1200,7 @@ class VMwareVMOps(object):
                 rp = parent_tree.data(rp_name)
             except ValueError:
                 LOG.warning('Could not find resource-provider %(rp)s for '
-                            'reserving resources after spawning a big VM.',
+                            'reserving resources after (re)starting a big VM.',
                             {'rp': rp_name})
             else:
                 # reserve the bigvm resource. this prohibits any further
@@ -1894,6 +1898,9 @@ class VMwareVMOps(object):
                         LOG.debug('DRS override was already deleted.',
                                   instance=instance)
                         ctx.reraise = False
+
+        self._clean_up_after_special_spawning(context, flavor.memory_mb,
+                                              flavor)
 
     def _resize_disk(self, instance, vm_ref, vmdk, flavor):
         if (flavor.root_gb > instance.old_flavor.root_gb


### PR DESCRIPTION
Mark the BigVM host as used after resizing a VM, same as after
spawning a new VM.

Applied for both big -> big resizes as well as small -> big resizes.