### PR TITLE
Alias flavor names from catalog:alias extra_spec

### DIFF
--- a/nova/conf/flavors.py
+++ b/nova/conf/flavors.py
@@ -27,6 +27,23 @@ flavor_opts = [
 Default flavor to use for the EC2 API only.
 The Nova API does not support a default flavor.
 """),
+    cfg.StrOpt(
+        "flavorid_alias_prefix",
+        default="x_deprecated_",
+        help="""
+To enable gradual deprecation of old flavor names, the new flavors can specifiy
+an extra_spec key 'catalog:alias', which adds the flavor to the flavor listing
+a second time, only with a different flavorid, and the flavor name replaced by
+the value of 'catalog:alias'.
+
+The flavorid is changed by prepending this config value to the actual flavorid.
+When the flavor with this flavorid is inspected or used to deploy a server, the
+actual aliased flavor will be shown/used respectively.
+
+The 'x_' prefix in the default sorts aliased flavors towards the end of the
+flavor list (when sorting by flavorid, which is the API default). This
+decreases visibility for aliased flavors.
+""")
 ]
 
 

--- a/nova/tests/functional/api_sample_tests/test_flavors.py
+++ b/nova/tests/functional/api_sample_tests/test_flavors.py
@@ -125,3 +125,47 @@ class FlavorsSampleJsonTest2_61(FlavorsSampleJsonTest):
         new_flavor.create()
         self.flavor_show_id = new_flavor_id
         self.subs = {'flavorid': new_flavor_id}
+
+
+class FlavorIdAliasTest(api_sample_base.ApiSampleTestBaseV21):
+    alias_prefix = "x_test_alias_"
+
+    def setUp(self):
+        super(FlavorIdAliasTest, self).setUp()
+        self.ctxt = nova_context.get_admin_context()
+        self.flags(flavorid_alias_prefix=self.alias_prefix)
+
+    def _create_aliased_flavor(self, alias):
+        flavors = objects.FlavorList.get_all(self.ctxt)
+        self.flavor_id = str(int(flavors[-1].flavorid) + 1)
+        self.flavor_id_alias = self.alias_prefix + self.flavor_id
+        aliased_flavor = objects.Flavor(
+            self.ctxt, memory_mb=2048, vcpus=1, root_gb=20,
+            flavorid=self.flavor_id, name='my.flavor',
+            extra_specs={'catalog:alias': alias})
+        aliased_flavor.create()
+
+    @staticmethod
+    def _response_flavor_ids(response):
+        return [f['id'] for f in response.json()['flavors']]
+
+    def test_aliased_flavor_visible_in_list(self):
+        self._create_aliased_flavor('my.flavor.old')
+        response = self._do_get('flavors')
+        self.assertIn(self.flavor_id_alias,
+                      self._response_flavor_ids(response))
+
+    def test_aliased_flavor_unaliased_name_in_show(self):
+        self._create_aliased_flavor('my.flavor.old')
+        response = self._do_get('flavors/%s' % self.flavor_id_alias)
+        response_flavor = response.json()['flavor']
+        response_id = response_flavor['id']
+        response_name = response_flavor['name']
+        self.assertEqual(response_id, self.flavor_id)
+        self.assertEqual(response_name, 'my.flavor')
+
+    def test_empty_catalog_alias_doesnt_create_alias(self):
+        self._create_aliased_flavor('')
+        response = self._do_get('flavors')
+        self.assertNotIn(self.flavor_id_alias,
+                         self._response_flavor_ids(response))


### PR DESCRIPTION
When the extra_spec _"catalog:alias"_ is present list an additional alias flavor in the flavor list, with a name of the extra_spec value.

For the alias the `flavorid` is appended with _'\_alias_id'_ in order to have a unique id, with a straightforward removal process, without any further DB lookups.

This is done to enable phasing out flavors. "Aliased" flavors appear when listing available flavors, but they don't actually exist and get automatically converted into their actual flavor counterparts on flavor show and when creating servers.

This means inspecting a flavor by name and deploying a server with a flavor by name will result in the actual flavor being shown or used for creation, respectively.
