### PR TITLE
nova-consoleauth: port is expected to be string by validation

### DIFF
--- a/nova/consoleauth/manager.py
+++ b/nova/consoleauth/manager.py
@@ -107,6 +107,11 @@ class ConsoleAuthManager(manager.Manager):
         instance_uuid = token['instance_uuid']
         if instance_uuid is None:
             return False
+        # NOTE(mariusleu): Starting with Rocky, when this runs only under
+        # [workarounds]/enable_consoleauth, the port is expected to be a
+        # string by the validation.
+        if CONF.workarounds.enable_consoleauth:
+            token['port'] = str(token['port'])
 
         # NOTE(comstud): consoleauth was meant to run in API cells.  So,
         # if cells is enabled, we must call down to the child cell for


### PR DESCRIPTION
Starting with Rocky, the validate_console_port is expecting the port
to be a string, so nova-consoleauth has to fulfill that expectation.
This commit should be carried up to Train, before nova-consoleauth
code gets completely removed.

The regression was introduced here: https://github.com/openstack/nova/commit/ba269da87a7ac0130f87fca78083a09231533c2