### PR TITLE
Cherry-Pick: vmware: Handle folder renames in rescue cmd

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -441,7 +441,7 @@ class VMwareVMOpsTestCase(test.TestCase):
         backing = vmwareapi_fake.DataObject()
         backing.datastore = ds.ref
         device.backing = backing
-        vmdk = vm_util.VmdkInfo('[fake] uuid/root.vmdk',
+        vmdk = vm_util.VmdkInfo('[fake] test (uuid)/root.vmdk',
                                 'fake-adapter',
                                 'fake-disk',
                                 'fake-capacity',
@@ -462,7 +462,8 @@ class VMwareVMOpsTestCase(test.TestCase):
 
             uuid = self._instance.image_ref
             cache_path = ds.build_path('vmware_base', uuid, uuid + '.vmdk')
-            rescue_path = ds.build_path(self._uuid, uuid + '-rescue.vmdk')
+            vm_folder = ds_obj.DatastorePath.parse(vmdk.path).dirname
+            rescue_path = ds.build_path(vm_folder, uuid + '-rescue.vmdk')
 
             mock_disk_copy.assert_called_once_with(self._session, dc_info.ref,
                              cache_path, rescue_path)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1803,7 +1803,8 @@ class VMwareVMOps(object):
         self._fetch_image_if_missing(context, vi)
 
         # Get the rescue disk path
-        rescue_disk_path = datastore.build_path(instance.uuid,
+        vm_folder = ds_obj.DatastorePath.parse(vmdk.path).dirname
+        rescue_disk_path = datastore.build_path(vm_folder,
                 "%s-rescue.%s" % (image_info.image_id, image_info.file_type))
 
         # Copy the cached image to the be the rescue disk. This will be used


### PR DESCRIPTION
When a VM is storage-vMotioned, the name of the folder its files are in
can change. Then, a rescue command trying to put the rescue disk into a
folder named after the instance's UUID cannot work anymore and actually
raises a FileNotFoundException for the directory path.

To fix this, we now take the root VMDK's folder and copy the rescue
image into that.

Change-Id: Icef785b96e51942e7bac2df10c116078c77fedc4
Closes-Bug: #1915815