### PR TITLE
Handle sharding-enabled in scheduler shard filter

### DIFF
--- a/nova/scheduler/filters/shard_filter.py
+++ b/nova/scheduler/filters/shard_filter.py
@@ -33,11 +33,15 @@ class ShardFilter(filters.BaseHostFilter):
     """Filter hosts based on the vcenter-shard configured in their aggregate
     and the vcenter-shards configured in the project's tags in keystone. They
     have to overlap for a host to pass this filter.
+
+    Alternatively the project may have the "sharding_enabled" tag set, which
+    enables the project for hosts in all shards.
     """
 
     _PROJECT_SHARD_CACHE = {}
     _PROJECT_SHARD_CACHE_RETENTION_TIME = 10 * 60
     _SHARD_PREFIX = 'vc-'
+    _ALL_SHARDS = "sharding_enabled"
 
     def _update_cache(self):
         """Ask keystone for the list of projects to save the interesting tags
@@ -83,7 +87,8 @@ class ShardFilter(filters.BaseHostFilter):
             for project in data['projects']:
                 project_id = project['id']
                 shards = [t for t in project['tags']
-                          if t.startswith(self._SHARD_PREFIX)]
+                          if t.startswith(self._SHARD_PREFIX)
+                          or t == self._ALL_SHARDS]
                 self._PROJECT_SHARD_CACHE[project_id] = shards
 
             url = data['links']['next']
@@ -148,7 +153,11 @@ class ShardFilter(filters.BaseHostFilter):
                       {'project_id': project_id})
             return False
 
-        if host_shard_names & set(shards):
+        if self._ALL_SHARDS in shards:
+            LOG.debug('project enabled for all shards %(project_shards)s.',
+                      {'project_shards': shards})
+            return True
+        elif host_shard_names & set(shards):
             LOG.debug('%(host_state)s shard %(host_shard)s found in project '
                       'shards %(project_shards)s.',
                       {'host_state': host_state,

--- a/nova/tests/unit/scheduler/filters/test_shard_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_shard_filter.py
@@ -177,3 +177,24 @@ class TestShardFilter(test.NoDBTestCase):
         self.filt_cls._PROJECT_SHARD_CACHE['foo'] = ['vc-a-0', 'vc-a-1',
                                                      'vc-b-0']
         self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_shard_project_has_sharding_enabled_any_host_passes(self):
+        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled']
+        aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1']),
+                 objects.Aggregate(id=1, name='vc-a-0', hosts=['host1'])]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='baz',
+            flavor=objects.Flavor(extra_specs={}))
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_shard_project_has_sharding_enabled_and_single_shards(self):
+        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled',
+                                                     'vc-a-1']
+        aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1']),
+                 objects.Aggregate(id=1, name='vc-a-0', hosts=['host1'])]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='baz',
+            flavor=objects.Flavor(extra_specs={}))
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))


### PR DESCRIPTION
If a project has only one shard enabled per AZ in the keystone project
tags, the sharding filter works like before.

If either
 - the project tags have more than one VCenter enabled for any AZ, or
 - the project tags contain the tag "sharding_enabled"
then the hosts in _all_ shards will pass the shard filter for this
project.

This was done to facilitate both enablement of sharding (only one
simple tag to set), and mainly for frontend code to detect sharding
status (mostly) without parsing tag strings. (If sharding is not
enabled, then vc-* tags will have to be parsed to find out which
shard(s) the project is on.)