### PR TITLE
Fix empty result for vim_util.get_properties_for_a_collection_of_objects()

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vim_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vim_util.py
@@ -36,3 +36,9 @@ class VMwareVIMUtilTestCase(test.NoDBTestCase):
             self.vim, cluster_refs[0], 'datastore', 'Datastore', property)
         datastores = [oc.obj for oc in result.objects]
         self.assertEqual(expected_ds, datastores)
+
+    def test_get_properties_for_an_empty_collection_of_objects(self):
+        result = vim_util.get_properties_for_a_collection_of_objects(
+            self.vim, "Foo", [], ["bar", "baz"])
+        self.assertTrue(hasattr(result, "objects"))
+        self.assertTrue(hasattr(result.objects, "__iter__"))

--- a/nova/virt/vmwareapi/vim_util.py
+++ b/nova/virt/vmwareapi/vim_util.py
@@ -25,6 +25,11 @@ import nova.conf
 CONF = nova.conf.CONF
 
 
+class EmptyRetrieveResult(object):
+    def __init__(self):
+        self.objects = []
+
+
 def object_to_dict(obj, list_depth=1):
     """Convert Suds object into serializable format.
 
@@ -136,7 +141,7 @@ def get_properties_for_a_collection_of_objects(vim, type,
     """
     client_factory = vim.client.factory
     if len(obj_list) == 0:
-        return []
+        return EmptyRetrieveResult()
     prop_spec = get_prop_spec(client_factory, type, properties)
     lst_obj_specs = []
     for obj in obj_list:


### PR DESCRIPTION
If the `obj_list` parameter to the `vim_utils.get_properties_for_a_collection_of_objects()` function is empty, an empty list was returned. The non-error path returns a `vim.RetrieveResult` object, with an iterable "objects" attribute.

Introduce a dummy class `EmptyRetrieveResult` which behaves like `vim.RetrieveResult` for the empty case, and return an instance if the list of objects to be queried is empty.
