### PR TITLE
Ignore passed consumers in allocation candidates

### DIFF
--- a/nova/api/openstack/placement/lib.py
+++ b/nova/api/openstack/placement/lib.py
@@ -18,7 +18,8 @@ common library that both placement and its consumers can require."""
 
 class RequestGroup(object):
     def __init__(self, use_same_provider=True, resources=None,
-                 required_traits=None, forbidden_traits=None, member_of=None):
+                 required_traits=None, forbidden_traits=None, member_of=None,
+                 ignore_consumers=None):
         """Create a grouping of resource and trait requests.
 
         :param use_same_provider:
@@ -31,12 +32,15 @@ class RequestGroup(object):
         :param forbidden_traits: A set of { trait_name, ... }
         :param member_of: A list of [ [aggregate_UUID],
                                       [aggregate_UUID, aggregate_UUID] ... ]
+        :param ignore_consumers: A list of UUIDs of consumers that should be
+                ignored when finding allocation candidates.
         """
         self.use_same_provider = use_same_provider
         self.resources = resources or {}
         self.required_traits = required_traits or set()
         self.forbidden_traits = forbidden_traits or set()
         self.member_of = member_of or []
+        self.ignore_consumers = ignore_consumers or []
 
     def __str__(self):
         ret = 'RequestGroup(use_same_provider=%s' % str(self.use_same_provider)
@@ -49,5 +53,6 @@ class RequestGroup(object):
         ret += ', aggregates=[%s]' % ', '.join(
             sorted('[%s]' % ', '.join(agglist)
                    for agglist in sorted(self.member_of)))
+        ret += ', ignore_consumers=[%s]' % ', '.join(self.ignore_consumers)
         ret += ')'
         return ret

--- a/nova/api/openstack/placement/schemas/allocation_candidate.py
+++ b/nova/api/openstack/placement/schemas/allocation_candidate.py
@@ -41,9 +41,12 @@ GET_SCHEMA_1_16['properties']['limit'] = {
     "minLength": 1
 }
 
-# Add required parameter.
+# Add required parameter and ignore_consumer parameter
 GET_SCHEMA_1_17 = copy.deepcopy(GET_SCHEMA_1_16)
 GET_SCHEMA_1_17['properties']['required'] = {
+    "type": ["string"]
+}
+GET_SCHEMA_1_17['properties']['ignore_consumer'] = {
     "type": ["string"]
 }
 

--- a/nova/tests/functional/api/openstack/placement/db/test_allocation_candidates.py
+++ b/nova/tests/functional/api/openstack/placement/db/test_allocation_candidates.py
@@ -2764,3 +2764,125 @@ class AllocationCandidatesTestCase(tb.PlacementDbBaseTestCase):
         provider_names = ['cn1']
         expect_root_ids = self._get_rp_ids_matching_names(provider_names)
         self.assertEqual(expect_root_ids, tree_root_ids)
+
+    def test_ignore_consumers(self):
+        """Confirm that the resources used by all given consumers are ignored
+        when retrieving allocation candidates.
+        """
+        cn1 = self._create_provider('cn1', uuids.cn1)
+        tb.add_inventory(cn1, fields.ResourceClass.VCPU, 8)
+        tb.add_inventory(cn1, fields.ResourceClass.MEMORY_MB, 2048)
+        tb.add_inventory(cn1, fields.ResourceClass.DISK_GB, 2000)
+
+        cn2 = self._create_provider('cn2', uuids.cn2)
+        tb.add_inventory(cn2, fields.ResourceClass.VCPU, 8)
+        tb.add_inventory(cn2, fields.ResourceClass.MEMORY_MB, 2048)
+        tb.add_inventory(cn2, fields.ResourceClass.DISK_GB, 2000)
+
+        # allocate some resources on both compute nodes
+        self.allocate_from_provider(cn1, fields.ResourceClass.MEMORY_MB, 600,
+                                    consumer_id=uuids.consumer1)
+        self.allocate_from_provider(cn1, fields.ResourceClass.MEMORY_MB, 600,
+                                    consumer_id=uuids.consumer2)
+        self.allocate_from_provider(cn2, fields.ResourceClass.MEMORY_MB, 600,
+                                    consumer_id=uuids.consumer3)
+        self.allocate_from_provider(cn2, fields.ResourceClass.MEMORY_MB, 600,
+                                    consumer_id=uuids.consumer4)
+
+        # define requested resources
+        groups = {
+            '': placement_lib.RequestGroup(
+                use_same_provider=False,
+                resources={
+                    fields.ResourceClass.VCPU: 2,
+                    fields.ResourceClass.MEMORY_MB: 1200,
+                })
+        }
+
+        # get allocation candidates. expect no candidates as we don't have
+        # enough memory available
+        alloc_cands = self._get_allocation_candidates(groups)
+        self._validate_allocation_requests([], alloc_cands)
+
+        ignore_consumers = [uuids.consumer3]
+        # ignore consumer3 in request. we should now get back cn2 as there are
+        # enough resources without it
+        groups[''].ignore_consumers = ignore_consumers
+        alloc_cands = self._get_allocation_candidates(groups)
+        expected = [
+            [('cn2', fields.ResourceClass.VCPU, 2),
+             ('cn2', fields.ResourceClass.MEMORY_MB, 1200)]
+        ]
+        self._validate_allocation_requests(expected, alloc_cands)
+
+        # ignore consumer3 but request more than should be available given
+        # consumer4. this is to make sure we don't just ignore everything
+        groups = {
+            '': placement_lib.RequestGroup(
+                use_same_provider=False,
+                ignore_consumers=ignore_consumers,
+                resources={
+                    fields.ResourceClass.VCPU: 2,
+                    fields.ResourceClass.MEMORY_MB: 1500,
+                })
+        }
+        alloc_cands = self._get_allocation_candidates(groups)
+        self._validate_allocation_requests([], alloc_cands)
+
+    def test_ignore_consumers_sharing_providers(self):
+        """Confirm that all resources used by all given consumers are ignored
+        when retrieving allocation candidates.
+        This must be true if multiple providers are required to fulfill the
+        request like it is for bigVMs.
+        """
+        cn1 = self._create_provider('cn1', uuids.cn1)
+        tb.add_inventory(cn1, fields.ResourceClass.VCPU, 8)
+        tb.add_inventory(cn1, fields.ResourceClass.MEMORY_MB, 2048)
+        tb.add_inventory(cn1, fields.ResourceClass.DISK_GB, 2000)
+
+        # create a custom resource
+        bigvm_rc = rp_obj.ResourceClass(
+            self.ctx,
+            name='CUSTOM_BIGVM',
+        )
+        bigvm_rc.create()
+
+        # add a sharing child provider
+        bigvm = self._create_provider('bigvm', uuids.bigvm, parent=cn1.uuid)
+        tb.add_inventory(bigvm, bigvm_rc.name, 2)
+        tb.set_traits(bigvm, "MISC_SHARES_VIA_AGGREGATE")
+
+        # add some allocations
+        self.allocate_from_provider(cn1, fields.ResourceClass.MEMORY_MB, 600,
+                                    consumer_id=uuids.consumer1)
+        self.allocate_from_provider(cn1, fields.ResourceClass.MEMORY_MB, 600,
+                                    consumer_id=uuids.consumer2)
+        self.allocate_from_provider(bigvm, bigvm_rc.name, 2,
+                                    consumer_id=uuids.consumer3)
+
+        # request too many resources, get nothing
+        groups = {
+            '': placement_lib.RequestGroup(
+                use_same_provider=False,
+                resources={
+                    fields.ResourceClass.VCPU: 2,
+                    fields.ResourceClass.MEMORY_MB: 1200,
+                    'CUSTOM_BIGVM': 2
+                })
+        }
+
+        # get allocation candidates. expect no candidates as we don't have
+        # enough memory available
+        alloc_cands = self._get_allocation_candidates(groups)
+        self._validate_allocation_requests([], alloc_cands)
+
+        # request fitting resources if consumer2 and consumer3 are replaced
+        ignore_consumers = [uuids.consumer2, uuids.consumer3]
+        groups[''].ignore_consumers = ignore_consumers
+        alloc_cands = self._get_allocation_candidates(groups)
+        expected = [
+            [('cn1', fields.ResourceClass.VCPU, 2),
+             ('cn1', fields.ResourceClass.MEMORY_MB, 1200),
+             ('bigvm', bigvm_rc.name, 2)]
+        ]
+        self._validate_allocation_requests(expected, alloc_cands)

--- a/nova/tests/unit/scheduler/test_utils.py
+++ b/nova/tests/unit/scheduler/test_utils.py
@@ -336,7 +336,8 @@ class TestUtils(test.NoDBTestCase):
             'RequestGroup(use_same_provider=False, '
             'resources={DISK_GB:1, MEMORY_MB:1024, VCPU:1}, '
             'traits=[], '
-            'aggregates=[[baz], [foo, bar]])',
+            'aggregates=[[baz], [foo, bar]], '
+            'ignore_consumers=[])',
             str(req))
 
     def test_resources_from_request_spec_no_aggregates(self):
@@ -660,19 +661,23 @@ class TestUtils(test.NoDBTestCase):
             'RequestGroup(use_same_provider=False, '
             'resources={MEMORY_MB:2048, VCPU:2}, '
             'traits=[CUSTOM_MAGIC, HW_CPU_X86_AVX, !CUSTOM_BRONZE], '
-            'aggregates=[]), '
+            'aggregates=[], '
+            'ignore_consumers=[]), '
             'RequestGroup(use_same_provider=True, '
             'resources={DISK_GB:5}, '
             'traits=[], '
-            'aggregates=[]), '
+            'aggregates=[], '
+            'ignore_consumers=[]), '
             'RequestGroup(use_same_provider=True, '
             'resources={IPV4_ADDRESS:1, SRIOV_NET_VF:1}, '
             'traits=[CUSTOM_PHYSNET_NET1, !CUSTOM_PHYSNET_NET2], '
-            'aggregates=[]), '
+            'aggregates=[], '
+            'ignore_consumers=[]), '
             'RequestGroup(use_same_provider=True, '
             'resources={IPV4_ADDRESS:2, SRIOV_NET_VF:1}, '
             'traits=[CUSTOM_PHYSNET_NET2, HW_NIC_ACCEL_SSL], '
-            'aggregates=[])',
+            'aggregates=[], '
+            'ignore_consumers=[])',
             str(rr))
 
     def test_resource_request_from_extra_specs_append_request(self):


### PR DESCRIPTION
Porting https://github.com/sapcc/placement/pull/1 into rocky.

This commit makes it possible to pass a list of consumer UUIDs to ignore
when retrieven allocation candidates. This can be useful for
implementations replacing a VM on resize instead of copying it. Some
care has to be taken on the client side to not overbook the
resource-provider, but there's another check when trying to allocate the
resources that should make sure of that.