### PR TITLE
vmware: Set large VMs as partiallyAutomated in DRS

### DIFF
--- a/nova/conf/base.py
+++ b/nova/conf/base.py
@@ -113,6 +113,20 @@ For a couple of operations, e.g. scheduling decisions and special settings when
 spawning, we have to identify a big VM and handle them differently. Every VM
 having more or equal to this setting's amount of RAM is a big VM.
 """),
+    cfg.IntOpt(
+        'largevm_mb',
+        default=230 * 1024,      # 230 GB
+        min=0,
+        help="""
+Instance memory usage identifying it as large VM
+
+For a couple of operations, e.g. special settings when
+spawning, we have to identify a large VM and handle them differently - even
+differently than big VMs. Every VM having more or equal to this setting's
+amount of RAM and less than bigvm_mb is a large VM.
+
+See also: nova.utils.is_large_vm()
+"""),
     cfg.StrOpt(
         'bigvm_deployment_rp_name_prefix',
         default='bigvm-deployment',

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -1487,6 +1487,18 @@ def is_big_vm(memory_mb, flavor):
     return True
 
 
+def is_large_vm(memory_mb, flavor):
+    # small and big VMs are not large
+    if memory_mb < CONF.largevm_mb or memory_mb > CONF.bigvm_mb:
+        return False
+
+    # baremetal instances are not large
+    if is_baremetal_flavor(flavor):
+        return False
+
+    return True
+
+
 def vm_needs_special_spawning(memory_mb, flavor):
     if is_big_vm(memory_mb, flavor):
         return True

--- a/nova/virt/vmwareapi/special_spawning.py
+++ b/nova/virt/vmwareapi/special_spawning.py
@@ -214,7 +214,7 @@ class _SpecialVmSpawningServer(object):
             # TODO(jkulik) Filter for hosts having no VM with DRS
             # partiallyAutomated
             vms_per_host = {h: vms for h, vms in vms_per_host.items()
-                            if all(mem < CONF.bigvm_mb
+                            if all(mem < CONF.largevm_mb
                                    for mem, state, used_mem in vms)}
 
             if not vms_per_host:

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1245,7 +1245,8 @@ class VMwareVMOps(object):
         vm_util.rename_vm(self._session, vm_ref, instance)
 
         # Make sure we don't automatically move around "big" VMs
-        if utils.is_big_vm(int(instance.memory_mb), instance.flavor):
+        if utils.is_big_vm(int(instance.memory_mb), instance.flavor) or \
+                utils.is_large_vm(int(instance.memory_mb), instance.flavor):
             behavior = constants.DRS_BEHAVIOR_PARTIALLY_AUTOMATED
             LOG.debug("Adding DRS override '%s' for big VM.", behavior,
                       instance=instance)
@@ -1948,10 +1949,15 @@ class VMwareVMOps(object):
         vm_util.reconfigure_vm(self._session, vm_ref, vm_resize_spec)
 
         old_flavor = instance.old_flavor
-        old_is_big = utils.is_big_vm(int(old_flavor.memory_mb), old_flavor)
-        new_is_big = utils.is_big_vm(int(flavor.memory_mb), flavor)
+        old_needs_override = utils.is_big_vm(int(old_flavor.memory_mb),
+                                             old_flavor) \
+                             or utils.is_large_vm(int(old_flavor.memory_mb),
+                                                  old_flavor)
+        new_needs_override = utils.is_big_vm(int(flavor.memory_mb), flavor) \
+                             or utils.is_large_vm(int(flavor.memory_mb),
+                                                  flavor)
 
-        if not old_is_big and new_is_big:
+        if not old_needs_override and new_needs_override:
             # Make sure we don't automatically move around "big" VMs
             behavior = constants.DRS_BEHAVIOR_PARTIALLY_AUTOMATED
             LOG.debug("Adding DRS override '%s' for big VM.", behavior,
@@ -1961,7 +1967,7 @@ class VMwareVMOps(object):
                                                         vm_ref,
                                                         operation='add',
                                                         behavior=behavior)
-        elif old_is_big and not new_is_big:
+        elif old_needs_override and not new_needs_override:
             # remove the old override, if we had one before. make sure we don't
             # error out if it was already deleted another way
             LOG.debug("Removing DRS override for former big VM.",


### PR DESCRIPTION
We don't want them to move anymore. This might hinder our efforts to
spawn big VMs, but the nanny is supposed to help us here.

Change-Id: I5ebdbe2f287d50c9b9a755166702c3eccea62b14