### PR TITLE
Increase timeout for reserve_block_device_name RPC call

### DIFF
--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -1056,7 +1056,7 @@ class ComputeAPI(object):
                 kw.pop('tag')
 
         cctxt = client.prepare(server=_compute_host(None, instance),
-                               version=version)
+                               version=version, timeout=1800)
         return cctxt.call(ctxt, 'reserve_block_device_name', **kw)
 
     def backup_instance(self, ctxt, instance, image_id, backup_type,


### PR DESCRIPTION
Starting with rocky, we will have the "long_rpc_timeout" option
available, which is also used in this call. rocky also add some handling
for longer RPC calls, which - afaics - make the caller see a broken call
faster than the long RPC timeout. Since we're planning to upgrade to
rocky in the very near future, we can get along with not monitoring the
calls for now, but increasing the timeout by hardcoding the future
default-value.

This should lead to nova-api not running into MessagingTimeout that
often and thus delete the block_device_mapping entries properly, as it
can find out via Cinder, that the volume is already attached or
attaching.

Change-Id: I4d6b137d2f5659265adb54da1094a63e30b7b3e4