### PR TITLE
placement: Allow switching resources on overused providers

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -38,3 +38,4 @@ wsgi-intercept>=1.4.1 # MIT License
 
 # redirect tests in docs
 whereto>=0.3.0 # Apache-2.0
+setuptools<45.0.0


### PR DESCRIPTION
When a resource-provider gets overused in placement, e.g. because a host
in the cluster it represents goes down or because one memory dimm of
multiple fails, we need to be able to (offline) migrate/resize a VM to
reduce the pressure on the host and to make the resize process more
stable.

For that, we check in the call setting the allocations if for every
allocation with a value for a resource, there's also an allocation
removing such a resource - namely switching the allocations from one
consumer to another as is done for migrations.