### PR TITLE
Rename sharding- to resourcepool_enabled tag

### DIFF
--- a/nova/scheduler/filters/shard_filter.py
+++ b/nova/scheduler/filters/shard_filter.py
@@ -34,14 +34,14 @@ class ShardFilter(filters.BaseHostFilter):
     and the vcenter-shards configured in the project's tags in keystone. They
     have to overlap for a host to pass this filter.
 
-    Alternatively the project may have the "sharding_enabled" tag set, which
-    enables the project for hosts in all shards.
+    Alternatively the project may have the "resourcepools_enabled" tag set,
+    which enables the project for hosts in all shards.
     """
 
     _PROJECT_SHARD_CACHE = {}
     _PROJECT_SHARD_CACHE_RETENTION_TIME = 10 * 60
     _SHARD_PREFIX = 'vc-'
-    _ALL_SHARDS = "sharding_enabled"
+    _ALL_SHARDS = "resourcepools_enabled"
 
     def _update_cache(self):
         """Ask keystone for the list of projects to save the interesting tags

--- a/nova/tests/unit/scheduler/filters/test_shard_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_shard_filter.py
@@ -178,8 +178,8 @@ class TestShardFilter(test.NoDBTestCase):
                                                      'vc-b-0']
         self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
 
-    def test_shard_project_has_sharding_enabled_any_host_passes(self):
-        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled']
+    def test_shard_project_has_resourcepools_enabled_any_host_passes(self):
+        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['resourcepools_enabled']
         aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1']),
                  objects.Aggregate(id=1, name='vc-a-0', hosts=['host1'])]
         host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
@@ -188,8 +188,8 @@ class TestShardFilter(test.NoDBTestCase):
             flavor=objects.Flavor(extra_specs={}))
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
-    def test_shard_project_has_sharding_enabled_and_single_shards(self):
-        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled',
+    def test_shard_project_has_resourcepools_enabled_and_single_shards(self):
+        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['resourcepools_enabled',
                                                      'vc-a-1']
         aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1']),
                  objects.Aggregate(id=1, name='vc-a-0', hosts=['host1'])]


### PR DESCRIPTION
The customer-facing wording was changed. Reflect this in the
project tag string.

Fixup for 01014bc:
    "Handle sharding-enabled in scheduler shard filter"
