### PR TITLE
LargeVM memory reservation

### DIFF
--- a/nova/conf/base.py
+++ b/nova/conf/base.py
@@ -139,6 +139,20 @@ Clusters/resource-provider with this much usage are not used for freeing up a
 host for spawning (a big VM). Clusters found to reach that amount, that already
 have a host freed, get their free host removed.
 """),
+    cfg.IntOpt(
+        'bigvm_cluster_max_reservation_percent',
+        default=50,
+        help="""
+
+Clusters/resource-providers with this percentage of memory reserved (of their
+reservable memory, which can be less than total memory) are not used for
+freeing up a host for spawning big VMs. Clusters found to reach that amount,
+that already have a host freed, get their free host removed.
+
+Compare the values of conf.vmware.memory_reservation_cluster_hosts_max_fail and
+conf.vmware.memory_reservation_max_ratio_fallback to see how much of total
+memory is actually reservable.
+"""),
 ]
 
 

--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -115,6 +115,36 @@ is hot-created.
 For big VMs as determined by the `bigvm_mb` setting, this setting is not used.
 Big VMs always reserve all their memory.
 """),
+    cfg.IntOpt('memory_reservation_cluster_hosts_max_fail',
+                default=0,
+                min=0,
+                help="""
+Allow reserving instance memory while at least n hypervisors of memory remain
+unreserved in the cluster. This is a safety margin so a certain number of
+cluster hypervisors are allowed to fail. If more memory would be reserved and
+all the anticipated HV failures occurred, existing VMs with reserved memory
+would no longer be able to start.
+
+This setting applies to VMs with flavors which have a nonzero extra_spec
+"resources:CUSTOM_MEMORY_RESERVABLE_MB" set.
+
+The default value of 0 also leads to this setting being ignored and falling
+back on `memory_reservation_max_ratio_fallback`.
+"""),
+    cfg.FloatOpt('memory_reservation_max_ratio_fallback',
+        default=1.0,
+        help="""
+Allow reserving instance memory up to a maximum ratio in the cluster. This is a
+safety margin so a certain ratio of cluster hypervisors are allowed to fail. If
+more memory than that would be reserved and all the anticipated HV failures
+occurred, existing VMs with reserved memory would no longer be able to start.
+
+This setting applies to VMs with flavors which have a nonzero extra_spec
+"resources:CUSTOM_MEMORY_RESERVABLE_MB" set.
+
+This is a fallback when the `memory_reservation_cluster_hosts_max_fail` config
+is set to 0.
+"""),
     cfg.StrOpt('hostgroup_reservations_json_file',
         help="""
 Specifies the path to a JSON file containing vcpus and memory reservations per

--- a/nova/scheduler/client/report.py
+++ b/nova/scheduler/client/report.py
@@ -1235,6 +1235,56 @@ class SchedulerReportClient(object):
         raise exception.ResourceProviderUpdateFailed(url=url, error=resp.text)
 
     @safe_connect
+    def add_traits_for_provider(self, context, rp_uuid, traits):
+        """Add traits to the existing traits of a provider.
+
+        :param context: The security context
+        :param rp_uuid: The UUID of the provider whose traits will be altered
+        :param traits: An iterable of trait strings to be added
+        :raises: ResourceProviderUpdateConflict if the provider's generation
+                 doesn't match the generation in the cache.  Callers may choose
+                 to retrieve the provider and its associations afresh and
+                 redrive this operation.
+        :raises: ResourceProviderUpdateFailed on any other placement API
+                 failure.
+        :raises: TraitCreationFailed if traits contains a trait that did not
+                 exist in placement, and couldn't be created.
+        :raises: TraitRetrievalFailed if the initial query of existing traits
+                 was unsuccessful.
+        """
+        prev_traits = self._get_provider_traits(context, rp_uuid)
+        # NOTE(jakobk): Remove this check in Rocky.
+        if not isinstance(prev_traits, set):
+            prev_traits = prev_traits.traits
+        self.set_traits_for_provider(context, rp_uuid,
+                                     prev_traits | set(traits))
+
+    @safe_connect
+    def remove_traits_for_provider(self, context, rp_uuid, traits):
+        """Remove certain traits from a provider, leaving the rest.
+
+        :param context: The security context
+        :param rp_uuid: The UUID of the provider whose traits will be altered
+        :param traits: An iterable of trait strings to be removed
+        :raises: ResourceProviderUpdateConflict if the provider's generation
+                 doesn't match the generation in the cache.  Callers may choose
+                 to retrieve the provider and its associations afresh and
+                 redrive this operation.
+        :raises: ResourceProviderUpdateFailed on any other placement API
+                 failure.
+        :raises: TraitCreationFailed if traits contains a trait that did not
+                 exist in placement, and couldn't be created.
+        :raises: TraitRetrievalFailed if the initial query of existing traits
+                 was unsuccessful.
+        """
+        prev_traits = self._get_provider_traits(context, rp_uuid)
+        # NOTE(jakobk): Remove this check in Rocky.
+        if not isinstance(prev_traits, set):
+            prev_traits = prev_traits.traits
+        self.set_traits_for_provider(context, rp_uuid,
+                                     prev_traits ^ set(traits))
+
+    @safe_connect
     def set_aggregates_for_provider(self, context, rp_uuid, aggregates):
         """Replace a provider's aggregates with those specified.
 

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -39,6 +39,7 @@ from nova.compute import power_state
 from nova.compute import task_states
 from nova.compute import vm_states
 import nova.conf
+import nova.utils
 
 from nova import context
 from nova import exception
@@ -2398,6 +2399,13 @@ class VMwareAPIVMTestCase(test.TestCase,
                 'max_unit': 25,
                 'step_size': 1,
             },
+            nova.utils.MEMORY_RESERVABLE_MB_RESOURCE: {
+                'total': 2048 - 512,  # 512 CONF.reserved_host_memory_mb
+                'reserved': 0,
+                'min_unit': 1,
+                'max_unit': 1024,
+                'step_size': 1,
+            }
         }
         self.assertEqual(expected, inv)
 
@@ -2420,7 +2428,8 @@ class VMwareAPIVMTestCase(test.TestCase,
             'mem': {'total': 2048,
                     'free': 2048,
                     'max_mem_mb_per_host': 1024,
-                    'reserved_memory_mb': 512}}
+                    'reserved_memory_mb': 512,
+                    'vm_reservable_memory_ratio': 1.0}}
         inv = self.conn.get_inventory(self.node_name)
         expected = {
             fields.ResourceClass.VCPU: {
@@ -2444,6 +2453,15 @@ class VMwareAPIVMTestCase(test.TestCase,
                 'max_unit': 25,
                 'step_size': 1,
             },
+            nova.utils.MEMORY_RESERVABLE_MB_RESOURCE: {
+                # 512 reported reserved from vmware stats (see above)
+                # + 512 CONF.reserved_host_memory_mb
+                'total': 2048 - 512 - 512,
+                'reserved': 0,
+                'min_unit': 1,
+                'max_unit': 1024,
+                'step_size': 1,
+            }
         }
         self.assertEqual(expected, inv)
 

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -142,7 +142,8 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                                           'free': num_hosts * 4096 -
                                                   num_hosts * 512,
                                           'max_mem_mb_per_host': 4096,
-                                          'reserved_memory_mb': 0}}
+                                          'reserved_memory_mb': 0,
+                                          'vm_reservable_memory_ratio': 1.0}}
             self.assertEqual(expected_stats, result)
 
     def test_get_stats_from_cluster_hosts_connected_and_active(self):
@@ -197,13 +198,14 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                 'vcpus': 2}}
 
         expected = {'cpu': {'vcpus': 2 * 16,
-                                  'max_vcpus_per_host': 14,  # by host2 counts
-                                  'reserved_vcpus': 4 + 2},  # both hosts
-                          'mem': {'total': 2 * 4096,
-                                  'free': 2 * 4096 -
-                                          2 * 512,
-                                  'max_mem_mb_per_host': 4096 - 256,    # host1
-                                  'reserved_memory_mb': 512 + 256}}     # both
+                            'max_vcpus_per_host': 14,  # by host2 counts
+                            'reserved_vcpus': 4 + 2},  # both hosts
+                    'mem': {'total': 2 * 4096,
+                            'free': 2 * 4096 -
+                                    2 * 512,
+                            'max_mem_mb_per_host': 4096 - 256,  # host1
+                            'reserved_memory_mb': 512 + 256,    # both
+                            'vm_reservable_memory_ratio': 1.0}}
         self._test_get_stats_from_cluster(expected_stats=expected)
 
     def test_get_host_reservations_empty(self):

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1059,6 +1059,24 @@ class VMwareVMOpsTestCase(test.TestCase):
         expected = (self._context, int(flavor.memory_mb), flavor)
         fake_cleanup_after_special_spawning.assert_called_once_with(*expected)
 
+    def test_reserve_all_memory_for_memory_reserved_flavor(self):
+        self.flags(group='vmware', reserve_all_memory=False)
+        self._instance.flavor.extra_specs.update({
+            utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY:
+                self._instance.flavor.memory_mb})
+        specs = self._vmops._get_extra_specs(self._instance.flavor,
+                                             self._image_meta)
+        self.assertEqual(specs.memory_limits.reservation,
+                         self._instance.flavor.memory_mb)
+
+    def test_reserve_no_memory_for_memory_unreserved_flavor(self):
+        self.flags(group='vmware', reserve_all_memory=False)
+        self._instance.flavor.extra_specs.pop(
+            utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY, None)
+        specs = self._vmops._get_extra_specs(self._instance.flavor,
+                                             self._image_meta)
+        self.assertIsNone(specs.memory_limits.reservation)
+
     @mock.patch.object(vmops.VMwareVMOps, '_extend_virtual_disk')
     @mock.patch.object(ds_util, 'disk_move')
     @mock.patch.object(ds_util, 'disk_copy')

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -92,7 +92,8 @@ VIM_IMAGE_ATTRIBUTES = (
     'container_format', 'disk_format', 'min_ram', 'min_disk',
 )
 
-# Custom resource for reservable memory
+# Custom resource and trait for reservable memory
+SPECIAL_SPAWNING_TRAIT = 'CUSTOM_SPECIAL_SPAWNING'
 MEMORY_RESERVABLE_MB_RESOURCE = 'CUSTOM_MEMORY_RESERVABLE_MB'
 MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY = \
     'resources:' + MEMORY_RESERVABLE_MB_RESOURCE

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -92,6 +92,11 @@ VIM_IMAGE_ATTRIBUTES = (
     'container_format', 'disk_format', 'min_ram', 'min_disk',
 )
 
+# Custom resource for reservable memory
+MEMORY_RESERVABLE_MB_RESOURCE = 'CUSTOM_MEMORY_RESERVABLE_MB'
+MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY = \
+    'resources:' + MEMORY_RESERVABLE_MB_RESOURCE
+
 _FILE_CACHE = {}
 
 _SERVICE_TYPES = service_types.ServiceTypes()

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -1504,3 +1504,14 @@ def vm_needs_special_spawning(memory_mb, flavor):
         return True
 
     return False
+
+
+def vm_special_spawning_boot_only(flavor):
+    special_spawning_trait_key = 'trait:' + SPECIAL_SPAWNING_TRAIT
+    # NOTE(jakobk): 'required' is the only valid value for 'trait:' extra specs
+    # until nova 18.0.0 (rocky), when 'forbidden' is added.
+    special_trait = flavor.extra_specs.get(special_spawning_trait_key, '')
+    if special_trait.lower() == 'required':
+        return True
+
+    return False

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -41,6 +41,7 @@ from nova import exception
 from nova.i18n import _
 from nova.objects import fields as obj_fields
 import nova.privsep.path
+from nova import utils
 from nova.virt import driver
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import ds_util
@@ -486,6 +487,16 @@ class VMwareVCDriver(driver.ComputeDriver):
                 'min_unit': 1,
                 'max_unit': stats['mem']['max_mem_mb_per_host'],
                 'step_size': 1,
+            }})
+            available_memory_mb = stats['mem']['total'] - reserved_memory_mb
+            result.update({
+                utils.MEMORY_RESERVABLE_MB_RESOURCE: {
+                    'total': available_memory_mb,
+                    'reserved': available_memory_mb
+                        * (1 - stats['mem']['vm_reservable_memory_ratio']),
+                    'min_unit': 1,
+                    'max_unit': stats['mem']['max_mem_mb_per_host'],
+                    'step_size': 1,
             }})
         return result
 

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1524,13 +1524,32 @@ def get_stats_from_cluster(session, cluster):
                                              threads - reserved['vcpus'])
                     max_mem_mb_per_host = max(max_mem_mb_per_host,
                                               mem_mb - reserved['memory_mb'])
+            # NOTE (jakobk): For the total amount of hosts it doesn't matter
+            # whether the host is in MM or unreachable, because the count is
+            # used to calculate safety margins for resource allocations, and MM
+            # or otherwise unreachable hosts is precisely what that is supposed
+            # to guard against.
+            total_hypervisor_count = len(result.objects)
+
+            # Calculate VM-reservable memory as a ratio of total available
+            # memory, depending on either the configured tolerance for failed
+            # hypervisors or a single configurable ratio.
+            max_fail_hvs = \
+                CONF.vmware.memory_reservation_cluster_hosts_max_fail
+            if max_fail_hvs and total_hypervisor_count:
+                vm_reservable_memory_ratio = \
+                    (1 - max_fail_hvs / total_hypervisor_count)
+            else:
+                vm_reservable_memory_ratio = \
+                    CONF.vmware.memory_reservation_max_ratio_fallback
     stats = {'cpu': {'vcpus': vcpus,
                      'max_vcpus_per_host': max_vcpus_per_host,
                      'reserved_vcpus': reserved_vcpus},
              'mem': {'total': total_mem_mb,
                      'free': total_mem_mb - used_mem_mb,
                      'max_mem_mb_per_host': max_mem_mb_per_host,
-                     'reserved_memory_mb': reserved_memory_mb}}
+                     'reserved_memory_mb': reserved_memory_mb,
+                     'vm_reservable_memory_ratio': vm_reservable_memory_ratio}}
     return stats
 
 

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -39,6 +39,7 @@ from nova.i18n import _
 from nova.network import model as network_model
 from nova import objects
 from nova.utils import vm_needs_special_spawning
+from nova.utils import vm_special_spawning_boot_only
 from nova.virt.vmwareapi import cluster_util
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import vim_util
@@ -1583,6 +1584,15 @@ def update_cluster_placement(session, context, instance, cluster, vm_ref):
     cluster_util.update_placement(session, cluster, vm_ref, server_group_infos)
 
 
+def update_vm_special_spawning_group(session, instance, cluster, vm_ref,
+                                     operation="add"):
+    group_info = GroupInfo(CONF.vmware.special_spawning_vm_group, None)
+    if operation == "add":
+        cluster_util.update_placement(session, cluster, vm_ref, group_info)
+    if operation == "remove":
+        cluster_util.clean_empty_vm_groups(session, cluster, [group_info.uuid])
+
+
 def get_host_ref(session, cluster=None):
     """Get reference to a host within the cluster specified."""
     if cluster is None:
@@ -1824,7 +1834,7 @@ def reconfigure_vm(session, vm_ref, config_spec):
     session._wait_for_task(reconfig_task)
 
 
-def power_on_instance(session, instance, vm_ref=None):
+def power_on_instance(session, instance, cluster, vm_ref=None):
     """Power on the specified instance."""
 
     if vm_ref is None:
@@ -1839,6 +1849,10 @@ def power_on_instance(session, instance, vm_ref=None):
         LOG.debug("Powered on the VM", instance=instance)
     except vexc.InvalidPowerStateException:
         LOG.debug("VM already powered on", instance=instance)
+
+    if vm_special_spawning_boot_only(instance.flavor):
+        update_vm_special_spawning_group(session, instance, cluster, vm_ref,
+                                         operation="add")
 
 
 def _get_vm_port_indices(session, vm_ref):
@@ -1884,7 +1898,7 @@ def get_vm_detach_port_index(session, vm_ref, iface_id):
                 return int(option.key.split('.')[2])
 
 
-def power_off_instance(session, instance, vm_ref=None):
+def power_off_instance(session, instance, cluster, vm_ref=None):
     """Power off the specified instance."""
 
     if vm_ref is None:
@@ -1898,6 +1912,10 @@ def power_off_instance(session, instance, vm_ref=None):
         LOG.debug("Powered off the VM", instance=instance)
     except vexc.InvalidPowerStateException:
         LOG.debug("VM already powered off", instance=instance)
+
+    if vm_special_spawning_boot_only(instance.flavor):
+        update_vm_special_spawning_group(session, instance, cluster, vm_ref,
+                                         operation="remove")
 
 
 def find_rescue_device(hardware_devices, instance):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -363,6 +363,13 @@ class VMwareVMOps(object):
         if CONF.vmware.reserve_all_memory \
                 or utils.is_big_vm(int(flavor.memory_mb), flavor):
             extra_specs.memory_limits.reservation = int(flavor.memory_mb)
+        try:
+            memory_reserved_mb = int(flavor.extra_specs[
+                utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY])
+            if memory_reserved_mb > 0:
+                extra_specs.memory_limits.reservation = memory_reserved_mb
+        except (ValueError, KeyError):
+            pass
         extra_specs.cpu_limits.validate()
         extra_specs.memory_limits.validate()
         extra_specs.disk_io_limits.validate()


### PR DESCRIPTION
_[memreserv] Reserve memory for certain flavors_

VMs with reserved memory have better memory allocation
performance and less softlock issues. Coincidentally, many
larger VMs also have high performance requirements that puts
strict demands on the quick availability of their memory.

Implement memory reservation and a configurable maximum
number of cluster hosts that could theoretically fail and
still let all VMs with memory reservation boot up.

Nova provides the flavor extra_spec
    "quota:memory_reservation"
which reserves the given amount of memory. This change does
not make use of that feature, but instead introduces a
parallel custom resource
    "CUSTOM_MEMORY_RESERVABLE_MB".
The reason is that "quota:memory_reservation" does not allow
for limiting the total amount of reservable memory in the
same way the resource provider mechanics do. This is a
requirement for tolerating the above-mentioned partial host
failures, which can occur because a VMware host is a cluster
of hypervisors.

Add a "vm_reservable_memory_ratio" value to the cluster
stats in the VMware driver, and use that to calculate and
return the MEMORY_RESERVABLE_MB resource from the VMware
driver's get_inventory().

---

_[memreserv] Add special-spawning trait to BigVM host_

A custom trait is added, "CUSTOM_SPECIAL_SPAWNING".

Flavors can set this trait as "required" in order to force
spawning on the dedicated BigVM spawn-host (which is kept
free). This is done to facilitate spawning for VMs with
larger (but not quite as large as BigVM) flavors.

nova.scheduler.client.report.SchedulerReportClient gains
two new methods `add_traits_for_provider()` and
`remove_traits_for_provider()`.

---

_[memreserv] Boot mem-reserved VMs on BigVM spawn-host_

To facilitate quickly spawning VMs with memory reservation,
the BigVM-anti-affinity group that is usually set on all but
the BigVMs, is only set for memory-reserved VMs after it has
fully powered up. This makes LargeVMs spawn on the BigVM-
reserved host, but then get moved away from it when VMware
DRS follows the (now activated) anti-affinity group rule.

---

_[bigvm] Don't free host when too much reserved RAM_

The logic in BigVmManager to decide whether a cluster is
able to free another BigVM spawn-host is changed from only
using the total percentage of used memory to using the
amount of reserved memory as well.
