### PR TITLE
Unlist flavors with hidden extra_spec for users

### DIFF
--- a/nova/api/openstack/compute/flavors.py
+++ b/nova/api/openstack/compute/flavors.py
@@ -110,6 +110,8 @@ class FlavorsController(wsgi.Controller):
         else:
             filters['is_public'] = True
             filters['disabled'] = False
+            # Normal users cannot list hidden flavors
+            filters['hidden'] = False
 
         if 'minRam' in req.params:
             try:


### PR DESCRIPTION
Filter out flavor from flavor list when the extra_spec
    `catalog:hidden`
is present and `"true"` or `"True"`.

This is done to enable phasing out flavors. "Hidden" flavors will not
appear when listing available flavors (except for admins, which always
see all flavors). This will make them less discoverable.

Hidden flavors are still visible when retrieved via flavor ID, and are
still deployable.

Note: Hidden flavors are not deployable when using the OS CLI flag
`--flavor` with the flavor _name_, since that implies a "flavor list"
lookup.
