### PR TITLE
console_auth_token: allow pre-existing 'path' query parameter for novnc

### DIFF
--- a/nova/objects/console_auth_token.py
+++ b/nova/objects/console_auth_token.py
@@ -67,6 +67,23 @@ class ConsoleAuthToken(base.NovaTimestampObject, base.NovaObject):
                 # top-level 'token' query parameter was removed. The 'path'
                 # parameter is supported in older noVNC versions, so it is
                 # backward compatible.
+                # NOTE(mariusleu): If the path parameter is already
+                # configured in self.access_url_base, then we should
+                # just append the token to it.
+                parsed = urlparse.urlparse(self.access_url_base)
+                query = urlparse.parse_qs(parsed.query)
+                if 'path' in query:
+                    # Get single-valued query parameters, because parse_qs
+                    # returns by default key=[value] and urlencode doesn't
+                    # like that.
+                    qparams = {k: v[0] for k, v in query.items()}
+                    qparams['path'] = '%s?token=%s' % (qparams['path'],
+                                                       self.token)
+                    new_parsed = urlparse.ParseResult(
+                        parsed.scheme, parsed.netloc,
+                        parsed.path, parsed.params,
+                        urlparse.urlencode(qparams), parsed.fragment)
+                    return urlparse.urlunparse(new_parsed)
                 qparams = {'path': '?token=%s' % self.token}
                 return '%s?%s' % (self.access_url_base,
                                   urlparse.urlencode(qparams))

--- a/nova/tests/unit/objects/test_console_auth_token.py
+++ b/nova/tests/unit/objects/test_console_auth_token.py
@@ -30,7 +30,7 @@ from nova.tests import uuidsentinel
 class _TestConsoleAuthToken(object):
 
     @mock.patch('nova.db.api.console_auth_token_create')
-    def _test_authorize(self, console_type, mock_create):
+    def _test_authorize(self, console_type, mock_create, base_url=None):
         # the expires time is calculated from the current time and
         # a ttl value in the object. Fix the current time so we can
         # test expires is calculated correctly as expected
@@ -38,13 +38,17 @@ class _TestConsoleAuthToken(object):
         timeutils.set_time_override()
         ttl = 10
         expires = timeutils.utcnow_ts() + ttl
+        if not base_url:
+            base_url = fakes.fake_token_dict['access_url_base']
 
         db_dict = copy.deepcopy(fakes.fake_token_dict)
         db_dict['expires'] = expires
         db_dict['console_type'] = console_type
+        db_dict['access_url_base'] = base_url
         mock_create.return_value = db_dict
 
         create_dict = copy.deepcopy(fakes.fake_token_dict)
+        create_dict['access_url_base'] = base_url
         create_dict['expires'] = expires
         create_dict['console_type'] = console_type
         del create_dict['id']
@@ -54,6 +58,7 @@ class _TestConsoleAuthToken(object):
         expected = copy.deepcopy(fakes.fake_token_dict)
         del expected['token_hash']
         del expected['expires']
+        expected['access_url_base'] = base_url
         expected['token'] = fakes.fake_token
         expected['console_type'] = console_type
 
@@ -64,7 +69,7 @@ class _TestConsoleAuthToken(object):
             port=fakes.fake_token_dict['port'],
             internal_access_path=fakes.fake_token_dict['internal_access_path'],
             instance_uuid=fakes.fake_token_dict['instance_uuid'],
-            access_url_base=fakes.fake_token_dict['access_url_base'],
+            access_url_base=base_url,
         )
         with mock.patch('uuid.uuid4', return_value=fakes.fake_token):
             token = obj.authorize(ttl)
@@ -75,14 +80,14 @@ class _TestConsoleAuthToken(object):
 
         url = obj.access_url
         if console_type != 'novnc':
-            expected_url = '%s?token=%s' % (
-                fakes.fake_token_dict['access_url_base'],
-                fakes.fake_token)
+            expected_url = '%s?token=%s' % (base_url, fakes.fake_token)
         else:
-            path = urlparse.urlencode({'path': '?token=%s' % fakes.fake_token})
-            expected_url = '%s?%s' % (
-                fakes.fake_token_dict['access_url_base'],
-                path)
+            if 'path=' in base_url:
+                expected_url = base_url + urlparse.quote('?token=%s' % token)
+            else:
+                path = urlparse.urlencode({'path': '?token=%s' %
+                                                   fakes.fake_token})
+                expected_url = '%s?%s' % (base_url, path)
         self.assertEqual(expected_url, url)
 
     def test_authorize(self):
@@ -90,6 +95,10 @@ class _TestConsoleAuthToken(object):
 
     def test_authorize_novnc(self):
         self._test_authorize('novnc')
+
+    def test_authorize_novnc_with_path_in_base_url(self):
+        url = fakes.fake_token_dict['access_url_base'] + '?path=fake-path'
+        self._test_authorize('novnc', base_url=url)
 
     @mock.patch('nova.db.api.console_auth_token_create')
     def test_authorize_duplicate_token(self, mock_create):


### PR DESCRIPTION
For noVNC 1.1.0 or newer, there must be a 'path' query parameter only,
instead of 'token'.
This patch allows 'path' query parameter being present in the
novncproxy_base_url configuration. In that case, we just append
the token to it.