### PR TITLE
LargeVM memory reservation 2

### DIFF
--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -34,6 +34,7 @@ from nova.scheduler import client as scheduler_client
 from nova.scheduler.client.report import get_placement_request_id
 from nova.scheduler.client.report import NESTED_PROVIDER_API_VERSION
 from nova.scheduler.utils import ResourceRequest
+from nova import utils
 from nova.virt.vmwareapi import special_spawning
 
 LOG = logging.getLogger(__name__)
@@ -43,6 +44,7 @@ CONF = nova.conf.CONF
 MEMORY_MB = rc_fields.ResourceClass.MEMORY_MB
 BIGVM_RESOURCE = special_spawning.BIGVM_RESOURCE
 BIGVM_DISABLED_TRAIT = 'CUSTOM_BIGVM_DISABLED'
+MEMORY_RESERVABLE_MB_RESOURCE = utils.MEMORY_RESERVABLE_MB_RESOURCE
 VMWARE_HV_TYPE = 'VMware vCenter Server'
 SHARD_PREFIX = 'vc-'
 HV_SIZE_BUCKET_THRESHOLD_PERCENT = 10
@@ -84,11 +86,13 @@ class BigVmManager(manager.Manager):
            again if a migration happened in the background. We need to clean up
            the child rp in this case and redo the scheduling.
 
-        We only want to fill up clusters to a certain point, configurable via
-        bigvm_cluster_max_usage_percent. resource-providers having more RAM
-        usage than this, will not be used for a hv_size. Additionally, we check
-        in every iteration, if we have to give up a freed-up host, because the
-        cluster reached the limit.
+        We only want to fill up cluster memory to a certain point, configurable
+        via bigvm_cluster_max_usage_percent and
+        bigvm_cluster_max_reservation_percent. Resource-providers having more
+        RAM usage or -reservation than those two respectively, will not be used
+        for an hv_size. Additionally, we check in every iteration, if we have
+        to give up a freed-up host, because the cluster reached one of the
+        limits.
         """
         client = self.placement_client
 
@@ -139,16 +143,24 @@ class BigVmManager(manager.Manager):
             for p, d in provider_summaries.items():
                 used = vmware_providers.get(p, {})\
                         .get('memory_mb_used_percent', 100)
-                if used > CONF.bigvm_cluster_max_usage_percent:
+                reserved = vmware_providers.get(p, {})\
+                            .get('memory_reservable_mb_used_percent', 100)
+                if (used > CONF.bigvm_cluster_max_usage_percent
+                        or reserved
+                            > CONF.bigvm_cluster_max_reservation_percent):
                     continue
                 filtered_provider_summaries[p] = d
 
             if not filtered_provider_summaries:
                 LOG.warning('Could not find a resource-provider to free up a '
                             'host for hypervisor size %(hv_size)d, because '
-                            'all clusters are used more than %(max_used)d.',
+                            'all clusters are already using more than '
+                            '%(max_used)d%% of total memory or reserving more '
+                            'than %(max_reserved)d%% of reservable memory.',
                             {'hv_size': hv_size,
-                             'max_used': CONF.bigvm_cluster_max_usage_percent})
+                             'max_used': CONF.bigvm_cluster_max_usage_percent,
+                             'max_reserved':
+                                CONF.bigvm_cluster_max_reservation_percent})
                 continue
 
             # filter out providers that are disabled for bigVMs
@@ -287,15 +299,19 @@ class BigVmManager(manager.Manager):
             elif rp['uuid'] not in vmware_hvs:  # ignore baremetal
                 continue
             else:
-                # retrieve the MEMORY_MB resource
-                url = '/resource_providers/{}/inventories/{}'.format(
-                        rp['uuid'], MEMORY_MB)
+                # retrieve inventory for MEMORY_MB & MEMORY_RESERVABLE_MB info
+                url = '/resource_providers/{}/inventories'.format(rp['uuid'])
                 resp = client.get(url)
                 if resp.status_code != 200:
                     LOG.error('Could not retrieve inventory for RP %(rp)s.',
                               {'rp': rp['uuid']})
                     continue
-                memory_mb_inventory = resp.json()
+                inventory = resp.json()["inventories"]
+                memory_mb_inventory = inventory[MEMORY_MB]
+                memory_reservable_mb_inventory = inventory.get(
+                    MEMORY_RESERVABLE_MB_RESOURCE)
+                if not memory_reservable_mb_inventory:
+                    continue
 
                 # retrieve the usage
                 url = '/resource_providers/{}/usages'
@@ -311,6 +327,12 @@ class BigVmManager(manager.Manager):
                                    - memory_mb_inventory['reserved'])
                 memory_mb_used_percent = (usages[MEMORY_MB]
                                           / float(memory_mb_total) * 100)
+                memory_reservable_mb_total = (
+                    memory_reservable_mb_inventory['total']
+                    - memory_reservable_mb_inventory['reserved'])
+                memory_reservable_mb_used_percent = (
+                    usages.get(MEMORY_RESERVABLE_MB_RESOURCE, 0)
+                    / float(memory_reservable_mb_total) * 100)
 
                 host = vmware_hvs[rp['uuid']]
                 # ignore hypervisors we would never use anyways
@@ -327,13 +349,15 @@ class BigVmManager(manager.Manager):
                               'AZ or VC.',
                               {'host': host})
                     continue
-                vmware_providers[rp['uuid']] = {'hv_size': hv_size,
-                                                'host': host,
-                                                'az': host_azs[host],
-                                                'vc': host_vcs[host],
-                                                'cell_mapping': cell_mapping,
-                                                'memory_mb_used_percent':
-                                                    memory_mb_used_percent}
+                vmware_providers[rp['uuid']] = {
+                    'hv_size': hv_size,
+                    'host': host,
+                    'az': host_azs[host],
+                    'vc': host_vcs[host],
+                    'cell_mapping': cell_mapping,
+                    'memory_mb_used_percent': memory_mb_used_percent,
+                    'memory_reservable_mb_used_percent':
+                        memory_reservable_mb_used_percent}
 
             # make sure the placement cache is filled
             client.get_provider_tree_and_ensure_root(context, rp['uuid'],
@@ -387,7 +411,10 @@ class BigVmManager(manager.Manager):
                 continue
             host_rp = vmware_providers[rp['host_rp_uuid']]
             used_percent = host_rp['memory_mb_used_percent']
-            if used_percent > CONF.bigvm_cluster_max_usage_percent:
+            reserved_percent = host_rp['memory_mb_reserved_percent']
+            if used_percent > CONF.bigvm_cluster_max_usage_percent \
+                    or reserved_percent \
+                        > CONF.bigvm_cluster_max_reservation_percent:
                 overused_providers[rp_uuid] = rp
                 LOG.info('Resource-provider %(host_rp_uuid)s with free host '
                          'is overused. Marking %(rp_uuid)s for deletion.',

--- a/nova/conf/base.py
+++ b/nova/conf/base.py
@@ -111,6 +111,20 @@ Clusters/resource-provider with this much usage are not used for freeing up a
 host for spawning (a big VM). Clusters found to reach that amount, that already
 have a host freed, get their free host removed.
 """),
+    cfg.IntOpt(
+        'bigvm_cluster_max_reservation_percent',
+        default=50,
+        help="""
+
+Clusters/resource-providers with this percentage of memory reserved (of their
+reservable memory, which can be less than total memory) are not used for
+freeing up a host for spawning big VMs. Clusters found to reach that amount,
+that already have a host freed, get their free host removed.
+
+Compare the values of conf.vmware.memory_reservation_cluster_hosts_max_fail and
+conf.vmware.memory_reservation_max_ratio_fallback to see how much of total
+memory is actually reservable.
+"""),
 ]
 
 

--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -127,6 +127,36 @@ is hot-created.
 For big VMs as determined by the `bigvm_mb` setting, this setting is not used.
 Big VMs always reserve all their memory.
 """),
+    cfg.IntOpt('memory_reservation_cluster_hosts_max_fail',
+                default=0,
+                min=0,
+                help="""
+Allow reserving instance memory while at least n hypervisors of memory remain
+unreserved in the cluster. This is a safety margin so a certain number of
+cluster hypervisors are allowed to fail. If more memory would be reserved and
+all the anticipated HV failures occurred, existing VMs with reserved memory
+would no longer be able to start.
+
+This setting applies to VMs with flavors which have a nonzero extra_spec
+"resources:CUSTOM_MEMORY_RESERVABLE_MB" set.
+
+The default value of 0 also leads to this setting being ignored and falling
+back on `memory_reservation_max_ratio_fallback`.
+"""),
+    cfg.FloatOpt('memory_reservation_max_ratio_fallback',
+        default=1.0,
+        help="""
+Allow reserving instance memory up to a maximum ratio in the cluster. This is a
+safety margin so a certain ratio of cluster hypervisors are allowed to fail. If
+more memory than that would be reserved and all the anticipated HV failures
+occurred, existing VMs with reserved memory would no longer be able to start.
+
+This setting applies to VMs with flavors which have a nonzero extra_spec
+"resources:CUSTOM_MEMORY_RESERVABLE_MB" set.
+
+This is a fallback when the `memory_reservation_cluster_hosts_max_fail` config
+is set to 0.
+"""),
     cfg.StrOpt('hostgroup_reservations_json_file',
         help="""
 Specifies the path to a JSON file containing vcpus and memory reservations per

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -39,6 +39,7 @@ from nova.compute import power_state
 from nova.compute import task_states
 from nova.compute import vm_states
 import nova.conf
+import nova.utils
 
 from nova import context
 from nova import exception
@@ -2398,6 +2399,13 @@ class VMwareAPIVMTestCase(test.TestCase,
                 'max_unit': 25,
                 'step_size': 1,
             },
+            nova.utils.MEMORY_RESERVABLE_MB_RESOURCE: {
+                'total': 2048 - 512,  # 512 CONF.reserved_host_memory_mb
+                'reserved': 0,
+                'min_unit': 1,
+                'max_unit': 1024,
+                'step_size': 1,
+            }
         }
         self.assertEqual(expected, inv)
 
@@ -2420,7 +2428,8 @@ class VMwareAPIVMTestCase(test.TestCase,
             'mem': {'total': 2048,
                     'free': 2048,
                     'max_mem_mb_per_host': 1024,
-                    'reserved_memory_mb': 512}}
+                    'reserved_memory_mb': 512,
+                    'vm_reservable_memory_ratio': 1.0}}
         inv = self.conn.get_inventory(self.node_name)
         expected = {
             fields.ResourceClass.VCPU: {
@@ -2444,6 +2453,15 @@ class VMwareAPIVMTestCase(test.TestCase,
                 'max_unit': 25,
                 'step_size': 1,
             },
+            nova.utils.MEMORY_RESERVABLE_MB_RESOURCE: {
+                # 512 reported reserved from vmware stats (see above)
+                # + 512 CONF.reserved_host_memory_mb
+                'total': 2048 - 512 - 512,
+                'reserved': 0,
+                'min_unit': 1,
+                'max_unit': 1024,
+                'step_size': 1,
+            }
         }
         self.assertEqual(expected, inv)
 

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -142,7 +142,8 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                                           'free': num_hosts * 4096 -
                                                   num_hosts * 512,
                                           'max_mem_mb_per_host': 4096,
-                                          'reserved_memory_mb': 0}}
+                                          'reserved_memory_mb': 0,
+                                          'vm_reservable_memory_ratio': 1.0}}
             self.assertEqual(expected_stats, result)
 
     def test_get_stats_from_cluster_hosts_connected_and_active(self):
@@ -197,13 +198,14 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                 'vcpus': 2}}
 
         expected = {'cpu': {'vcpus': 2 * 16,
-                                  'max_vcpus_per_host': 14,  # by host2 counts
-                                  'reserved_vcpus': 4 + 2},  # both hosts
-                          'mem': {'total': 2 * 4096,
-                                  'free': 2 * 4096 -
-                                          2 * 512,
-                                  'max_mem_mb_per_host': 4096 - 256,    # host1
-                                  'reserved_memory_mb': 512 + 256}}     # both
+                            'max_vcpus_per_host': 14,  # by host2 counts
+                            'reserved_vcpus': 4 + 2},  # both hosts
+                    'mem': {'total': 2 * 4096,
+                            'free': 2 * 4096 -
+                                    2 * 512,
+                            'max_mem_mb_per_host': 4096 - 256,  # host1
+                            'reserved_memory_mb': 512 + 256,    # both
+                            'vm_reservable_memory_ratio': 1.0}}
         self._test_get_stats_from_cluster(expected_stats=expected)
 
     def test_get_host_reservations_empty(self):

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1059,6 +1059,24 @@ class VMwareVMOpsTestCase(test.TestCase):
         expected = (self._context, int(flavor.memory_mb), flavor)
         fake_cleanup_after_special_spawning.assert_called_once_with(*expected)
 
+    def test_reserve_all_memory_for_memory_reserved_flavor(self):
+        self.flags(group='vmware', reserve_all_memory=False)
+        self._instance.flavor.extra_specs.update({
+            utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY:
+                self._instance.flavor.memory_mb})
+        specs = self._vmops._get_extra_specs(self._instance.flavor,
+                                             self._image_meta)
+        self.assertEqual(specs.memory_limits.reservation,
+                         self._instance.flavor.memory_mb)
+
+    def test_reserve_no_memory_for_memory_unreserved_flavor(self):
+        self.flags(group='vmware', reserve_all_memory=False)
+        self._instance.flavor.extra_specs.pop(
+            utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY, None)
+        specs = self._vmops._get_extra_specs(self._instance.flavor,
+                                             self._image_meta)
+        self.assertIsNone(specs.memory_limits.reservation)
+
     @mock.patch.object(vmops.VMwareVMOps, '_extend_virtual_disk')
     @mock.patch.object(ds_util, 'disk_move')
     @mock.patch.object(ds_util, 'disk_copy')

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -88,6 +88,11 @@ VIM_IMAGE_ATTRIBUTES = (
     'container_format', 'disk_format', 'min_ram', 'min_disk',
 )
 
+# Custom resource for reservable memory
+MEMORY_RESERVABLE_MB_RESOURCE = 'CUSTOM_MEMORY_RESERVABLE_MB'
+MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY = \
+    'resources:' + MEMORY_RESERVABLE_MB_RESOURCE
+
 _FILE_CACHE = {}
 
 _SERVICE_TYPES = service_types.ServiceTypes()

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -41,6 +41,7 @@ from nova import exception
 from nova.i18n import _
 import nova.privsep.path
 from nova import rc_fields as fields
+from nova import utils
 from nova.virt import driver
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import ds_util
@@ -493,6 +494,16 @@ class VMwareVCDriver(driver.ComputeDriver):
                 'min_unit': 1,
                 'max_unit': stats['mem']['max_mem_mb_per_host'],
                 'step_size': 1,
+            }})
+            available_memory_mb = stats['mem']['total'] - reserved_memory_mb
+            result.update({
+                utils.MEMORY_RESERVABLE_MB_RESOURCE: {
+                    'total': available_memory_mb,
+                    'reserved': int(available_memory_mb
+                        * (1 - stats['mem']['vm_reservable_memory_ratio'])),
+                    'min_unit': 1,
+                    'max_unit': stats['mem']['max_mem_mb_per_host'],
+                    'step_size': 1,
             }})
         return result
 

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1533,13 +1533,32 @@ def get_stats_from_cluster(session, cluster):
                                              threads - reserved['vcpus'])
                     max_mem_mb_per_host = max(max_mem_mb_per_host,
                                               mem_mb - reserved['memory_mb'])
+            # NOTE (jakobk): For the total amount of hosts it doesn't matter
+            # whether the host is in MM or unreachable, because the count is
+            # used to calculate safety margins for resource allocations, and MM
+            # or otherwise unreachable hosts is precisely what that is supposed
+            # to guard against.
+            total_hypervisor_count = len(result.objects)
+
+            # Calculate VM-reservable memory as a ratio of total available
+            # memory, depending on either the configured tolerance for failed
+            # hypervisors or a single configurable ratio.
+            max_fail_hvs = \
+                CONF.vmware.memory_reservation_cluster_hosts_max_fail
+            if max_fail_hvs and total_hypervisor_count:
+                vm_reservable_memory_ratio = \
+                    (1 - max_fail_hvs / total_hypervisor_count)
+            else:
+                vm_reservable_memory_ratio = \
+                    CONF.vmware.memory_reservation_max_ratio_fallback
     stats = {'cpu': {'vcpus': vcpus,
                      'max_vcpus_per_host': max_vcpus_per_host,
                      'reserved_vcpus': reserved_vcpus},
              'mem': {'total': total_mem_mb,
                      'free': total_mem_mb - used_mem_mb,
                      'max_mem_mb_per_host': max_mem_mb_per_host,
-                     'reserved_memory_mb': reserved_memory_mb}}
+                     'reserved_memory_mb': reserved_memory_mb,
+                     'vm_reservable_memory_ratio': vm_reservable_memory_ratio}}
     return stats
 
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -364,6 +364,13 @@ class VMwareVMOps(object):
         if CONF.vmware.reserve_all_memory \
                 or utils.is_big_vm(int(flavor.memory_mb), flavor):
             extra_specs.memory_limits.reservation = int(flavor.memory_mb)
+        try:
+            memory_reserved_mb = int(flavor.extra_specs[
+                utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY])
+            if memory_reserved_mb > 0:
+                extra_specs.memory_limits.reservation = memory_reserved_mb
+        except (ValueError, KeyError):
+            pass
         extra_specs.cpu_limits.validate()
         extra_specs.memory_limits.validate()
         extra_specs.disk_io_limits.validate()


### PR DESCRIPTION
See sapcc/nova#159 for previous discussion. This version targets rocky, and fixes a small but significant bug. (See below.)

---

[memreserv] Reserve memory for certain flavors

VMs with reserved memory have better memory allocation performance and less softlock issues. Coincidentally, many larger VMs also have high performance requirements that puts strict demands on the quick availability of their memory.

Implement memory reservation and a configurable maximum number of cluster hosts that could theoretically fail and still let all VMs with memory reservation boot up.

Nova provides the flavor extra_spec "quota:memory_reservation" which reserves the given amount of memory. This change does not make use of that feature, but instead introduces a parallel custom resource "CUSTOM_MEMORY_RESERVABLE_MB". The reason is that "quota:memory_reservation" does not allow for limiting the total amount of reservable memory in the same way the resource provider mechanics do. This is a requirement for tolerating the above-mentioned partial host failures, which can occur because a VMware host is a cluster of hypervisors.

Add a "vm_reservable_memory_ratio" value to the cluster stats in the VMware driver, and use that to calculate and return the MEMORY_RESERVABLE_MB resource from the VMware driver's `get_inventory()`.

---

[memreserv] Add special-spawning trait to BigVM host

A custom trait is added, "CUSTOM_SPECIAL_SPAWNING".

Flavors can set this trait as "required" in order to force spawning on the dedicated BigVM spawn-host (which is kept free). This is done to facilitate spawning for VMs with larger (but not quite as large as BigVM) flavors.

nova.scheduler.client.report.SchedulerReportClient gains two new methods `add_traits_for_provider()` and `remove_traits_for_provider()`.

---

[memreserv] Boot mem-reserved VMs on BigVM spawn-host

To facilitate quickly spawning VMs with memory reservation, the BigVM-anti-affinity group that is usually set on all but the BigVMs, is only set for memory-reserved VMs after it has fully powered up. This makes LargeVMs spawn on the BigVM- reserved host, but then get moved away from it when VMware DRS follows the (now activated) anti-affinity group rule.

---

[bigvm] Don't free host when too much reserved RAM

The logic in BigVmManager to decide whether a cluster is able to free another BigVM spawn-host is changed from only using the total percentage of used memory to using the amount of reserved memory as well.
