### PR TITLE
bigvm/hostsizefilter: Pass filter if NUMA trait required

### DIFF
--- a/nova/scheduler/filters/bigvm_filter.py
+++ b/nova/scheduler/filters/bigvm_filter.py
@@ -112,6 +112,7 @@ class BigVmFlavorHostSizeFilter(BigVmBaseFilter):
     """
     _EXTRA_SPECS_KEY = 'host_fraction'
     _HV_SIZE_TOLERANCE_PERCENT = 10
+    _NUMA_TRAIT_SPEC_PREFIX = 'trait:CUSTOM_NUMASIZE_'
 
     def _memory_match_with_tolerance(self, memory_mb, requested_ram_mb):
         """Return True if requested_ram_mb is equal to memory_mb or down to
@@ -120,14 +121,34 @@ class BigVmFlavorHostSizeFilter(BigVmBaseFilter):
         tolerance = memory_mb * self._HV_SIZE_TOLERANCE_PERCENT / 100.0
         return memory_mb - tolerance <= requested_ram_mb <= memory_mb
 
+    def _get_numa_trait_requirement(self, extra_specs):
+        """Return the (first) extra_specs key for required numa host traits."""
+        try:
+            return next(k for k, v in extra_specs.items()
+                        if k.startswith(self._NUMA_TRAIT_SPEC_PREFIX)
+                            and v == "required")
+        except StopIteration:
+            return None
+
     def _check_flavor_extra_specs(self, host_state, flavor,
                                   hypervisor_ram_mb, requested_ram_mb):
         """Use a flavor attribute to define the fraction of the host this VM
         should match.
         """
         extra_specs = flavor.extra_specs
-        # if there's no definition in the big VM flavor, we cannot make an
-        # informed decision and bail out
+
+        # Check if we ask for a specific NUMA trait and if so we assume this
+        # cluster already matched via trait requirement in placement.
+        numa_trait_spec = self._get_numa_trait_requirement(extra_specs)
+        if numa_trait_spec:
+            LOG.debug('Flavor %(flavor_name)s has NUMA host requirement '
+                      '%(numa_trait) set. Host-fraction filtering ignored.',
+                      {'flavor_name': flavor.name,
+                       'numa_trait': numa_trait_spec.replace('trait:', '')})
+            return True
+
+        # if numa trait is not set and there's no host_fraction definition in
+        # the big VM flavor, we cannot make an informed decision and bail out
         if self._EXTRA_SPECS_KEY not in extra_specs:
             LOG.info('Flavor %(flavor_name)s has no extra_specs.'
                      '%(specs_key)s. Cannot schedule on %(host_state)s.',

--- a/nova/tests/unit/scheduler/filters/test_bigvm_filters.py
+++ b/nova/tests/unit/scheduler/filters/test_bigvm_filters.py
@@ -336,3 +336,25 @@ class TestBigVmFlavorHostSizeFilter(test.NoDBTestCase):
         host = fakes.FakeHostState('host1', 'compute',
                 {'uuid': uuidsentinel.host1})
         self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_extra_specs_has_numa_trait_required(self):
+        """test trait:CUSTOM_NUMASIZE_*=required passes filter"""
+        extra_specs = {'trait:CUSTOM_NUMASIZE_C1_M1': 'required'}
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
+                                  extra_specs=extra_specs,
+                                  name='random-name'))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_extra_specs_has_numa_trait_not_required(self):
+        """test trait:CUSTOM_NUMASIZE_*=forbidden fails filter"""
+        extra_specs = {'trait:CUSTOM_NUMASIZE_C1_M1': 'forbidden'}
+        spec_obj = objects.RequestSpec(
+            flavor=objects.Flavor(memory_mb=CONF.bigvm_mb,
+                                  extra_specs=extra_specs,
+                                  name='random-name'))
+        host = fakes.FakeHostState('host1', 'compute',
+                {'uuid': uuidsentinel.host1})
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))


### PR DESCRIPTION
If one of the new `CUSTOM_NUMASIZE_*` host traits is required on a (BigVM) flavor, then the host was already matched in placement, and the filter can succeed early.

This is a temporary measure until we phase out host-fraction filtering altogether when the old BigVM flavors are disabled.
