### PR TITLE
vmware: Detect automatically disabled host on restart

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -203,7 +203,8 @@ class VMwareAPIVMTestCase(test.TestCase,
         return objects.Service(**service_ref)
 
     @mock.patch.object(driver.VMwareVCDriver, '_register_openstack_extension')
-    def setUp(self, mock_register):
+    @mock.patch.object(objects.Service, 'get_by_compute_host')
+    def setUp(self, mock_svc, mock_register):
         super(VMwareAPIVMTestCase, self).setUp()
         ds_util.dc_cache_reset()
         vm_util.vm_refs_cache_reset()
@@ -225,6 +226,7 @@ class VMwareAPIVMTestCase(test.TestCase,
         vmwareapi_fake.reset()
         nova.tests.unit.image.fake.stub_out_image_service(self)
         service = self._create_service(host=HOST)
+        mock_svc.return_value = service
 
         virtapi = fake.FakeComputeVirtAPI(mock.MagicMock())
         self.conn = driver.VMwareVCDriver(virtapi, False)


### PR DESCRIPTION
If we disabled the host automatically, because we couldn't reach the
vCenter, we set a flag on the `VCState`. This flag is lost with a
compute-node restart, but the service stays disabled.

We now check the service's state and compare the disabled_reason on
startup to detect if we disabled the service automatically. This means,
the driver will automatically enable the service again if it can reach
the vCenter.

Change-Id: I1e49d5962adfd0bb585543c7a5580d343628f687