### PR TITLE
Fix python3 syntax in rocky

### DIFF
--- a/nova/virt/vmwareapi/special_spawning.py
+++ b/nova/virt/vmwareapi/special_spawning.py
@@ -14,6 +14,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from operator import itemgetter
+
 from oslo_log import log as logging
 import oslo_messaging as messaging
 from oslo_vmware import vim_util as vutil
@@ -257,7 +259,7 @@ class _SpecialVmSpawningServer(object):
                             for h, vms in vms_per_host.items()}
 
             # take the one with least memory used
-            host, _ = sorted(mem_per_host.items(), key=lambda (x, y): y)[0]
+            host, _ = sorted(mem_per_host.items(), key=itemgetter(1))[0]
             host_ref = host_objs[host]
 
             client_factory = self._session.vim.client.factory

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -27,7 +27,6 @@ import re
 import six
 import time
 
-import cluster_util
 import decorator
 from oslo_concurrency import lockutils
 from oslo_log import log as logging
@@ -59,6 +58,7 @@ from nova import version
 from nova.virt import configdrive
 from nova.virt import driver
 from nova.virt import hardware
+from nova.virt.vmwareapi import cluster_util
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import ds_util
 from nova.virt.vmwareapi import error_util


### PR DESCRIPTION
Two little syntax issues with the current rocky code.

There are 60+ unit tests failing for me as well...