### PR TITLE
shard_filter: debug log for ironic nodes without VC aggregate

### DIFF
--- a/nova/scheduler/filters/shard_filter.py
+++ b/nova/scheduler/filters/shard_filter.py
@@ -123,10 +123,12 @@ class ShardFilter(filters.BaseHostFilter):
 
         host_shard_names = set(aggr.name for aggr in host_shard_aggrs)
         if not host_shard_names:
-            LOG.error('%(host_state)s is not in an aggregate starting with '
-                      '%(shard_prefix)s.',
-                      {'host_state': host_state,
-                       'shard_prefix': self._SHARD_PREFIX})
+            log_method = (LOG.debug if nova_utils.is_baremetal_host(host_state)
+                          else LOG.error)
+            log_method('%(host_state)s is not in an aggregate starting with '
+                       '%(shard_prefix)s.',
+                       {'host_state': host_state,
+                        'shard_prefix': self._SHARD_PREFIX})
             return False
 
         # forbid changing the shard of an instance

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -1401,6 +1401,10 @@ def is_baremetal_flavor(flavor):
     return 'capabilities:cpu_arch' in flavor.extra_specs
 
 
+def is_baremetal_host(host_state):
+    return host_state.hypervisor_type == 'ironic'
+
+
 def is_big_vm(memory_mb, flavor):
     # small VMs are not big
     if memory_mb < CONF.bigvm_mb:


### PR DESCRIPTION
We don't expect ironic nodes to be in a vc-* host aggregate,
therefore we log it to debug instead of error for such nodes.