### PR TITLE
vmware: Add Mirror-instance-logs-to-syslog config

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -159,6 +159,12 @@ For spawning a VM on a prepared empty host, we need all other VMs to be in a
 DRS VM group that prohibits them from running on the prepared host. This
 setting configures the name of that VM group.
 """),
+    cfg.BoolOpt('mirror_instance_logs_to_syslog',
+        default=False,
+        help="""
+Forward the "vmware.log" files for all instances to the syslog monitoring
+service. The syslog ID string is: [instance UUID] + '_vmx_log'.
+"""),
 ]
 
 vmwareapi_opts = [

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -463,6 +463,12 @@ def get_vm_create_spec(client_factory, instance, data_store_name,
         opt.value = CONF.vmware.smbios_asset_tag
         extra_config.append(opt)
 
+    if CONF.vmware.mirror_instance_logs_to_syslog:
+        opt = client_factory.create('ns0:OptionValue')
+        opt.key = 'vmx.log.syslogID'
+        opt.value = instance.uuid + '_vmx_log'
+        extra_config.append(opt)
+
     # big VMs need to prefer HT threads to stay in NUMA nodes
     if extra_specs.numa_prefer_ht is not None:
         opt = client_factory.create('ns0:OptionValue')


### PR DESCRIPTION
After the instance is deleted in VSphere its syslogs are deleted along with it, which hinders post-mortem debugging.

Add a config flag `forward_instance_logs_to_loginsight` to forward all instance logs to VMware's Loginsight monitoring service, to be able to inspect them after the instance is gone.
