### PR TITLE
Memory reservation fixes

### DIFF
--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -411,13 +411,19 @@ class BigVmManager(manager.Manager):
                 continue
             host_rp = vmware_providers[rp['host_rp_uuid']]
             used_percent = host_rp['memory_mb_used_percent']
-            reserved_percent = host_rp['memory_mb_reserved_percent']
-            if used_percent > CONF.bigvm_cluster_max_usage_percent \
-                    or reserved_percent \
-                        > CONF.bigvm_cluster_max_reservation_percent:
+            if used_percent > CONF.bigvm_cluster_max_usage_percent:
                 overused_providers[rp_uuid] = rp
                 LOG.info('Resource-provider %(host_rp_uuid)s with free host '
-                         'is overused. Marking %(rp_uuid)s for deletion.',
+                         'is overused on regular memory usage. Marking '
+                         '%(rp_uuid)s for deletion.',
+                         {'host_rp_uuid': rp['host_rp_uuid'],
+                          'rp_uuid': rp_uuid})
+            reserved_percent = host_rp['memory_mb_reserved_percent']
+            if reserved_percent > CONF.bigvm_cluster_max_reservation_percent:
+                overused_providers[rp_uuid] = rp
+                LOG.info('Resource-provider %(host_rp_uuid)s with free host '
+                         'is overused on reserved memory usage. Marking '
+                         '%(rp_uuid)s for deletion.',
                          {'host_rp_uuid': rp['host_rp_uuid'],
                           'rp_uuid': rp_uuid})
 

--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -418,7 +418,7 @@ class BigVmManager(manager.Manager):
                          '%(rp_uuid)s for deletion.',
                          {'host_rp_uuid': rp['host_rp_uuid'],
                           'rp_uuid': rp_uuid})
-            reserved_percent = host_rp['memory_mb_reserved_percent']
+            reserved_percent = host_rp['memory_reservable_mb_used_percent']
             if reserved_percent > CONF.bigvm_cluster_max_reservation_percent:
                 overused_providers[rp_uuid] = rp
                 LOG.info('Resource-provider %(host_rp_uuid)s with free host '

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1077,6 +1077,16 @@ class VMwareVMOpsTestCase(test.TestCase):
                                              self._image_meta)
         self.assertIsNone(specs.memory_limits.reservation)
 
+    def test_global_reserve_all_memory_overrides_flavor_setting(self):
+        self.flags(group='vmware', reserve_all_memory=True)
+        self._instance.flavor.extra_specs.update({
+            utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY:
+                self._instance.flavor.memory_mb // 2})
+        specs = self._vmops._get_extra_specs(self._instance.flavor,
+                                             self._image_meta)
+        self.assertEqual(specs.memory_limits.reservation,
+                         self._instance.flavor.memory_mb)  # ie NOT memory_mb/2
+
     @mock.patch.object(vmops.VMwareVMOps, '_extend_virtual_disk')
     @mock.patch.object(ds_util, 'disk_move')
     @mock.patch.object(ds_util, 'disk_copy')

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1087,6 +1087,16 @@ class VMwareVMOpsTestCase(test.TestCase):
         self.assertEqual(specs.memory_limits.reservation,
                          self._instance.flavor.memory_mb)  # ie NOT memory_mb/2
 
+    def test_reserve_max_flavor_memory_for_memory_reserved_flavor(self):
+        self.flags(group='vmware', reserve_all_memory=False)
+        self._instance.flavor.extra_specs.update({
+            utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY:
+                self._instance.flavor.memory_mb + 1000})
+        specs = self._vmops._get_extra_specs(self._instance.flavor,
+                                             self._image_meta)
+        self.assertEqual(specs.memory_limits.reservation,
+                         self._instance.flavor.memory_mb)
+
     @mock.patch.object(vmops.VMwareVMOps, '_extend_virtual_disk')
     @mock.patch.object(ds_util, 'disk_move')
     @mock.patch.object(ds_util, 'disk_copy')

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -369,7 +369,8 @@ class VMwareVMOps(object):
                 memory_reserved_mb = int(flavor.extra_specs[
                     utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY])
                 if memory_reserved_mb > 0:
-                    extra_specs.memory_limits.reservation = memory_reserved_mb
+                    extra_specs.memory_limits.reservation = min(
+                        int(flavor.memory_mb), memory_reserved_mb)
             except (ValueError, KeyError):
                 pass
         extra_specs.cpu_limits.validate()

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -364,13 +364,14 @@ class VMwareVMOps(object):
         if CONF.vmware.reserve_all_memory \
                 or utils.is_big_vm(int(flavor.memory_mb), flavor):
             extra_specs.memory_limits.reservation = int(flavor.memory_mb)
-        try:
-            memory_reserved_mb = int(flavor.extra_specs[
-                utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY])
-            if memory_reserved_mb > 0:
-                extra_specs.memory_limits.reservation = memory_reserved_mb
-        except (ValueError, KeyError):
-            pass
+        else:
+            try:
+                memory_reserved_mb = int(flavor.extra_specs[
+                    utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY])
+                if memory_reserved_mb > 0:
+                    extra_specs.memory_limits.reservation = memory_reserved_mb
+            except (ValueError, KeyError):
+                pass
         extra_specs.cpu_limits.validate()
         extra_specs.memory_limits.validate()
         extra_specs.disk_io_limits.validate()


### PR DESCRIPTION
- Split BigVM memory overuse trigger log messages
- Fix reserved-memory-usage RP lookup key name in BigVM manager
- Only use flavor-reserved-memory when not reserving all memory (via config or for BigVM)
- Prohibit reserving more memory than the flavor has specified
