### PR TITLE
console_auth_token: remove workaround for novnc

### DIFF
--- a/nova/objects/console_auth_token.py
+++ b/nova/objects/console_auth_token.py
@@ -61,17 +61,7 @@ class ConsoleAuthToken(base.NovaTimestampObject, base.NovaObject):
         specific to this authorization.
         """
         if self.obj_attr_is_set('id'):
-            if self.console_type == 'novnc':
-                # NOTE(melwitt): As of noVNC v1.1.0, we must use the 'path'
-                # query parameter to pass the auth token within, as the
-                # top-level 'token' query parameter was removed. The 'path'
-                # parameter is supported in older noVNC versions, so it is
-                # backward compatible.
-                qparams = {'path': '?token=%s' % self.token}
-                return '%s?%s' % (self.access_url_base,
-                                  urlparse.urlencode(qparams))
-            else:
-                return '%s?token=%s' % (self.access_url_base, self.token)
+            return '%s?token=%s' % (self.access_url_base, self.token)
 
     @staticmethod
     def _from_db_object(context, obj, db_obj):

--- a/nova/tests/unit/objects/test_console_auth_token.py
+++ b/nova/tests/unit/objects/test_console_auth_token.py
@@ -74,15 +74,9 @@ class _TestConsoleAuthToken(object):
         self.compare_obj(obj, expected)
 
         url = obj.access_url
-        if console_type != 'novnc':
-            expected_url = '%s?token=%s' % (
-                fakes.fake_token_dict['access_url_base'],
-                fakes.fake_token)
-        else:
-            path = urlparse.urlencode({'path': '?token=%s' % fakes.fake_token})
-            expected_url = '%s?%s' % (
-                fakes.fake_token_dict['access_url_base'],
-                path)
+        expected_url = '%s?token=%s' % (
+            fakes.fake_token_dict['access_url_base'],
+            fakes.fake_token)
         self.assertEqual(expected_url, url)
 
     def test_authorize(self):


### PR DESCRIPTION
In Rocky, there was a special condition introduced for novnc consoles,
that would add a 'path' query parameter to the base url.
This is not needed, since that 'path' parameter is already included
in the base_url we configure in the deployment, so we only need
nova to append the 'token' to the query string.