### PR TITLE
Resize migrate improvement

### DIFF
--- a/nova/virt/vmwareapi/error_util.py
+++ b/nova/virt/vmwareapi/error_util.py
@@ -31,3 +31,8 @@ class PbmDefaultPolicyUnspecified(exception.Invalid):
 
 class PbmDefaultPolicyDoesNotExist(exception.NovaException):
     msg_fmt = _("The default PBM policy doesn't exist on the backend.")
+
+
+class InvalidHostAddrFormat(exception.NovaException):
+    msg_fmt = _("The provided host address couldn't be recognised as a valid "
+                "format supported by the VMwareVCDriver.")

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -323,9 +323,9 @@ class VMwareVolumeOps(object):
         return vm_util.get_vmdk_volume_disk(hardware_devices)
 
     def _attach_volume_vmdk(self, connection_info, instance,
-                            adapter_type=None):
+                            adapter_type=None, vm_ref=None):
         """Attach vmdk volume storage to VM instance."""
-        vm_ref = vm_util.get_vm_ref(self._session, instance)
+        vm_ref = vm_ref or vm_util.get_vm_ref(self._session, instance)
         LOG.debug("_attach_volume_vmdk: %s", connection_info,
                   instance=instance)
         data = connection_info['data']
@@ -356,9 +356,9 @@ class VMwareVolumeOps(object):
         LOG.debug("Attached VMDK: %s", connection_info, instance=instance)
 
     def _attach_volume_iscsi(self, connection_info, instance,
-                             adapter_type=None):
+                             adapter_type=None, vm_ref=None):
         """Attach iscsi volume storage to VM instance."""
-        vm_ref = vm_util.get_vm_ref(self._session, instance)
+        vm_ref = vm_ref or vm_util.get_vm_ref(self._session, instance)
         # Attach Volume to VM
         LOG.debug("_attach_volume_iscsi: %s", connection_info,
                   instance=instance)
@@ -381,15 +381,18 @@ class VMwareVolumeOps(object):
                                device_name=device_name)
         LOG.debug("Attached ISCSI: %s", connection_info, instance=instance)
 
-    def attach_volume(self, connection_info, instance, adapter_type=None):
+    def attach_volume(self, connection_info, instance, adapter_type=None,
+                      vm_ref=None):
         """Attach volume storage to VM instance."""
         driver_type = connection_info['driver_volume_type']
         LOG.debug("Volume attach. Driver type: %s", driver_type,
                   instance=instance)
         if driver_type == constants.DISK_FORMAT_VMDK:
-            self._attach_volume_vmdk(connection_info, instance, adapter_type)
+            self._attach_volume_vmdk(connection_info, instance, adapter_type,
+                                     vm_ref=vm_ref)
         elif driver_type == constants.DISK_FORMAT_ISCSI:
-            self._attach_volume_iscsi(connection_info, instance, adapter_type)
+            self._attach_volume_iscsi(connection_info, instance, adapter_type,
+                                      vm_ref=vm_ref)
         else:
             raise exception.VolumeDriverNotFound(driver_type=driver_type)
 
@@ -514,9 +517,9 @@ class VMwareVolumeOps(object):
             raise exception.DiskNotFound(message=_("Unable to find volume"))
         return device
 
-    def _detach_volume_vmdk(self, connection_info, instance):
+    def _detach_volume_vmdk(self, connection_info, instance, vm_ref=None):
         """Detach volume storage to VM instance."""
-        vm_ref = vm_util.get_vm_ref(self._session, instance)
+        vm_ref = vm_ref or vm_util.get_vm_ref(self._session, instance)
         # Detach Volume from VM
         LOG.debug("_detach_volume_vmdk: %s", connection_info,
                   instance=instance)
@@ -559,9 +562,9 @@ class VMwareVolumeOps(object):
 
         LOG.debug("Detached VMDK: %s", connection_info, instance=instance)
 
-    def _detach_volume_iscsi(self, connection_info, instance):
+    def _detach_volume_iscsi(self, connection_info, instance, vm_ref=None):
         """Detach volume storage to VM instance."""
-        vm_ref = vm_util.get_vm_ref(self._session, instance)
+        vm_ref = vm_ref or vm_util.get_vm_ref(self._session, instance)
         # Detach Volume from VM
         LOG.debug("_detach_volume_iscsi: %s", connection_info,
                   instance=instance)
@@ -584,15 +587,15 @@ class VMwareVolumeOps(object):
         self.detach_disk_from_vm(vm_ref, instance, device, destroy_disk=True)
         LOG.debug("Detached ISCSI: %s", connection_info, instance=instance)
 
-    def detach_volume(self, connection_info, instance):
+    def detach_volume(self, connection_info, instance, vm_ref=None):
         """Detach volume storage to VM instance."""
         driver_type = connection_info['driver_volume_type']
         LOG.debug("Volume detach. Driver type: %s", driver_type,
                   instance=instance)
         if driver_type == constants.DISK_FORMAT_VMDK:
-            self._detach_volume_vmdk(connection_info, instance)
+            self._detach_volume_vmdk(connection_info, instance, vm_ref=vm_ref)
         elif driver_type == constants.DISK_FORMAT_ISCSI:
-            self._detach_volume_iscsi(connection_info, instance)
+            self._detach_volume_iscsi(connection_info, instance, vm_ref=vm_ref)
         else:
             raise exception.VolumeDriverNotFound(driver_type=driver_type)
 


### PR DESCRIPTION
This is a refactoring of the cold migrate/resize of the VMware driver.

Before this, the driver was migrating/resizing the VMs "in place" by doing a move operation (RelocateVM_Task). The destination host was "pulling" the vm via the RelocateVM, which was kind of against nova principles (nova actually instructs the source host to "copy" the vm to the destination).

Now the vm will be copied to the destination (by a CloneVM_Task), so this copy will eventually be kept upon user's confirmation (or deleted, if the migration is reverted). It's how nova manager expects the driver to act like and enables better failure recovery.

This also introduces the capability of migrating cross-vcenter (cross-az / cross-cell / cross-shard), by storing enough information in migration.dest_host property about the destination vcenter location.