### PR TITLE
Allow multiple flavor aliases for single flavor

### DIFF
--- a/nova/conf/flavors.py
+++ b/nova/conf/flavors.py
@@ -33,8 +33,10 @@ The Nova API does not support a default flavor.
         help="""
 To enable gradual deprecation of old flavor names, the new flavors can specifiy
 an extra_spec key 'catalog:alias', which adds the flavor to the flavor listing
-a second time, only with a different flavorid, and the flavor name replaced by
-the value of 'catalog:alias'.
+a second time (or more), only with a different flavorid, and the flavor name
+replaced by the value of 'catalog:alias'. You can set multiple aliases (so the
+new flavor takes the place of several old flavors) by specifying multiple
+comma-separated aliases.
 
 The flavorid is changed by prepending this config value to the actual flavorid.
 When the flavor with this flavorid is inspected or used to deploy a server, the

--- a/nova/tests/functional/api_sample_tests/test_flavors.py
+++ b/nova/tests/functional/api_sample_tests/test_flavors.py
@@ -138,7 +138,7 @@ class FlavorIdAliasTest(api_sample_base.ApiSampleTestBaseV21):
     def _create_aliased_flavor(self, alias):
         flavors = objects.FlavorList.get_all(self.ctxt)
         self.flavor_id = str(int(flavors[-1].flavorid) + 1)
-        self.flavor_id_alias = self.alias_prefix + self.flavor_id
+        self.flavor_id_alias = self.alias_prefix + self.flavor_id + "_0"
         aliased_flavor = objects.Flavor(
             self.ctxt, memory_mb=2048, vcpus=1, root_gb=20,
             flavorid=self.flavor_id, name='my.flavor',
@@ -169,3 +169,13 @@ class FlavorIdAliasTest(api_sample_base.ApiSampleTestBaseV21):
         response = self._do_get('flavors')
         self.assertNotIn(self.flavor_id_alias,
                          self._response_flavor_ids(response))
+
+    def test_multiple_aliases_list(self):
+        self._create_aliased_flavor('old1,old2, old3')
+        response = self._do_get('flavors')
+        self.assertIn(self.flavor_id_alias,
+                      self._response_flavor_ids(response))
+        self.assertIn(self.flavor_id_alias.replace("_0", "_1"),
+                      self._response_flavor_ids(response))
+        self.assertIn(self.flavor_id_alias.replace("_0", "_2"),
+                      self._response_flavor_ids(response))


### PR DESCRIPTION
During renaming/restructuring of flavors, multiple old flavors get mapped to a single new flavor. But `catalog:alias` on the new flavor previously only accepted a single alias pointing to the deprecated flavor.

The interpretation of `catalog:aliases` extra_spec is changed so that the value can be a single alias name or a comma-separated list of multiple names.

Compare: a6e4b321 - "Alias flavor names from catalog:alias extra_spec"
