### PR TITLE
Revert "[api] Prohibit certain VMs from joining server groups"

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -1231,13 +1231,6 @@ class API(base.Base):
         instance_group = self._get_requested_instance_group(context,
                                    filter_properties)
 
-        if instance_group and utils.vm_needs_special_spawning(
-                                                    base_options['memory_mb'],
-                                                    instance_type):
-            msg = 'This type of VM cannot be assigned to server groups ' \
-                  'because of its scheduling requirements.'
-            raise exception.InvalidRequest(msg)
-
         tags = self._create_tag_list_obj(context, tags)
 
         instances_to_build = self._provision_instances(

--- a/nova/tests/unit/api/openstack/compute/test_serversV21.py
+++ b/nova/tests/unit/api/openstack/compute/test_serversV21.py
@@ -4467,26 +4467,6 @@ class ServersControllerCreateTest(test.TestCase):
         self.assertRaises(exception.ValidationError,
                           self.controller.create, self.req, body=self.body)
 
-    def test_create_instance_with_group_hint_big_vm(self):
-        ctxt = self.req.environ['nova.context']
-        test_group = objects.InstanceGroup(ctxt)
-        test_group.project_id = ctxt.project_id
-        test_group.user_id = ctxt.user_id
-        test_group.create()
-
-        CONF.set_override('bigvm_mb', 512)
-
-        def fake_instance_destroy(context, uuid, constraint):
-            return fakes.stub_instance(1)
-
-        self.stub_out('nova.db.instance_destroy', fake_instance_destroy)
-        self.body['os:scheduler_hints'] = {'group': test_group.uuid}
-        self.req.body = jsonutils.dump_as_bytes(self.body)
-        self.assertRaisesRegex(webob.exc.HTTPBadRequest,
-                               r'because of its scheduling requirements',
-                               self.controller.create, self.req,
-                               body=self.body)
-
     def test_create_server_bad_hints_non_dict(self):
         sch_hints = ['os:scheduler_hints', 'OS-SCH-HNT:scheduler_hints']
         for hint in sch_hints:


### PR DESCRIPTION
This reverts commit 79693220128d7a5ceb2b76b5d3c3ce765d4dbd9f.

After some discussion, we want to enable big VMs for
affinity/anti-affinity again. This is a requirement by one customer, who
wants to run a Hana with a replica and make sure they're not on the same
host. While we never spawn big VMs on the same host, we might move them
around. Whatever tooling we use for that needs to take the DRS rules
into account then.

Not using soft-(anti-)affinity might lead to VMs being unspawnable, if
the free host happens to be in the wrong cluster.