### PR TITLE
vmware: Do not reraise exception on DRS override removal

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1987,12 +1987,9 @@ class VMwareVMOps(object):
                                                             self._cluster,
                                                             vm_ref,
                                                             operation='remove')
-            except vexc.VimFaultException as e:
-                with excutils.save_and_reraise_exception() as ctx:
-                    if 'InvalidArgument' in e.fault_list:
-                        LOG.debug('DRS override was already deleted.',
-                                  instance=instance)
-                        ctx.reraise = False
+            except Exception:
+                LOG.exception('Could not remove DRS override.',
+                              instance=instance)
 
         self._clean_up_after_special_spawning(context, flavor.memory_mb,
                                               flavor)


### PR DESCRIPTION
We're currently unable to remove a DRS override as our SOAP library is
unable to create an appropriate request accepted by the vCenter.
Therefore, we still allow the resize to work for now and have to
manually remove the override later on.

We keep the code in, so we get a reminder in the logs and sentry, that
this needs fixing. We just don't fail the resize for it.

Change-Id: I4d344347860c7d97d6f4b2e68d9bbac069d71b74