### PR TITLE
nova-consoleauth: port is expected to be string by validation

### DIFF
--- a/nova/consoleauth/manager.py
+++ b/nova/consoleauth/manager.py
@@ -107,11 +107,6 @@ class ConsoleAuthManager(manager.Manager):
         instance_uuid = token['instance_uuid']
         if instance_uuid is None:
             return False
-        # NOTE(mariusleu): Starting with Rocky, when this runs only under
-        # [workarounds]/enable_consoleauth, the port is expected to be a
-        # string by the validation.
-        if CONF.workarounds.enable_consoleauth:
-            token['port'] = str(token['port'])
 
         # NOTE(comstud): consoleauth was meant to run in API cells.  So,
         # if cells is enabled, we must call down to the child cell for
@@ -124,11 +119,16 @@ class ConsoleAuthManager(manager.Manager):
                                                                instance_uuid)
         with nova_context.target_cell(context, mapping.cell_mapping) as cctxt:
             instance = objects.Instance.get_by_uuid(cctxt, instance_uuid)
-
+            port = token['port']
+            # NOTE(mariusleu): Starting with Rocky, when this runs only under
+            # [workarounds]/enable_consoleauth, the port is expected to be a
+            # string by the validation.
+            if CONF.workarounds.enable_consoleauth:
+                port = str(port)
             return self.compute_rpcapi.validate_console_port(
                 cctxt,
                 instance,
-                token['port'],
+                port,
                 token['console_type'])
 
     def check_token(self, context, token):


### PR DESCRIPTION
This amends the previous PR's commit.

Starting with Rocky, the validate_console_port is expecting the port
to be a string [1], so nova-consoleauth has to fulfill that expectation.
This commit should be carried up to Train, before nova-consoleauth
code gets completely removed.

[1] https://github.com/openstack/nova/commit/ba269da87a7ac0130f87fca78083a09231533c2