### PR TITLE
Fix project limits calculation.

### DIFF
--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -1562,8 +1562,8 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
                         counts[t_name] = counts.get(t_name, 0) + instance_count
                     else:
                         counts['instances'] += instance_count
-                        counts['cores'] += cores
-                        counts['ram'] += ram
+                        counts['cores'] += int(cores)
+                        counts['ram'] += int(ram)
 
             return counts
 


### PR DESCRIPTION
Cast Decimal to Int in _get_counts, similar to _get_counts_in_db.

SQLalchemy func.sum() returns Decimal on MySQL. When the usage limits
are calculated unless explicitly converted to Int we end up with
Decimal objects that cannot be JSONified and thus causing
ValueError: Circular reference detected.