### PR TITLE
Do not block on reservation

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -1730,8 +1730,11 @@ class ComputeManager(manager.Manager):
             return self.driver.get_device_name_for_instance(
                 instance, bdms, block_device_obj)
         except NotImplementedError:
-            return compute_utils.get_device_name_for_instance(
-                instance, bdms, block_device_obj.get("device_name"))
+            @utils.synchronized(instance.uuid + "-bdms")
+            def _do_get_device_name_for_instance():
+                return compute_utils.get_device_name_for_instance(
+                    instance, bdms, block_device_obj.get("device_name"))
+            return _do_get_device_name_for_instance()
 
     def _default_block_device_names(self, instance, image_meta, block_devices):
         """Verify that all the devices have the device_name set. If not,
@@ -5804,7 +5807,22 @@ class ComputeManager(manager.Manager):
             raise exception.MultiattachNotSupportedByVirtDriver(
                 volume_id=volume_id)
 
-        @utils.synchronized(instance.uuid)
+        # There is only one driver, which calls out to the hypervisor for that,
+        # so we need to lock the instance against manipulations
+        # Otherwise, we can do our own logic and have to synchronise that
+        # Since we do NOT hold a lock on instance level, we need to introduce
+        # one on the instance bdm level in _get_device_name_for_instance, so
+        # that we are protected against concurrency issues with other calls to
+        # that function
+        driver_specific_device_name = self.driver.capabilities.get(
+            "driver_specific_device_name", False)
+        if driver_specific_device_name:
+            synchronized = utils.synchronized(instance.uuid)
+        else:
+            def synchronized(f):
+                return f
+
+        @synchronized
         def do_reserve():
             bdms = (
                 objects.BlockDeviceMappingList.get_by_instance_uuid(

--- a/nova/virt/driver.py
+++ b/nova/virt/driver.py
@@ -133,6 +133,7 @@ class ComputeDriver(object):
         "supports_extend_volume": False,
         "supports_multiattach": False,
         "supports_trusted_certs": False,
+        "driver_specific_device_name": False
     }
 
     requires_allocation_refresh = False

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -322,6 +322,7 @@ class LibvirtDriver(driver.ComputeDriver):
         # determined in init_host.
         "supports_multiattach": False,
         "supports_trusted_certs": True,
+        "driver_specific_device_name": True
     }
 
     def __init__(self, virtapi, read_only=False):


### PR DESCRIPTION
The attachment operation may potentially be long-running,
so a batch of attachments/reservations may be causing a rpc timeout.
The compute node still blocks on the lock and creates a bdm regardless.

This replaces the instance lock with a bdm specific lock on
bdm allocation.

That means reserving a device name can run concurrently with
detaching a volume.

This will likely create a different behaviour, but since the
value has a non-zero probability of being wrong anyway,
we risk it being wrong more often.