### PR TITLE
Optimize quota:separate query

### DIFF
--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -1553,13 +1553,22 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
                 if missing_itypes:
                     # Not found in flavor db. might be deleted. get it from the
                     # saved info
-                    db_flavors = context.session.query(
-                            models.InstanceExtra.flavor
-                        ).join(models.Instance). \
-                        filter(
+                    iquery = context.session.query(
+                            models.Instance.uuid
+                        ).filter(
                             models.Instance.instance_type_id.
                             in_(missing_itypes)
-                        ).distinct(models.Instance.instance_type_id)
+                        ).group_by(
+                            models.Instance.instance_type_id
+                        ).subquery()
+
+                    db_flavors = context.session.query(
+                            models.InstanceExtra.flavor
+                        ).join(
+                            iquery,
+                            models.InstanceExtra.instance_uuid == iquery.c.uuid
+                        )
+
                     for db_flavor in db_flavors:
                         flavor_info = jsonutils.loads(db_flavor[0])
                         flavor = objects.Flavor.obj_from_primitive(


### PR DESCRIPTION
Probably with switching to mariadb, the query got too slow in bigger
regions, because mariadb joins the instance_extra and the instances
table, which have more than 100.000 rows in a bigger region. Since we
only need one instance_extra entry per missing flavor, we force mariadb
to use a temporary table to join against instance_extra, which is much
faster it only contains as many rows as we're missing flavors.

Attention: This code probably doesn't run on PostgresSQL anymore,
because "GROUP BY" doesn't behave the same way there.

Change-Id: If0e95cd1d62c00490dc86ca6273e07f8d2fd98ac