### PR TITLE
[manage] Fix purge-request-specs dry-run bug

### DIFF
--- a/nova/cmd/manage.py
+++ b/nova/cmd/manage.py
@@ -853,13 +853,13 @@ class ApiDbCommands(object):
             print(_("Purged %d request specs from the DB")
                     % request_spec_count)
         else:
+            request_spec_ids = [r[0] for r in request_spec_ids]
             print(_("There are at least %(count)d records in the DB for "
                     "deleted instances' request specs. Run this command again "
                     "without the dry-run option to purge these records.\n"
-                    "From %(first_id)d to %(last_id)d")
-                    % {'count': request_spec_count[0],
-                       'first_id': request_spec_count[1],
-                       'last_id': request_spec_count[2]})
+                    "Records with these ids would be deleted:\n%(id_list)s")
+                    % {'count': len(request_spec_ids),
+                       'id_list': request_spec_ids})
         instance_mapping_count = objects.InstanceMappingList.\
             destroy_bulk_without_instance(context, extant_instance_uuids,
                                           dry_run, older_than, max_number)
@@ -867,13 +867,13 @@ class ApiDbCommands(object):
             print(_("Purged %d instance mappings from the DB")
                     % instance_mapping_count)
         else:
+            instance_mapping_ids = [i[0] for i in instance_mapping_ids]
             print(_("There are at least %(count)d records in the DB for "
                     "deleted instance mappings. Run this command again "
                     "without the dry-run option to purge these records.\n"
-                    "From %(first_id)d to %(last_id)d")
-                    % {'count': instance_mapping_count[0],
-                        'first_id': instance_mapping_count[1],
-                        'last_id': instance_mapping_count[2]})
+                    "Records with these ids would be deleted:\n%(id_list)s")
+                    % {'count': len(instance_mapping_ids),
+                       'id_list': instance_mapping_ids})
         finished = True if dry_run else max(request_spec_count,
                                             instance_mapping_count) == 0
         return finished

--- a/nova/objects/instance_mapping.py
+++ b/nova/objects/instance_mapping.py
@@ -223,8 +223,7 @@ class InstanceMappingList(base.ObjectListBase, base.NovaObject):
                 api_models.InstanceMapping.created_at.asc()).limit(max_number)
         to_delete_ids = query.values('id')
         if dry_run:
-            return (len(to_delete_ids), to_delete_ids[0][0],
-                    to_delete_ids[-1][0])
+            return to_delete_ids
         else:
             # NOTE(gc): SQLAlchemy prohibits query.limit().delete() for obscure
             # reasons. So we need to pass the list of all ids to be deleted to

--- a/nova/objects/request_spec.py
+++ b/nova/objects/request_spec.py
@@ -602,8 +602,7 @@ class RequestSpec(base.NovaObject):
                 .limit(max_number)
         to_delete_ids = query.values('id')
         if dry_run:
-            return (len(to_delete_ids), to_delete_ids[0][0],
-                    to_delete_ids[-1][0])
+            return to_delete_ids
         else:
             # NOTE(gc): SQLAlchemy prohibits query.limit().delete() for obscure
             # reasons. So we need to pass the list of all ids to be deleted to


### PR DESCRIPTION
SQLAlchemy query objects are generators, and in --dry-run mode I
missed that I cannot get len() from or index into generators.

Return the query from the purge function instead and deal with
formatting it in the cmd function. Also print *all* ids that would be
deleted.