### PR TITLE
Prohibit migration between vCenters for multi-shard projects

### DIFF
--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -296,6 +296,12 @@ class ComputeTaskManager(base.Base):
         image = utils.get_image_from_system_metadata(
             instance.system_metadata)
 
+        # NOTE(jkulik): We need the instance's current host in at least one
+        # filter to make sure we don't pass vCenter boundaries, i.e. shards
+        scheduler_hints = {'source_host': [instance.host]}
+        sh = filter_properties.setdefault('scheduler_hints', {})
+        sh.update(scheduler_hints)
+
         # NOTE(sbauza): If a reschedule occurs when prep_resize(), then
         # it only provides filter_properties legacy dict back to the
         # conductor with no RequestSpec part of the payload.
@@ -312,6 +318,12 @@ class ComputeTaskManager(base.Base):
             # original RequestSpec object for make sure the scheduler verifies
             # the right one and not the original flavor
             request_spec.flavor = flavor
+
+            if (not request_spec.obj_attr_is_set('scheduler_hints')
+                    or request_spec.scheduler_hints is None):
+                request_spec._from_hints(scheduler_hints)
+            else:
+                request_spec.scheduler_hints.update(scheduler_hints)
 
         task = self._build_cold_migrate_task(context, instance, flavor,
                 request_spec, clean_shutdown, host_list)

--- a/nova/conductor/tasks/live_migrate.py
+++ b/nova/conductor/tasks/live_migrate.py
@@ -268,7 +268,9 @@ class LiveMigrationTask(base.TaskBase):
         """
         image = utils.get_image_from_system_metadata(
             self.instance.system_metadata)
-        filter_properties = {'ignore_hosts': attempted_hosts}
+        scheduler_hints = {'source_host': [self.source]}
+        filter_properties = {'ignore_hosts': attempted_hosts,
+                             'scheduler_hints': scheduler_hints}
         if not self.request_spec:
             # NOTE(sbauza): We were unable to find an original RequestSpec
             # object - probably because the instance is old.
@@ -285,6 +287,13 @@ class LiveMigrationTask(base.TaskBase):
             # if we want to make sure that the next destination
             # is not forced to be the original host
             request_spec.reset_forced_destinations()
+            # NOTE(jkulik): We need the instance's current host in at least one
+            # filter to make sure we don't pass vCenter boundaries, i.e. shards
+            if (not request_spec.obj_attr_is_set('scheduler_hints')
+                    or request_spec.scheduler_hints is None):
+                request_spec._from_hints(scheduler_hints)
+            else:
+                request_spec.scheduler_hints.update(scheduler_hints)
         scheduler_utils.setup_instance_group(self.context, request_spec)
 
         # We currently only support live migrating to hosts in the same

--- a/nova/tests/unit/conductor/test_conductor.py
+++ b/nova/tests/unit/conductor/test_conductor.py
@@ -2300,7 +2300,8 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
             availability_zone=None,
             pci_requests=None,
             numa_topology=None,
-            project_id=self.context.project_id)
+            project_id=self.context.project_id,
+            host='host1')
         image = 'fake-image'
         fake_spec = objects.RequestSpec(image=objects.ImageMeta())
         spec_fc_mock.return_value = fake_spec
@@ -2350,7 +2351,8 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
             numa_topology=None,
             pci_requests=None,
             availability_zone=None,
-            project_id=self.context.project_id)
+            project_id=self.context.project_id,
+            host='host1')
         image = 'fake-image'
 
         fake_spec = objects.RequestSpec(image=objects.ImageMeta())
@@ -2386,7 +2388,8 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
             instance_type_id=flavor['id'],
             system_metadata={},
             uuid=uuids.instance,
-            user_id=fakes.FAKE_USER_ID)
+            user_id=fakes.FAKE_USER_ID,
+            host='host1')
         fake_spec = fake_request_spec.fake_spec_obj()
         image = 'fake-image'
 
@@ -2430,7 +2433,8 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
             flavor=flavor,
             numa_topology=None,
             pci_requests=None,
-            availability_zone=None)
+            availability_zone=None,
+            host='host1')
         image = 'fake-image'
         exception = exc.UnsupportedPolicyException(reason='')
         fake_spec = fake_request_spec.fake_spec_obj()
@@ -2447,10 +2451,11 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
         set_vm_mock.assert_called_once_with(self.context, inst_obj.uuid,
                                             'migrate_server', updates,
                                             exception, fake_spec)
+        filter_properties = {'scheduler_hints': {'source_host': ['host1']}}
         spec_fc_mock.assert_called_once_with(
             self.context, inst_obj.uuid, image, flavor, inst_obj.numa_topology,
-            inst_obj.pci_requests, {}, None, inst_obj.availability_zone,
-            project_id=inst_obj.project_id)
+            inst_obj.pci_requests, filter_properties, None,
+            inst_obj.availability_zone, project_id=inst_obj.project_id)
 
     @mock.patch.object(objects.InstanceMapping, 'get_by_instance_uuid')
     @mock.patch.object(scheduler_utils, 'setup_instance_group')
@@ -2477,7 +2482,8 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
             availability_zone=None,
             pci_requests=None,
             numa_topology=None,
-            project_id=self.context.project_id)
+            project_id=self.context.project_id,
+            host='host1')
         image = 'fake-image'
         fake_spec = objects.RequestSpec(image=objects.ImageMeta())
         legacy_request_spec = fake_spec.to_legacy_request_spec_dict()
@@ -2539,7 +2545,8 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
             flavor=flavor,
             availability_zone=None,
             pci_requests=None,
-            numa_topology=None)
+            numa_topology=None,
+            host='host1')
         image = 'fake-image'
         fake_spec = fake_request_spec.fake_spec_obj()
 
@@ -2564,7 +2571,8 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
             instance_type_id=flavor['id'],
             system_metadata={},
             uuid=uuids.instance,
-            user_id=fakes.FAKE_USER_ID)
+            user_id=fakes.FAKE_USER_ID,
+            host='host1')
 
         fake_spec = fake_request_spec.fake_spec_obj()
         image = 'fake-image'


### PR DESCRIPTION
Projects having multiple shards in the same AZ can lead to the scheduler deciding to use a host in another shard/vCenter. We currently cannot support this and any migration started will fail.

We can repair the instance with `hammer vc gen-wrong-bb-fix-cmds` when accommodating the command for shards, but that's manual effort. The instance will stay powered off until someone looks at it.

To fix this, the conductor passes the instance's host as a scheduler-hint, so we can adapt the `ShardFilter` to filter out hosts of other shards.

In the long run, we want to support such migrations, too.