### PR TITLE
shellinabox: add support for db tokens

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -54,7 +54,6 @@ from oslo_service import periodic_task
 from oslo_utils import excutils
 from oslo_utils import strutils
 from oslo_utils import timeutils
-from oslo_utils import uuidutils
 import six
 from six.moves import range
 
@@ -5733,35 +5732,31 @@ class ComputeManager(manager.Manager):
         if not CONF.serial_console.enabled:
             raise exception.ConsoleTypeUnavailable(console_type=console_type)
 
+        if console_type == 'serial':
+            base_url = CONF.serial_console.base_url
+        elif console_type == 'shellinabox':
+            base_url = CONF.shellinabox.base_url
+        else:
+            raise exception.ConsoleTypeInvalid(console_type=console_type)
+
         context = context.elevated()
 
         try:
             # Retrieve connect info from driver, and then decorate with our
             # access info token
             console = self.driver.get_serial_console(context, instance)
-            if console_type == 'serial':
-                console_auth = objects.ConsoleAuthToken(
-                    context=context,
-                    console_type=console_type,
-                    host=console.host,
-                    port=console.port,
-                    internal_access_path=console.internal_access_path,
-                    instance_uuid=instance.uuid,
-                    access_url_base=CONF.serial_console.base_url,
-                )
-                console_auth.authorize(CONF.consoleauth.token_ttl)
-                connect_info = console.get_connection_info(
-                    console_auth.token, console_auth.access_url)
-            elif console_type == 'shellinabox':
-                token = uuidutils.generate_uuid()
-                # token and internal url for shellinabox
-                access_url = '%s%s?token=%s' % (
-                    CONF.shellinabox.base_url,
-                    console.internal_access_path,
-                    token)
-                connect_info = console.get_connection_info(token, access_url)
-            else:
-                raise exception.ConsoleTypeInvalid(console_type=console_type)
+            console_auth = objects.ConsoleAuthToken(
+                context=context,
+                console_type=console_type,
+                host=console.host,
+                port=console.port,
+                internal_access_path=console.internal_access_path,
+                instance_uuid=instance.uuid,
+                access_url_base=base_url,
+            )
+            console_auth.authorize(CONF.consoleauth.token_ttl)
+            connect_info = console.get_connection_info(
+                console_auth.token, console_auth.access_url)
 
         except exception.InstanceNotFound:
             if instance.vm_state != vm_states.BUILDING:

--- a/nova/console/shellinaboxproxy.py
+++ b/nova/console/shellinaboxproxy.py
@@ -13,15 +13,31 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from nova.compute import rpcapi as compute_rpcapi
 from nova import config
-from nova.consoleauth import rpcapi as consoleauth_rpcapi
+from nova.console.websocketproxy import NovaProxyRequestHandlerBase
 from nova import context
+from nova import exception
 
 STATIC_FILES_EXT = ('.js', '.css', '.html', '.ico', '.png', '.gif')
 
 
-class NovaShellInaBoxProxy(object):
+class NovaShellInaBoxProxy(NovaProxyRequestHandlerBase):
     """Class that injects token validation routine into proxy logic."""
+
+    def __init__(self):
+        self._compute_rpcapi = None
+
+    @property
+    def compute_rpcapi(self):
+        # This is copied from NovaProxyRequestHandler, just to avoid
+        # extending that class (because it inherits
+        # websockify.ProxyRequestHandler in addition and we don't need that).
+        # For upgrades we should have a look again if anything changed there,
+        # that we might need to also include here.
+        if not self._compute_rpcapi:
+            self._compute_rpcapi = compute_rpcapi.ComputeAPI()
+        return self._compute_rpcapi
 
     def path_includes_static_files(self):
         """Returns True if requested path includes static files."""
@@ -40,9 +56,10 @@ class NovaShellInaBoxProxy(object):
             else:
                 # Validate the token
                 ctxt = context.get_admin_context()
-                rpcapi = consoleauth_rpcapi.ConsoleAuthAPI()
-
-                if not rpcapi.check_token(ctxt, token=self.token):
+                try:
+                    super(NovaShellInaBoxProxy, self)._get_connect_info(
+                        ctxt, self.token)
+                except exception.InvalidToken:
                     # Token not valid
                     flow.response.status_code = 403
                     flow.response.content = ("The token has expired "

--- a/nova/objects/console_auth_token.py
+++ b/nova/objects/console_auth_token.py
@@ -87,6 +87,10 @@ class ConsoleAuthToken(base.NovaTimestampObject, base.NovaObject):
                 qparams = {'path': '?token=%s' % self.token}
                 return '%s?%s' % (self.access_url_base,
                                   urlparse.urlencode(qparams))
+            elif self.console_type == 'shellinabox':
+                return '%s%s?token=%s' % (self.access_url_base,
+                                          self.internal_access_path,
+                                          self.token)
             else:
                 return '%s?token=%s' % (self.access_url_base, self.token)
 


### PR DESCRIPTION
Rocky introduces database tokens and deprecates the nova-consoleauth
service. Thus, shellinabox needs to access the tokens from the
database as well.
This still supports the old nova-consoleauth by enabling it via
the [workarounds]/enable_consoleauth.