### PR TITLE
vmware: Add option for setting default hw_version

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -394,6 +394,19 @@ All VMs in the cluster have to be in a VM group that has a rule specifying a
 must-not-run-on-hostgroup rule for this hostgroup. Putting a host in this
 hostgroup will then result in the host getting freed up by DRS.
 """),
+    cfg.StrOpt('default_hw_version',
+               default=None,
+               help="""
+Set a default hardware version for VMs, that can be overridden in flavors
+
+This version is especially useful in multi-cluster environments where clusters
+get upgraded individually but movement of VMs is necessary between them
+nonetheless. It is recommend to set this to the highest version supported by
+all clusters in the environment.
+
+Example: "vmx-13" for vSphere 6.5.
+Versions can be looked up here: https://kb.vmware.com/s/article/1003746
+"""),
 ]
 
 ALL_VMWARE_OPTS = (vmwareapi_vif_opts +

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -1161,6 +1161,21 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         expected.tools.beforeGuestStandby = True
         self.assertEqual(expected, result)
 
+    def test_get_vm_create_spec_with_default_hw_version(self):
+        CONF.set_override('default_hw_version', 'vmx-13',
+                          'vmware')
+        extra_specs = vm_util.ExtraSpecs()
+        fake_factory = fake.FakeFactory()
+        result = vm_util.get_vm_create_spec(fake_factory,
+                                            self._instance,
+                                            'fake-datastore', [],
+                                            extra_specs)
+
+        expected = self._create_vm_config_spec()
+        expected.version = 'vmx-13'
+
+        self.assertEqual(expected, result)
+
     def test_create_vm(self):
 
         def fake_call_method(module, method, *args, **kwargs):

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -2562,6 +2562,8 @@ class VMwareVMOpsTestCase(test.TestCase):
                          actual.cpu_limits.shares_level)
         self.assertEqual(expected.cpu_limits.shares_share,
                          actual.cpu_limits.shares_share)
+        self.assertEqual(expected.hw_version,
+                         actual.hw_version)
 
     def _validate_flavor_extra_specs(self, flavor_extra_specs, expected):
         # Validate that the extra specs are parsed correctly
@@ -2625,6 +2627,13 @@ class VMwareVMOpsTestCase(test.TestCase):
         extra_specs = vm_util.ExtraSpecs(vif_limits=vif_limits)
         self.assertRaises(exception.InvalidInput,
             self._validate_flavor_extra_specs, flavor_extra_specs, extra_specs)
+
+    def test_extra_specs_hw_version_override(self):
+        CONF.set_override('default_hw_version', 'vmx-13',
+                          'vmware')
+        flavor_extra_specs = {'vmware:hw_version': 'vmx-14'}
+        extra_specs = vm_util.ExtraSpecs(hw_version='vmx-14')
+        self._validate_flavor_extra_specs(flavor_extra_specs, extra_specs)
 
     def _make_vm_config_info(self, is_iso=False, is_sparse_disk=False,
                              vsphere_location=None):

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -115,7 +115,7 @@ class ExtraSpecs(object):
         self.memory_limits = memory_limits or Limits()
         self.disk_io_limits = disk_io_limits or Limits()
         self.vif_limits = vif_limits or Limits()
-        self.hw_version = hw_version
+        self.hw_version = hw_version or CONF.vmware.default_hw_version
         self.storage_policy = storage_policy
         self.cores_per_socket = cores_per_socket
         self.hv_enabled = hv_enabled

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,7 +19,7 @@ osprofiler>=1.4.0 # Apache-2.0
 testresources>=2.0.0 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
-bandit>=1.1.0 # Apache-2.0
+bandit>=1.1.0,<1.6 # Apache-2.0
 gabbi>=1.35.0 # Apache-2.0
 
 # vmwareapi driver specific dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 minversion = 2.1
 envlist = py{27,35},functional,pep8
 skipsdist = True
+requires = virtualenv<20
 
 [testenv]
 basepython = python3.5


### PR DESCRIPTION
This is necessary with multi-version clusters where migrating e.g. on
resize needs to be possible.

Change-Id: Idc287c4dfa2b5d6a6a837a5014063417c8e13768