### PR TITLE
remove check-cherry-picks.sh invocation for pep8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,6 @@ commands =
   bash -c "! find doc/ -type f -name *.json | xargs grep -U -n $'\r'"
   # Check that all included JSON files are valid JSON
   bash -c '! find doc/ -type f -name *.json | xargs -t -n1 python -m json.tool 2>&1 > /dev/null | grep -B1 -v ^python'
-  bash tools/check-cherry-picks.sh
 
 [testenv:fast8]
 description =


### PR DESCRIPTION
As upstream also states, this script may fail for forks, like ours,
so instead of disabling it via environment variables in CI only,
we remove it completely from tox.ini so that pep8 commands will
work out of the box for everyone.