### PR TITLE
bigvm: Fix small<->big resize direction detection

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -996,19 +996,16 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
                        return_value='fake-spec')
-    @mock.patch.object(utils, 'is_big_vm')
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
-    def test_resize_vm_bigvm_upsize(self, fake_drs_override, fake_is_big_vm,
-                                    fake_resize_spec, fake_reconfigure,
+    def test_resize_vm_bigvm_upsize(self, fake_drs_override, fake_resize_spec,
+                                    fake_reconfigure,
                                     fake_cleanup_after_special_spawning,
                                     fake_get_extra_specs, fake_get_metadata):
-        # new is big, new is big, old is not
-        fake_is_big_vm.side_effect = [True, False]
         extra_specs = vm_util.ExtraSpecs()
         fake_get_extra_specs.return_value = extra_specs
         fake_get_metadata.return_value = self._metadata
-        flavor = objects.Flavor(name='m1.small',
-                                memory_mb=1024,
+        flavor = objects.Flavor(name='bigvm-test',
+                                memory_mb=CONF.bigvm_mb,
                                 vcpus=2,
                                 extra_specs={})
         instance = self._instance.obj_clone()
@@ -1030,14 +1027,11 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
                        return_value='fake-spec')
-    @mock.patch.object(utils, 'is_big_vm')
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
-    def test_resize_vm_bigvm_downsize(self, fake_drs_override, fake_is_big_vm,
+    def test_resize_vm_bigvm_downsize(self, fake_drs_override,
                                       fake_resize_spec, fake_reconfigure,
                                       fake_cleanup_after_special_spawning,
                                       fake_get_extra_specs, fake_get_metadata):
-        # new is not big, new is not big, old is big
-        fake_is_big_vm.side_effect = [False, True]
         extra_specs = vm_util.ExtraSpecs()
         fake_get_extra_specs.return_value = extra_specs
         fake_get_metadata.return_value = self._metadata
@@ -1047,6 +1041,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                 extra_specs={})
         instance = self._instance.obj_clone()
         instance.old_flavor = instance.flavor.obj_clone()
+        instance.old_flavor.memory_mb = CONF.bigvm_mb
         self._vmops._resize_vm(self._context, instance, 'vm-ref', flavor,
                                None)
         fake_drs_override.assert_called_once_with(self._session,

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1869,8 +1869,8 @@ class VMwareVMOps(object):
         vm_util.reconfigure_vm(self._session, vm_ref, vm_resize_spec)
 
         old_flavor = instance.old_flavor
-        new_is_big = utils.is_big_vm(int(old_flavor.memory_mb), old_flavor)
-        old_is_big = utils.is_big_vm(int(flavor.memory_mb), flavor)
+        old_is_big = utils.is_big_vm(int(old_flavor.memory_mb), old_flavor)
+        new_is_big = utils.is_big_vm(int(flavor.memory_mb), flavor)
 
         if not old_is_big and new_is_big:
             # Make sure we don't automatically move around "big" VMs


### PR DESCRIPTION
Upsize and downsize to/from a BigVM flavor was accidentally switched,
and the test didn't catch it because it forced the result of
is_big_vm().

Correct the resize direction and improve the tests by un-mocking
is_big_vm() and setting actual BigVM memory sizes on the instance
flavors in the tests.