### PR TITLE
vmware: Optionally attach disconnected serial ports

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -92,6 +92,18 @@ Related options:
 This option is ignored if serial_port_service_uri is not specified.
 * serial_port_service_uri
 """),
+    cfg.BoolOpt('serial_port_connected_default',
+                default=True,
+                help="""
+Configure, whether the added serial port should be connected by default
+
+This option can be used to enable the possibility to collect logs only for
+specific VMs, by reconfiguring and rebooting them in the vCenter.
+
+Related options:
+This option is ignored if serial_port_service_uri is not specified.
+* serial_port_service_uri
+"""),
     cfg.StrOpt('serial_log_dir',
                default='/opt/vmware/vspc',
                help="""

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -509,9 +509,9 @@ def create_serial_port_spec(client_factory):
     backing.proxyURI = CONF.vmware.serial_port_proxy_uri
 
     connectable_spec = client_factory.create('ns0:VirtualDeviceConnectInfo')
-    connectable_spec.startConnected = True
+    connectable_spec.startConnected = CONF.vmware.serial_port_connected_default
     connectable_spec.allowGuestControl = True
-    connectable_spec.connected = True
+    connectable_spec.connected = CONF.vmware.serial_port_connected_default
 
     serial_port = client_factory.create('ns0:VirtualSerialPort')
     serial_port.connectable = connectable_spec


### PR DESCRIPTION
We want to be able to configure new VMs with our currently-disabled vSPC
services, because it doesn't seem to be possible to reconfigure a serial
port on a running VM - other than setting it to connected and
startConnected. Therefore, we add a config option.

Change-Id: I0b9d7a7d1445c2017756146068e287628a39bec6