### PR TITLE
Add migration for 'internal_access_path' column to allow more than 255 chars.

### DIFF
--- a/nova/db/sqlalchemy/migrate_repo/versions/391_placeholder.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/391_placeholder.py
@@ -1,0 +1,22 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+# This is a placeholder for backports.
+# Do not use this number for new work.  New work starts after
+# all the placeholders.
+#
+# See this for more information:
+# http://lists.openstack.org/pipermail/openstack-dev/2013-March/006827.html
+
+
+def upgrade(migrate_engine):
+    pass

--- a/nova/db/sqlalchemy/migrate_repo/versions/392_fix_internal_access_path_max_length.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/392_fix_internal_access_path_max_length.py
@@ -1,0 +1,30 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from sqlalchemy import MetaData, Text, Table
+
+
+def upgrade(migrate_engine):
+    meta = MetaData()
+    meta.bind = migrate_engine
+
+    table_console_auth_tokens = Table('console_auth_tokens',
+                                      meta,
+                                      autoload=True)
+    col_internal_access_path = getattr(table_console_auth_tokens.c,
+                                       'internal_access_path')
+
+    if col_internal_access_path.type.length == 255:
+        # The internal_access_path column of console_auth_tokens table has
+        # length(255) which is sometimes not enough when used with vmware
+        # driver: https://bugs.launchpad.net/nova/+bug/1900371
+        col_internal_access_path.alter(type=Text)

--- a/nova/db/sqlalchemy/models.py
+++ b/nova/db/sqlalchemy/models.py
@@ -1604,7 +1604,7 @@ class ConsoleAuthToken(BASE, NovaBase):
     console_type = Column(String(255), nullable=False)
     host = Column(String(255), nullable=False)
     port = Column(Integer, nullable=False)
-    internal_access_path = Column(String(255))
+    internal_access_path = Column(Text)
     instance_uuid = Column(String(36), nullable=False)
     expires = Column(Integer, nullable=False)
     access_url_base = Column(String(255))

--- a/nova/tests/unit/db/test_migrations.py
+++ b/nova/tests/unit/db/test_migrations.py
@@ -166,6 +166,7 @@ class NovaMigrationsCheckers(test_migrations.ModelsMigrationsSync,
         special = [
             216,  # Havana
             272,  # NOOP migration due to revert
+            391,  # ccloud: custom placeholder for Rocky upgrade
         ]
 
         havana_placeholders = list(range(217, 227))
@@ -225,6 +226,10 @@ class NovaMigrationsCheckers(test_migrations.ModelsMigrationsSync,
             # is no longer used. The field value is always NULL so
             # it does not affect anything.
             346,
+
+            # 392 changes 'internal_access_path' column type from String to
+            # Text to allow more than 255 chars. Alter operation is done.
+            392
         ]
         # Reviewers: DO NOT ALLOW THINGS TO BE ADDED HERE
 
@@ -1008,6 +1013,14 @@ class NovaMigrationsCheckers(test_migrations.ModelsMigrationsSync,
         self.assertColumnExists(engine, 'instance_extra', 'trusted_certs')
         self.assertColumnExists(engine, 'shadow_instance_extra',
                                 'trusted_certs')
+
+    def _check_392(self, engine, data):
+        self.assertColumnExists(engine,
+                                'console_auth_tokens',
+                                'internal_access_path')
+        table = oslodbutils.get_table(engine, 'console_auth_tokens')
+        self.assertIsInstance(table.c.internal_access_path.type,
+                              sqlalchemy.types.Text)
 
 
 class TestNovaMigrationsSQLite(NovaMigrationsCheckers,


### PR DESCRIPTION
    The 'internal_access_path' column of 'console_auth_tokens' table has the
    type String with max length of 255 characters which might not be enough
    when used with VmWare and that will cause a DBDataError.

    This migration changes the internal_access_path type to be Text with max
    length of 65535 characters.

    Closes-Bug: #1900371