### PR TITLE
Server Creation with Block Device Mapping with Cinder 3.44+ Volume Attachments

### DIFF
--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -16880,7 +16880,8 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                      'destination_type': 'volume',
                      'volume_id': 'fake-image-id',
                      'device_name': '/dev/vdxx',
-                     'disk_bus': 'scsi'}))]
+                     'disk_bus': 'scsi',
+                     'attachment_id': None}))]
 
         drvr = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), False)
         drvr.default_device_names_for_instance(instance,

--- a/nova/tests/unit/virt/test_block_device.py
+++ b/nova/tests/unit/virt/test_block_device.py
@@ -119,6 +119,30 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         'connection_info': {"fake": "connection_info"},
         'delete_on_termination': False}
 
+    volume_bdm_dict_without_conn_info = block_device.BlockDeviceDict(
+        {'id': 3, 'instance_uuid': uuids.instance,
+         'device_name': '/dev/sda1',
+         'source_type': 'volume',
+         'disk_bus': 'scsi',
+         'device_type': 'disk',
+         'volume_size': 8,
+         'destination_type': 'volume',
+         'volume_id': 'fake-volume-id-1',
+         'guest_format': 'ext4',
+         'connection_info': None,
+         'delete_on_termination': False,
+         'boot_index': 0})
+
+    volume_driver_bdm_without_conn_info = {
+        'attachment_id': None,
+        'mount_device': '/dev/sda1',
+        'connection_info': {},
+        'delete_on_termination': False,
+        'disk_bus': 'scsi',
+        'device_type': 'disk',
+        'guest_format': 'ext4',
+        'boot_index': 0}
+
     volsnapshot_bdm_dict = block_device.BlockDeviceDict(
         {'id': 4, 'instance_uuid': uuids.instance,
          'device_name': '/dev/sda2',
@@ -215,6 +239,8 @@ class TestDriverBlockDevice(test.NoDBTestCase):
             self.context, self.ephemeral_bdm_dict)
         self.volume_bdm = fake_block_device.fake_bdm_object(
             self.context, self.volume_bdm_dict)
+        self.volume_bdm_without_conn_info = fake_block_device.fake_bdm_object(
+            self.context, self.volume_bdm_dict_without_conn_info)
         self.volsnapshot_bdm = fake_block_device.fake_bdm_object(
             self.context, self.volsnapshot_bdm_dict)
         self.volimage_bdm = fake_block_device.fake_bdm_object(
@@ -1189,6 +1215,11 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         self.assertEqual(self.volsnapshot_driver_bdm,
                          driver_block_device.convert_volume(
                              self.volsnapshot_bdm))
+
+    def test_convert_volume_without_connection_info(self):
+        self.assertEqual(self.volume_driver_bdm_without_conn_info,
+                         driver_block_device.convert_volume(
+                             self.volume_bdm_without_conn_info))
 
     def test_legacy_block_devices(self):
         test_snapshot = self.driver_classes['volsnapshot'](

--- a/nova/tests/unit/virt/test_block_device.py
+++ b/nova/tests/unit/virt/test_block_device.py
@@ -228,8 +228,8 @@ class TestDriverBlockDevice(test.NoDBTestCase):
 
     def setUp(self):
         super(TestDriverBlockDevice, self).setUp()
-        self.volume_api = self.mox.CreateMock(cinder.API)
-        self.virt_driver = self.mox.CreateMock(driver.ComputeDriver)
+        self.volume_api = mock.MagicMock(autospec=cinder.API)
+        self.virt_driver = mock.MagicMock(autospec=driver.ComputeDriver)
         self.context = context.RequestContext('fake_user',
                                               'fake_project')
         # create bdm objects for testing
@@ -508,23 +508,28 @@ class TestDriverBlockDevice(test.NoDBTestCase):
     def test_volume_delete_attachment_with_shared_targets(self):
         self.test_volume_delete_attachment(include_shared_targets=True)
 
+    @mock.patch.object(encryptors, 'get_encryption_metadata')
+    @mock.patch.object(objects.BlockDeviceMapping, 'save')
     def _test_volume_attach(self, driver_bdm, bdm_dict,
-                            fake_volume, fail_check_av_zone=False,
+                            fake_volume, mock_save, mock_get_encry,
+                            fail_check_av_zone=False,
                             driver_attach=False, fail_driver_attach=False,
                             volume_attach=True, fail_volume_attach=False,
                             access_mode='rw', availability_zone=None,
                             multiattach=False, driver_multi_attach=False,
                             fail_with_virt_driver=False,
-                            include_shared_targets=False):
+                            include_shared_targets=False,
+                            wait_func=None):
+        expected_save_calls = []
         if driver_multi_attach:
-            self.virt_driver.capabilities['supports_multiattach'] = True
+            # 'supports_multiattach' is True
+            self.virt_driver.capabilities.get.return_value = True
         else:
-            self.virt_driver.capabilities['supports_multiattach'] = False
+            # 'supports_multiattach' is False
+            self.virt_driver.capabilities.get.return_value = False
         elevated_context = self.context.elevated()
-        self.stubs.Set(self.context, 'elevated',
-                       lambda: elevated_context)
-        self.mox.StubOutWithMock(driver_bdm._bdm_obj, 'save')
-        self.mox.StubOutWithMock(encryptors, 'get_encryption_metadata')
+        self.stub_out('nova.context.RequestContext.elevated',
+                      lambda s: elevated_context)
         instance_detail = {'id': '123', 'uuid': uuids.uuid,
                            'availability_zone': availability_zone}
         instance = fake_instance.fake_instance_obj(self.context,
@@ -540,113 +545,168 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         if include_shared_targets:
             fake_volume['shared_targets'] = True
             fake_volume['service_uuid'] = uuids.service_uuid
-            self.volume_api.get(
-                self.context, fake_volume['id'],
-                microversion='3.48').AndReturn(fake_volume)
+            self.volume_api.get.return_value = fake_volume
         else:
             # First call to get() fails because the API isn't new enough.
-            self.volume_api.get(
-                self.context, fake_volume['id'], microversion='3.48').AndRaise(
-                    exception.CinderAPIVersionNotAvailable(version='3.48'))
             # So we fallback to the old call.
-            self.volume_api.get(self.context,
-                                fake_volume['id']).AndReturn(fake_volume)
+            self.volume_api.get.side_effect = [
+                exception.CinderAPIVersionNotAvailable(version='3.48'),
+                fake_volume]
 
-        if not fail_check_av_zone:
-            self.volume_api.check_availability_zone(self.context,
-                                fake_volume,
-                                instance=instance).AndReturn(None)
-        else:
-            self.volume_api.check_availability_zone(self.context,
-                                fake_volume,
-                                instance=instance).AndRaise(
-                                        test.TestingException)
-            # The @update_db decorator will save any changes.
-            driver_bdm._bdm_obj.save().AndReturn(None)
-            return instance, expected_conn_info
-
-        self.virt_driver.get_volume_connector(instance).AndReturn(connector)
-
-        if fail_with_virt_driver:
-            driver_bdm._bdm_obj.save().AndReturn(None)
-            return instance, expected_conn_info
-
-        if self.attachment_id is None:
-            self.volume_api.initialize_connection(
-                elevated_context, fake_volume['id'],
-                connector).AndReturn(connection_info)
-        else:
-            self.volume_api.attachment_update(
-                elevated_context, self.attachment_id, connector,
-                bdm_dict['device_name']).AndReturn(
-                    {'connection_info': connection_info})
-
-        if driver_attach:
-            encryptors.get_encryption_metadata(
-                    elevated_context, self.volume_api, fake_volume['id'],
-                    connection_info).AndReturn(enc_data)
-            if not fail_driver_attach:
-                self.virt_driver.attach_volume(
-                        elevated_context, expected_conn_info, instance,
-                        bdm_dict['device_name'],
-                        disk_bus=bdm_dict['disk_bus'],
-                        device_type=bdm_dict['device_type'],
-                        encryption=enc_data).AndReturn(None)
-            else:
-                self.virt_driver.attach_volume(
-                        elevated_context, expected_conn_info, instance,
-                        bdm_dict['device_name'],
-                        disk_bus=bdm_dict['disk_bus'],
-                        device_type=bdm_dict['device_type'],
-                        encryption=enc_data).AndRaise(test.TestingException)
-                if self.attachment_id is None:
-                    self.volume_api.terminate_connection(
-                            elevated_context, fake_volume['id'],
-                            connector).AndReturn(None)
-                else:
-                    self.volume_api.attachment_delete(
-                        elevated_context, self.attachment_id).AndReturn(None)
+        try:
+            if fail_check_av_zone:
+                self.volume_api.check_availability_zone.side_effect = (
+                    test.TestingException())
                 # The @update_db decorator will save any changes.
-                driver_bdm._bdm_obj.save().AndReturn(None)
-                return instance, expected_conn_info
+                expected_save_calls.append(mock.call())
+                # Exit setting mock
+                raise test.TestingException()
 
-        if volume_attach:
-            # save updates before marking the volume as in-use
-            driver_bdm._bdm_obj.save().AndReturn(None)
-            if not fail_volume_attach:
-                if self.attachment_id is None:
-                    self.volume_api.attach(elevated_context, fake_volume['id'],
-                                           uuids.uuid, bdm_dict['device_name'],
-                                            mode=access_mode).AndReturn(None)
-                else:
-                    self.volume_api.attachment_complete(
-                        elevated_context, self.attachment_id).AndReturn(None)
+            self.virt_driver.get_volume_connector.return_value = connector
+
+            if fail_with_virt_driver:
+                expected_save_calls.append(mock.call())
+                # Exit setting mock
+                raise test.TestingException()
+
+            if self.attachment_id is None:
+                self.volume_api.initialize_connection.return_value = (
+                    connection_info)
             else:
-                if self.attachment_id is None:
-                    self.volume_api.attach(elevated_context, fake_volume['id'],
-                                           uuids.uuid, bdm_dict['device_name'],
-                                            mode=access_mode).AndRaise(
-                                                test.TestingException)
-                    if driver_attach:
-                        self.virt_driver.detach_volume(
-                            self.context, expected_conn_info, instance,
-                            bdm_dict['device_name'],
-                            encryption=enc_data).AndReturn(None)
-                    self.volume_api.terminate_connection(
-                        elevated_context, fake_volume['id'],
-                        connector).AndReturn(None)
-                    self.volume_api.detach(elevated_context,
-                                           fake_volume['id']).AndReturn(None)
-                else:
-                    self.volume_api.attachment_complete(
-                        elevated_context, self.attachment_id).AndRaise(
-                            test.TestingException)
-                    self.volume_api.attachment_delete(
-                        elevated_context, self.attachment_id).AndReturn(None)
+                self.volume_api.attachment_update.return_value = {
+                    'connection_info': connection_info}
 
-        # The @update_db decorator will save any changes.
-        driver_bdm._bdm_obj.save().AndReturn(None)
-        return instance, expected_conn_info
+            if driver_attach:
+                mock_get_encry.return_value = enc_data
+                if fail_driver_attach:
+                    self.virt_driver.attach_volume.side_effect = (
+                        test.TestingException())
+                    # The @update_db decorator will save any changes.
+                    expected_save_calls.append(mock.call())
+                    # Exit setting mock
+                    raise test.TestingException()
+
+            if volume_attach:
+                # save updates before marking the volume as in-use
+                expected_save_calls.append(mock.call())
+                if fail_volume_attach:
+                    if self.attachment_id is None:
+                        self.volume_api.attach.side_effect = (
+                            test.TestingException())
+                    else:
+                        self.volume_api.attachment_complete.side_effect = (
+                            test.TestingException())
+
+            # The @update_db decorator will save any changes.
+            expected_save_calls.append(mock.call())
+        except test.TestingException:
+            pass
+
+        if multiattach and fail_with_virt_driver:
+            self.assertRaises(exception.MultiattachNotSupportedByVirtDriver,
+                              driver_bdm.attach, self.context, instance,
+                              self.volume_api, self.virt_driver)
+        elif fail_check_av_zone or fail_driver_attach or fail_volume_attach:
+            self.assertRaises(test.TestingException, driver_bdm.attach,
+                              self.context, instance, self.volume_api,
+                              self.virt_driver,
+                              do_driver_attach=driver_attach)
+        else:
+            if wait_func:
+                driver_bdm.attach(self.context, instance,
+                                  self.volume_api, self.virt_driver,
+                                  wait_func)
+            else:
+                driver_bdm.attach(self.context, instance,
+                                  self.volume_api, self.virt_driver,
+                                  do_driver_attach=driver_attach)
+                self.assertThat(driver_bdm['connection_info'],
+                                matchers.DictMatches(expected_conn_info))
+
+        if include_shared_targets:
+            self.volume_api.get.assert_called_once_with(
+                self.context, fake_volume['id'], microversion='3.48')
+        else:
+            # First call to get() fails because the API isn't new enough.
+            # So we fallback to the old call.
+            self.volume_api.get.assert_has_calls([
+                mock.call(self.context, fake_volume['id'],
+                          microversion='3.48'),
+                mock.call(self.context, fake_volume['id'])])
+
+        try:
+            self.volume_api.check_availability_zone.assert_called_once_with(
+                self.context, fake_volume, instance=instance)
+            if fail_check_av_zone:
+                # Exit assert calls
+                raise test.TestingException()
+
+            self.virt_driver.get_volume_connector.assert_called_once_with(
+                instance)
+
+            if fail_with_virt_driver:
+                raise test.TestingException()
+
+            if self.attachment_id is None:
+                self.volume_api.initialize_connection.assert_called_once_with(
+                    elevated_context, fake_volume['id'], connector)
+            else:
+                self.volume_api.attachment_update.assert_called_once_with(
+                    elevated_context, self.attachment_id, connector,
+                    bdm_dict['device_name'])
+
+            if driver_attach:
+                mock_get_encry.assert_called_once_with(
+                    elevated_context, self.volume_api, fake_volume['id'],
+                    connection_info)
+                self.virt_driver.attach_volume.assert_called_once_with(
+                    elevated_context, expected_conn_info, instance,
+                    bdm_dict['device_name'], disk_bus=bdm_dict['disk_bus'],
+                    device_type=bdm_dict['device_type'], encryption=enc_data)
+                if fail_driver_attach:
+                    if self.attachment_id is None:
+                        mock_terminate = self.volume_api.terminate_connection
+                        mock_terminate.assert_called_once_with(
+                            elevated_context, fake_volume['id'], connector)
+                    else:
+                        mock_att_delete = self.volume_api.attachment_delete
+                        mock_att_delete.assert_called_once_with(
+                            elevated_context, self.attachment_id)
+                    # Exit assert calls
+                    raise test.TestingException()
+
+            if volume_attach:
+                if not fail_volume_attach:
+                    if self.attachment_id is None:
+                        self.volume_api.attach.assert_called_once_with(
+                            elevated_context, fake_volume['id'], uuids.uuid,
+                            bdm_dict['device_name'], mode=access_mode)
+                    else:
+                        mock_att_complete = self.volume_api.attachment_complete
+                        mock_att_complete.assert_called_once_with(
+                            elevated_context, self.attachment_id)
+                else:
+                    if self.attachment_id is None:
+                        self.volume_api.attach.assert_called_once_with(
+                            elevated_context, fake_volume['id'], uuids.uuid,
+                            bdm_dict['device_name'], mode=access_mode)
+                        mock_terminate = self.volume_api.terminate_connection
+                        mock_terminate.assert_called_once_with(
+                            elevated_context, fake_volume['id'], connector)
+                        self.volume_api.detach.assert_called_once_with(
+                            elevated_context, fake_volume['id'])
+                    else:
+                        mock_att_complete = self.volume_api.attachment_complete
+                        mock_att_complete.assert_called_once_with(
+                            elevated_context, self.attachment_id)
+                        mock_att_delete = self.volume_api.attachment_delete
+                        mock_att_delete.assert_called_once_with(
+                            elevated_context, self.attachment_id)
+        except test.TestingException:
+            pass
+
+        if expected_save_calls:
+            mock_save.assert_has_calls(expected_save_calls)
 
     def test_volume_attach(self, include_shared_targets=False):
         test_bdm = self.driver_classes['volume'](
@@ -654,16 +714,8 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-1',
                   'attach_status': 'detached'}
 
-        instance, expected_conn_info = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume,
-                include_shared_targets=include_shared_targets)
-
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance,
-                        self.volume_api, self.virt_driver)
-        self.assertThat(test_bdm['connection_info'],
-                        matchers.DictMatches(expected_conn_info))
+        self._test_volume_attach(test_bdm, self.volume_bdm, volume,
+                                 include_shared_targets=include_shared_targets)
 
     def test_volume_attach_with_shared_targets(self):
         self.test_volume_attach(include_shared_targets=True)
@@ -673,15 +725,8 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-1',
                   'attach_status': 'detached'}
 
-        instance, expected_conn_info = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume, access_mode='ro')
-
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance,
-                        self.volume_api, self.virt_driver)
-        self.assertThat(test_bdm['connection_info'],
-                        matchers.DictMatches(expected_conn_info))
+        self._test_volume_attach(
+            test_bdm, self.volume_bdm, volume, access_mode='ro')
 
     def test_volume_attach_update_size(self):
         test_bdm = self.driver_classes['volume'](self.volume_bdm)
@@ -690,14 +735,7 @@ class TestDriverBlockDevice(test.NoDBTestCase):
                   'attach_status': 'detached',
                   'size': 42}
 
-        instance, expected_conn_info = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume)
-
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance,
-                        self.volume_api, self.virt_driver)
-        self.assertEqual(expected_conn_info, test_bdm['connection_info'])
+        self._test_volume_attach(test_bdm, self.volume_bdm, volume)
         self.assertEqual(42, test_bdm.volume_size)
 
     def test_volume_attach_check_av_zone_fails(self):
@@ -705,12 +743,8 @@ class TestDriverBlockDevice(test.NoDBTestCase):
             self.volume_bdm)
         volume = {'id': 'fake-volume-id-1'}
 
-        instance, _ = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume, fail_check_av_zone=True)
-        self.mox.ReplayAll()
-
-        self.assertRaises(test.TestingException, test_bdm.attach, self.context,
-                         instance, self.volume_api, self.virt_driver)
+        self._test_volume_attach(test_bdm, self.volume_bdm, volume,
+                                 fail_check_av_zone=True)
 
     def test_volume_no_volume_attach(self):
         test_bdm = self.driver_classes['volume'](
@@ -718,16 +752,8 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-1',
                   'attach_status': 'detached'}
 
-        instance, expected_conn_info = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume, driver_attach=False)
-
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance,
-                        self.volume_api, self.virt_driver,
-                        do_driver_attach=False)
-        self.assertThat(test_bdm['connection_info'],
-                        matchers.DictMatches(expected_conn_info))
+        self._test_volume_attach(test_bdm, self.volume_bdm, volume,
+                                 driver_attach=False)
 
     def test_volume_attach_no_check_driver_attach(self):
         test_bdm = self.driver_classes['volume'](
@@ -735,30 +761,16 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-1',
                   'attach_status': 'detached'}
 
-        instance, expected_conn_info = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume, driver_attach=True)
-
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance,
-                        self.volume_api, self.virt_driver,
-                        do_driver_attach=True)
-        self.assertThat(test_bdm['connection_info'],
-                        matchers.DictMatches(expected_conn_info))
+        self._test_volume_attach(test_bdm, self.volume_bdm, volume,
+                                 driver_attach=True)
 
     def test_volume_attach_driver_attach_fails(self):
         test_bdm = self.driver_classes['volume'](
             self.volume_bdm)
         volume = {'id': 'fake-volume-id-1'}
 
-        instance, _ = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume, driver_attach=True,
-                fail_driver_attach=True)
-        self.mox.ReplayAll()
-
-        self.assertRaises(test.TestingException, test_bdm.attach, self.context,
-                         instance, self.volume_api, self.virt_driver,
-                         do_driver_attach=True)
+        self._test_volume_attach(test_bdm, self.volume_bdm, volume,
+                                 driver_attach=True, fail_driver_attach=True)
 
     @mock.patch('nova.objects.BlockDeviceMapping.save')
     @mock.patch('nova.volume.cinder.API')
@@ -822,15 +834,11 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-1',
                   'attach_status': 'detached'}
 
-        instance, _ = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume, fail_volume_attach=True)
-        self.mox.ReplayAll()
+        self._test_volume_attach(test_bdm, self.volume_bdm, volume,
+                                 fail_volume_attach=True)
 
-        self.assertRaises(test.TestingException, test_bdm.attach, self.context,
-                         instance, self.volume_api, self.virt_driver,
-                         do_driver_attach=False)
-
-    def test_refresh_connection(self):
+    @mock.patch.object(objects.BlockDeviceMapping, 'save')
+    def test_refresh_connection(self, mock_save):
         test_bdm = self.driver_classes['volsnapshot'](
             self.volsnapshot_bdm)
 
@@ -840,26 +848,27 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         expected_conn_info = {'data': {'multipath_id': 'fake_multipath_id'},
                               'serial': 'fake-volume-id-2'}
 
-        self.mox.StubOutWithMock(test_bdm._bdm_obj, 'save')
-
         if self.attachment_id is None:
-            self.virt_driver.get_volume_connector(instance).AndReturn(
-                connector)
-            self.volume_api.initialize_connection(
-                self.context, test_bdm.volume_id,
-                connector).AndReturn(connection_info)
+            self.virt_driver.get_volume_connector.return_value = connector
+            self.volume_api.initialize_connection.return_value = (
+                connection_info)
         else:
-            self.volume_api.attachment_get(
-                self.context, self.attachment_id).AndReturn(
-                    {'connection_info': connection_info})
-        test_bdm._bdm_obj.save().AndReturn(None)
-
-        self.mox.ReplayAll()
+            self.volume_api.attachment_get.return_value = {
+                'connection_info': connection_info}
 
         test_bdm.refresh_connection_info(self.context, instance,
                                          self.volume_api, self.virt_driver)
         self.assertThat(test_bdm['connection_info'],
                         matchers.DictMatches(expected_conn_info))
+        if self.attachment_id is None:
+            self.virt_driver.get_volume_connector.assert_called_once_with(
+                instance)
+            self.volume_api.initialize_connection.assert_called_once_with(
+                self.context, test_bdm.volume_id, connector)
+        else:
+            self.volume_api.attachment_get.assert_called_once_with(
+                self.context, self.attachment_id)
+        mock_save.assert_called_once_with()
 
     def test_snapshot_attach_no_volume(self):
         no_volume_snapshot = self.volsnapshot_bdm_dict.copy()
@@ -875,20 +884,19 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-2',
                   'attach_status': 'detached'}
 
-        wait_func = self.mox.CreateMockAnything()
+        wait_func = mock.MagicMock()
+        self.volume_api.get_snapshot.return_value = snapshot
+        self.volume_api.create.return_value = volume
 
-        self.volume_api.get_snapshot(self.context,
-                                     'fake-snapshot-id-1').AndReturn(snapshot)
-        self.volume_api.create(self.context, 3, '', '', snapshot,
-                               availability_zone=None).AndReturn(volume)
-        wait_func(self.context, 'fake-volume-id-2').AndReturn(None)
-        instance, expected_conn_info = self._test_volume_attach(
-               test_bdm, no_volume_snapshot, volume)
-        self.mox.ReplayAll()
+        self._test_volume_attach(test_bdm, no_volume_snapshot, volume,
+                                 wait_func=wait_func)
 
-        test_bdm.attach(self.context, instance, self.volume_api,
-                        self.virt_driver, wait_func)
-        self.assertEqual(test_bdm.volume_id, 'fake-volume-id-2')
+        self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+        self.volume_api.get_snapshot.assert_called_once_with(
+            self.context, 'fake-snapshot-id-1')
+        self.volume_api.create.assert_called_once_with(
+            self.context, 3, '', '', snapshot, availability_zone=None)
+        wait_func.assert_called_once_with(self.context, 'fake-volume-id-2')
 
     def test_snapshot_attach_no_volume_cinder_cross_az_attach_false(self):
         # Tests that the volume created from the snapshot has the same AZ as
@@ -907,21 +915,20 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-2',
                   'attach_status': 'detached'}
 
-        wait_func = self.mox.CreateMockAnything()
+        wait_func = mock.MagicMock()
 
-        self.volume_api.get_snapshot(self.context,
-                                     'fake-snapshot-id-1').AndReturn(snapshot)
-        self.volume_api.create(self.context, 3, '', '', snapshot,
-                               availability_zone='test-az').AndReturn(volume)
-        wait_func(self.context, 'fake-volume-id-2').AndReturn(None)
-        instance, expected_conn_info = self._test_volume_attach(
-               test_bdm, no_volume_snapshot, volume,
-               availability_zone='test-az')
-        self.mox.ReplayAll()
+        self.volume_api.get_snapshot.return_value = snapshot
+        self.volume_api.create.return_value = volume
+        self._test_volume_attach(test_bdm, no_volume_snapshot, volume,
+                                 availability_zone='test-az',
+                                 wait_func=wait_func)
 
-        test_bdm.attach(self.context, instance, self.volume_api,
-                        self.virt_driver, wait_func)
         self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+        self.volume_api.get_snapshot.assert_called_once_with(
+            self.context, 'fake-snapshot-id-1')
+        self.volume_api.create.assert_called_once_with(
+            self.context, 3, '', '', snapshot, availability_zone='test-az')
+        wait_func.assert_called_once_with(self.context, 'fake-volume-id-2')
 
     def test_snapshot_attach_fail_volume(self):
         fail_volume_snapshot = self.volsnapshot_bdm_dict.copy()
@@ -968,20 +975,19 @@ class TestDriverBlockDevice(test.NoDBTestCase):
 
         instance = {'id': 'fake_id', 'uuid': uuids.uuid}
 
-        volume_class = self.driver_classes['volume']
-        self.mox.StubOutWithMock(volume_class, 'attach')
-
-        # Make sure theses are not called
-        self.mox.StubOutWithMock(self.volume_api, 'get_snapshot')
-        self.mox.StubOutWithMock(self.volume_api, 'create')
-
-        volume_class.attach(self.context, instance, self.volume_api,
-                            self.virt_driver).AndReturn(None)
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance, self.volume_api,
-                        self.virt_driver)
-        self.assertEqual(test_bdm.volume_id, 'fake-volume-id-2')
+        with test.nested(
+            mock.patch.object(self.driver_classes['volume'], 'attach'),
+            mock.patch.object(self.volume_api, 'get_snapshot'),
+            mock.patch.object(self.volume_api, 'create'),
+        ) as (mock_attach, mock_get_snapshot, mock_create):
+            test_bdm.attach(self.context, instance, self.volume_api,
+                            self.virt_driver)
+            self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+            mock_attach.assert_called_once_with(
+                self.context, instance, self.volume_api, self.virt_driver)
+            # Make sure theses are not called
+            mock_get_snapshot.assert_not_called()
+            mock_create.assert_not_called()
 
     def test_image_attach_no_volume(self):
         no_volume_image = self.volimage_bdm_dict.copy()
@@ -996,18 +1002,16 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-2',
                   'attach_status': 'detached'}
 
-        wait_func = self.mox.CreateMockAnything()
+        wait_func = mock.MagicMock()
 
-        self.volume_api.create(self.context, 1, '', '', image_id=image['id'],
-                               availability_zone=None).AndReturn(volume)
-        wait_func(self.context, 'fake-volume-id-2').AndReturn(None)
-        instance, expected_conn_info = self._test_volume_attach(
-               test_bdm, no_volume_image, volume)
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance, self.volume_api,
-                        self.virt_driver, wait_func)
-        self.assertEqual(test_bdm.volume_id, 'fake-volume-id-2')
+        self.volume_api.create.return_value = volume
+        self._test_volume_attach(test_bdm, no_volume_image, volume,
+                                 wait_func=wait_func)
+        self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+        self.volume_api.create.assert_called_once_with(
+            self.context, 1, '', '', image_id=image['id'],
+            availability_zone=None)
+        wait_func.assert_called_once_with(self.context, 'fake-volume-id-2')
 
     def test_image_attach_no_volume_cinder_cross_az_attach_false(self):
         # Tests that the volume created from the image has the same AZ as the
@@ -1025,19 +1029,18 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume = {'id': 'fake-volume-id-2',
                   'attach_status': 'detached'}
 
-        wait_func = self.mox.CreateMockAnything()
+        wait_func = mock.MagicMock()
+        self.volume_api.create.return_value = volume
 
-        self.volume_api.create(self.context, 1, '', '', image_id=image['id'],
-                               availability_zone='test-az').AndReturn(volume)
-        wait_func(self.context, 'fake-volume-id-2').AndReturn(None)
-        instance, expected_conn_info = self._test_volume_attach(
-               test_bdm, no_volume_image, volume,
-               availability_zone='test-az')
-        self.mox.ReplayAll()
+        self._test_volume_attach(test_bdm, no_volume_image, volume,
+                                 availability_zone='test-az',
+                                 wait_func=wait_func)
 
-        test_bdm.attach(self.context, instance, self.volume_api,
-                        self.virt_driver, wait_func)
         self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+        self.volume_api.create.assert_called_once_with(
+            self.context, 1, '', '', image_id=image['id'],
+            availability_zone='test-az')
+        wait_func.assert_called_once_with(self.context, 'fake-volume-id-2')
 
     def test_image_attach_fail_volume(self):
         fail_volume_image = self.volimage_bdm_dict.copy()
@@ -1080,20 +1083,19 @@ class TestDriverBlockDevice(test.NoDBTestCase):
 
         instance = {'id': 'fake_id', 'uuid': uuids.uuid}
 
-        volume_class = self.driver_classes['volume']
-        self.mox.StubOutWithMock(volume_class, 'attach')
-
-        # Make sure theses are not called
-        self.mox.StubOutWithMock(self.volume_api, 'get_snapshot')
-        self.mox.StubOutWithMock(self.volume_api, 'create')
-
-        volume_class.attach(self.context, instance, self.volume_api,
-                            self.virt_driver).AndReturn(None)
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance, self.volume_api,
-                        self.virt_driver)
-        self.assertEqual(test_bdm.volume_id, 'fake-volume-id-2')
+        with test.nested(
+            mock.patch.object(self.driver_classes['volume'], 'attach'),
+            mock.patch.object(self.volume_api, 'get_snapshot'),
+            mock.patch.object(self.volume_api, 'create'),
+        ) as (mock_attch, mock_get_snapshot, mock_create):
+            test_bdm.attach(self.context, instance, self.volume_api,
+                            self.virt_driver)
+            self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+            mock_attch.assert_called_once_with(
+                self.context, instance, self.volume_api, self.virt_driver)
+            # Make sure theses are not called
+            mock_get_snapshot.assert_not_called()
+            mock_create.assert_not_called()
 
     def test_blank_attach_fail_volume(self):
         no_blank_volume = self.volblank_bdm_dict.copy()
@@ -1370,16 +1372,8 @@ class TestDriverBlockDeviceNewFlow(TestDriverBlockDevice):
                   'attachments': {'fake_instance_2':
                                   {'mountpoint': '/dev/vdc'}}}
 
-        instance, expected_conn_info = self._test_volume_attach(
-                test_bdm, self.volume_bdm, volume, multiattach=True,
-                driver_multi_attach=True)
-
-        self.mox.ReplayAll()
-
-        test_bdm.attach(self.context, instance,
-                        self.volume_api, self.virt_driver)
-        self.assertThat(test_bdm['connection_info'],
-                        matchers.DictMatches(expected_conn_info))
+        self._test_volume_attach(test_bdm, self.volume_bdm, volume,
+                                 multiattach=True, driver_multi_attach=True)
 
     def test_volume_attach_multiattach_no_virt_driver_support(self):
         test_bdm = self.driver_classes['volume'](
@@ -1391,15 +1385,9 @@ class TestDriverBlockDeviceNewFlow(TestDriverBlockDevice):
                   'attachments': {'fake_instance_2':
                                   {'mountpoint': '/dev/vdc'}}}
 
-        instance, _ = self._test_volume_attach(test_bdm, self.volume_bdm,
-                                               volume, multiattach=True,
-                                               fail_with_virt_driver=True)
-
-        self.mox.ReplayAll()
-
-        self.assertRaises(exception.MultiattachNotSupportedByVirtDriver,
-                          test_bdm.attach, self.context, instance,
-                          self.volume_api, self.virt_driver)
+        self._test_volume_attach(test_bdm, self.volume_bdm,
+                                 volume, multiattach=True,
+                                 fail_with_virt_driver=True)
 
     @mock.patch('nova.objects.BlockDeviceMapping.save')
     def test_refresh_connection_preserve_multiattach(self, mock_bdm_save):

--- a/nova/tests/unit/virt/test_block_device.py
+++ b/nova/tests/unit/virt/test_block_device.py
@@ -31,6 +31,8 @@ from nova.virt import driver
 from nova.virt import fake as fake_virt
 from nova.volume import cinder
 
+ATTACHMENT_ID = uuids.attachment_id
+
 
 class TestDriverBlockDevice(test.NoDBTestCase):
     # This is used to signal if we're dealing with a new style volume
@@ -256,6 +258,15 @@ class TestDriverBlockDevice(test.NoDBTestCase):
                 bdm = getattr(self, attr % name)
                 bdm['attachment_id'] = self.attachment_id
 
+    def stub_volume_create(self, volume):
+        # For any test that creates a volume (boot from volume where the source
+        # type is blank/image/snapshot), we'll also be creating an attachment
+        # so set the self.attachment_id value on the test and stub out the
+        # attachment_create method.
+        self.volume_api.create.return_value = volume
+        self.attachment_id = ATTACHMENT_ID
+        self.volume_api.attachment_create.return_value = {'id': ATTACHMENT_ID}
+
     @mock.patch('nova.virt.block_device.LOG')
     @mock.patch('os_brick.encryptors')
     def test_driver_detach_passes_failed(self, enc, log):
@@ -343,7 +354,13 @@ class TestDriverBlockDevice(test.NoDBTestCase):
                 # so skip those.
                 if not isinstance(test_bdm._bdm_obj.fields[fld],
                                   fields.BaseEnumField):
-                    test_bdm[alias or fld] = 'fake_changed_value'
+                    field = alias or fld
+                    if field == 'attachment_id':
+                        # Must set UUID values on UUID fields.
+                        fake_value = ATTACHMENT_ID
+                    else:
+                        fake_value = 'fake_changed_value'
+                    test_bdm[field] = fake_value
             test_bdm.save()
             for fld, alias in test_bdm._update_on_save.items():
                 self.assertEqual(test_bdm[alias or fld],
@@ -708,6 +725,8 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         if expected_save_calls:
             mock_save.assert_has_calls(expected_save_calls)
 
+        return instance.uuid
+
     def test_volume_attach(self, include_shared_targets=False):
         test_bdm = self.driver_classes['volume'](
             self.volume_bdm)
@@ -876,8 +895,9 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         test_bdm = self.driver_classes['volsnapshot'](
                 fake_block_device.fake_bdm_object(
                         self.context, no_volume_snapshot))
-        # When we create a volume, we attach it using the old flow.
-        self.attachment_id = None
+        # Make sure the test didn't already setup an attachment_id on the
+        # DriverVolSnapshotBlockDevice that we use to create a new volume.
+        self.assertIsNone(test_bdm.get('attachment_id'), test_bdm)
 
         snapshot = {'id': 'fake-volume-id-1',
                     'attach_status': 'detached'}
@@ -886,10 +906,11 @@ class TestDriverBlockDevice(test.NoDBTestCase):
 
         wait_func = mock.MagicMock()
         self.volume_api.get_snapshot.return_value = snapshot
-        self.volume_api.create.return_value = volume
 
-        self._test_volume_attach(test_bdm, no_volume_snapshot, volume,
-                                 wait_func=wait_func)
+        self.stub_volume_create(volume)
+
+        instance_uuid = self._test_volume_attach(
+            test_bdm, no_volume_snapshot, volume, wait_func=wait_func)
 
         self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
         self.volume_api.get_snapshot.assert_called_once_with(
@@ -898,6 +919,9 @@ class TestDriverBlockDevice(test.NoDBTestCase):
             self.context, 3, '', '', availability_zone=None,
             snapshot=snapshot)
         wait_func.assert_called_once_with(self.context, 'fake-volume-id-2')
+        self.volume_api.attachment_create.assert_called_once_with(
+            self.context, volume['id'], instance_uuid)
+        self.assertEqual(ATTACHMENT_ID, test_bdm.get('attachment_id'))
 
     def test_snapshot_attach_no_volume_cinder_cross_az_attach_false(self):
         # Tests that the volume created from the snapshot has the same AZ as
@@ -908,8 +932,6 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         test_bdm = self.driver_classes['volsnapshot'](
                 fake_block_device.fake_bdm_object(
                         self.context, no_volume_snapshot))
-        # When we create a volume, we attach it using the old flow.
-        self.attachment_id = None
 
         snapshot = {'id': 'fake-volume-id-1',
                     'attach_status': 'detached'}
@@ -919,7 +941,7 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         wait_func = mock.MagicMock()
 
         self.volume_api.get_snapshot.return_value = snapshot
-        self.volume_api.create.return_value = volume
+        self.stub_volume_create(volume)
         self._test_volume_attach(test_bdm, no_volume_snapshot, volume,
                                  availability_zone='test-az',
                                  wait_func=wait_func)
@@ -998,8 +1020,9 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         test_bdm = self.driver_classes['volimage'](
                 fake_block_device.fake_bdm_object(
                         self.context, no_volume_image))
-        # When we create a volume, we attach it using the old flow.
-        self.attachment_id = None
+        # Make sure the test didn't already setup an attachment_id on the
+        # DriverVolImageBlockDevice that we use to create a new volume.
+        self.assertIsNone(test_bdm.get('attachment_id'), test_bdm)
 
         image = {'id': 'fake-image-id-1'}
         volume = {'id': 'fake-volume-id-2',
@@ -1007,14 +1030,17 @@ class TestDriverBlockDevice(test.NoDBTestCase):
 
         wait_func = mock.MagicMock()
 
-        self.volume_api.create.return_value = volume
-        self._test_volume_attach(test_bdm, no_volume_image, volume,
-                                 wait_func=wait_func)
+        self.stub_volume_create(volume)
+        instance_uuid = self._test_volume_attach(
+            test_bdm, no_volume_image, volume, wait_func=wait_func)
         self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
         self.volume_api.create.assert_called_once_with(
             self.context, 1, '', '', image_id=image['id'],
             availability_zone=None)
         wait_func.assert_called_once_with(self.context, 'fake-volume-id-2')
+        self.volume_api.attachment_create.assert_called_once_with(
+            self.context, volume['id'], instance_uuid)
+        self.assertEqual(ATTACHMENT_ID, test_bdm.get('attachment_id'))
 
     def test_image_attach_no_volume_cinder_cross_az_attach_false(self):
         # Tests that the volume created from the image has the same AZ as the
@@ -1025,15 +1051,13 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         test_bdm = self.driver_classes['volimage'](
                 fake_block_device.fake_bdm_object(
                         self.context, no_volume_image))
-        # When we create a volume, we attach it using the old flow.
-        self.attachment_id = None
 
         image = {'id': 'fake-image-id-1'}
         volume = {'id': 'fake-volume-id-2',
                   'attach_status': 'detached'}
 
         wait_func = mock.MagicMock()
-        self.volume_api.create.return_value = volume
+        self.stub_volume_create(volume)
 
         self._test_volume_attach(test_bdm, no_volume_image, volume,
                                  availability_zone='test-az',
@@ -1141,20 +1165,21 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         test_bdm = self.driver_classes['volblank'](
                 fake_block_device.fake_bdm_object(
                         self.context, no_blank_volume))
+        # Make sure the test didn't already setup an attachment_id on the
+        # DriverVolBlankBlockDevice that we use to create a new volume.
+        self.assertIsNone(test_bdm.get('attachment_id'), test_bdm)
         instance = fake_instance.fake_instance_obj(mock.sentinel.ctx,
                                                    **{'uuid': uuids.uuid})
         volume_class = self.driver_classes['volume']
         volume = {'id': 'fake-volume-id-2',
                   'display_name': '%s-blank-vol' % uuids.uuid}
+        self.stub_volume_create(volume)
 
-        with test.nested(
-            mock.patch.object(self.volume_api, 'create', return_value=volume),
-            mock.patch.object(volume_class, 'attach')
-        ) as (vol_create, vol_attach):
+        with mock.patch.object(volume_class, 'attach') as vol_attach:
             test_bdm.attach(self.context, instance, self.volume_api,
                             self.virt_driver)
 
-            vol_create.assert_called_once_with(
+            self.volume_api.create.assert_called_once_with(
                 self.context, test_bdm.volume_size,
                 '%s-blank-vol' % uuids.uuid,
                 '', availability_zone=None)
@@ -1162,6 +1187,9 @@ class TestDriverBlockDevice(test.NoDBTestCase):
                                                self.volume_api,
                                                self.virt_driver)
             self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+        self.volume_api.attachment_create.assert_called_once_with(
+            self.context, volume['id'], instance.uuid)
+        self.assertEqual(ATTACHMENT_ID, test_bdm.get('attachment_id'))
 
     def test_blank_attach_volume_cinder_cross_az_attach_false(self):
         # Tests that the blank volume created is in the same availability zone
@@ -1178,21 +1206,20 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume_class = self.driver_classes['volume']
         volume = {'id': 'fake-volume-id-2',
                   'display_name': '%s-blank-vol' % uuids.uuid}
+        self.stub_volume_create(volume)
 
-        with mock.patch.object(self.volume_api, 'create',
-                               return_value=volume) as vol_create:
-            with mock.patch.object(volume_class, 'attach') as vol_attach:
-                test_bdm.attach(self.context, instance, self.volume_api,
-                                self.virt_driver)
+        with mock.patch.object(volume_class, 'attach') as vol_attach:
+            test_bdm.attach(self.context, instance, self.volume_api,
+                            self.virt_driver)
 
-                vol_create.assert_called_once_with(
-                    self.context, test_bdm.volume_size,
-                    '%s-blank-vol' % uuids.uuid,
-                    '', availability_zone='test-az')
-                vol_attach.assert_called_once_with(self.context, instance,
-                                                   self.volume_api,
-                                                   self.virt_driver)
-                self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+            self.volume_api.create.assert_called_once_with(
+                self.context, test_bdm.volume_size,
+                '%s-blank-vol' % uuids.uuid,
+                '', availability_zone='test-az')
+            vol_attach.assert_called_once_with(self.context, instance,
+                                               self.volume_api,
+                                               self.virt_driver)
+            self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
 
     def test_convert_block_devices(self):
         bdms = objects.BlockDeviceMappingList(
@@ -1359,7 +1386,7 @@ class TestDriverBlockDevice(test.NoDBTestCase):
                          E(bdm)._proxy_as_attr)
 
     def _test_boot_from_volume_source_blank_volume_type(
-            self, bdm, expected_volume_type):
+            self, bdm):
         self.flags(cross_az_attach=False, group='cinder')
         test_bdm = self.driver_classes['volblank'](bdm)
         updates = {'uuid': uuids.uuid, 'availability_zone': 'test-az'}
@@ -1368,23 +1395,22 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume_class = self.driver_classes['volume']
         volume = {'id': 'fake-volume-id-2',
                   'display_name': '%s-blank-vol' % uuids.uuid}
+        self.stub_volume_create(volume)
 
-        with mock.patch.object(self.volume_api, 'create',
-                               return_value=volume) as vol_create:
-            with mock.patch.object(volume_class, 'attach') as vol_attach:
-                test_bdm.attach(self.context, instance, self.volume_api,
-                                self.virt_driver)
+        with mock.patch.object(volume_class, 'attach') as vol_attach:
+            test_bdm.attach(self.context, instance, self.volume_api,
+                            self.virt_driver)
 
-                vol_create.assert_called_once_with(
-                    self.context, test_bdm.volume_size,
-                    '%s-blank-vol' % uuids.uuid, '',
-                    availability_zone='test-az')
-                vol_attach.assert_called_once_with(
-                    self.context, instance, self.volume_api, self.virt_driver)
-                self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+            self.volume_api.create.assert_called_once_with(
+                self.context, test_bdm.volume_size,
+                '%s-blank-vol' % uuids.uuid, '',
+                availability_zone='test-az')
+            vol_attach.assert_called_once_with(
+                self.context, instance, self.volume_api, self.virt_driver)
+            self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
 
     def _test_boot_from_volume_source_image_volume_type(
-            self, bdm, expected_volume_type):
+            self, bdm):
         self.flags(cross_az_attach=False, group='cinder')
         test_bdm = self.driver_classes['volimage'](bdm)
 
@@ -1395,24 +1421,22 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         image = {'id': 'fake-image-id-1'}
         volume = {'id': 'fake-volume-id-2',
                   'display_name': 'fake-image-vol'}
+        self.stub_volume_create(volume)
 
-        with mock.patch.object(self.volume_api, 'create',
-                               return_value=volume) as vol_create:
-            with mock.patch.object(volume_class, 'attach') as vol_attach:
-                test_bdm.attach(self.context, instance, self.volume_api,
-                                self.virt_driver)
+        with mock.patch.object(volume_class, 'attach') as vol_attach:
+            test_bdm.attach(self.context, instance, self.volume_api,
+                            self.virt_driver)
 
-                vol_create.assert_called_once_with(
-                    self.context, test_bdm.volume_size,
-                    '', '', image_id=image['id'],
-                    volume_type=expected_volume_type,
-                    availability_zone='test-az')
-                vol_attach.assert_called_once_with(
-                    self.context, instance, self.volume_api, self.virt_driver)
-                self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
+            self.volume_api.create.assert_called_once_with(
+                self.context, test_bdm.volume_size,
+                '', '', image_id=image['id'],
+                availability_zone='test-az')
+            vol_attach.assert_called_once_with(
+                self.context, instance, self.volume_api, self.virt_driver)
+            self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
 
     def _test_boot_from_volume_source_snapshot_volume_type(
-            self, bdm, expected_volume_type):
+            self, bdm):
         self.flags(cross_az_attach=False, group='cinder')
         test_bdm = self.driver_classes['volsnapshot'](bdm)
 
@@ -1425,30 +1449,31 @@ class TestDriverBlockDevice(test.NoDBTestCase):
         volume_class = self.driver_classes['volume']
         volume = {'id': 'fake-volume-id-2',
                   'display_name': 'fake-snapshot-vol'}
+        self.stub_volume_create(volume)
 
         with test.nested(
-            mock.patch.object(self.volume_api, 'create', return_value=volume),
             mock.patch.object(self.volume_api, 'get_snapshot',
                               return_value=snapshot),
             mock.patch.object(volume_class, 'attach')
         ) as (
-            vol_create, vol_get_snap, vol_attach
+            vol_get_snap, vol_attach
         ):
             test_bdm.attach(self.context, instance, self.volume_api,
                             self.virt_driver)
 
-            vol_create.assert_called_once_with(
+            self.volume_api.create.assert_called_once_with(
                 self.context, test_bdm.volume_size, '', '',
                 availability_zone='test-az', snapshot=snapshot)
             vol_attach.assert_called_once_with(
                 self.context, instance, self.volume_api, self.virt_driver)
             self.assertEqual('fake-volume-id-2', test_bdm.volume_id)
 
+
 class TestDriverBlockDeviceNewFlow(TestDriverBlockDevice):
     """Virt block_device tests for the Cinder 3.44 volume attach flow
     where a volume BDM has an attachment_id.
     """
-    attachment_id = uuids.attachment_id
+    attachment_id = ATTACHMENT_ID
 
     def test_volume_attach_multiattach(self):
         test_bdm = self.driver_classes['volume'](

--- a/nova/virt/block_device.py
+++ b/nova/virt/block_device.py
@@ -289,11 +289,13 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
              if k in self._new_fields | set(['delete_on_termination'])}
         )
         self['mount_device'] = self._bdm_obj.device_name
+        # connection_info might not be set so default to an empty dict so that
+        # it can be serialized to an empty JSON object.
         try:
             self['connection_info'] = jsonutils.loads(
                 self._bdm_obj.connection_info)
         except TypeError:
-            self['connection_info'] = None
+            self['connection_info'] = {}
 
     def _preserve_multipath_id(self, connection_info):
         if self['connection_info'] and 'data' in self['connection_info']:

--- a/nova/virt/block_device.py
+++ b/nova/virt/block_device.py
@@ -279,9 +279,8 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
                        'device_type': None}
 
     def _transform(self):
-        if (not self._bdm_obj.source_type == self._valid_source
-                or not self._bdm_obj.destination_type ==
-                self._valid_destination):
+        if (not self._bdm_obj.source_type == self._valid_source or
+                not self._bdm_obj.destination_type == self._valid_destination):
             raise _InvalidType
 
         self.update(
@@ -920,9 +919,9 @@ def is_implemented(bdm):
 
 
 def is_block_device_mapping(bdm):
-    return (bdm.source_type in ('image', 'volume', 'snapshot', 'blank')
-            and bdm.destination_type == 'volume'
-            and is_implemented(bdm))
+    return (bdm.source_type in ('image', 'volume', 'snapshot', 'blank') and
+            bdm.destination_type == 'volume' and
+            is_implemented(bdm))
 
 
 def get_volume_id(connection_info):

--- a/nova/virt/block_device.py
+++ b/nova/virt/block_device.py
@@ -276,7 +276,9 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
     _proxy_as_attr_inherited = set(['volume_size', 'volume_id'])
     _update_on_save = {'disk_bus': None,
                        'device_name': 'mount_device',
-                       'device_type': None}
+                       'device_type': None,
+                       # needed for boot from volume for blank/image/snapshot
+                       'attachment_id': None}
 
     def _transform(self):
         if (not self._bdm_obj.source_type == self._valid_source or
@@ -352,6 +354,21 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
 
     def _create_volume(self, context, instance, volume_api, size,
                        wait_func=None, **create_kwargs):
+        """Create a volume and attachment record.
+
+        :param context: nova auth RequestContext
+        :param instance: Instance object to which the created volume will be
+            attached.
+        :param volume_api: nova.volume.cinder.API instance
+        :param size: The size of the volume to create in GiB.
+        :param wait_func: Optional callback function to wait for the volume to
+            reach some status before continuing with a signature of::
+
+                wait_func(context, volume_id)
+        :param create_kwargs: Additional optional parameters used to create the
+            volume. See nova.volume.cinder.API.create for keys.
+        :return: A two-item tuple of volume ID and attachment ID.
+        """
         av_zone = _get_volume_create_az_value(instance)
         name = create_kwargs.pop('name', '')
         description = create_kwargs.pop('description', '')
@@ -362,7 +379,15 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
         if wait_func:
             self._call_wait_func(context, wait_func, volume_api, vol['id'])
 
-        return vol
+        # Unconditionally create an attachment record for the volume so the
+        # attach/detach flows use the "new style" introduced in Queens. Note
+        # that nova required the Cinder Queens level APIs (3.44+) starting in
+        # Train.
+        attachment_id = (
+            volume_api.attachment_create(
+                context, vol['id'], instance.uuid)['id'])
+
+        return vol['id'], attachment_id
 
     def _do_detach(self, context, instance, volume_api, virt_driver,
                    attachment_id=None, destroy_bdm=False):
@@ -730,14 +755,9 @@ class DriverVolSnapshotBlockDevice(DriverVolumeBlockDevice):
         if not self.volume_id:
             snapshot = volume_api.get_snapshot(context,
                                                self.snapshot_id)
-            vol = self._create_volume(
+            self.volume_id, self.attachment_id = self._create_volume(
                 context, instance, volume_api, self.volume_size,
                 wait_func=wait_func, snapshot=snapshot)
-
-            self.volume_id = vol['id']
-
-            # TODO(mriedem): Create an attachment to reserve the volume and
-            # make us go down the new-style attach flow.
 
         # Call the volume attach now
         super(DriverVolSnapshotBlockDevice, self).attach(
@@ -752,17 +772,13 @@ class DriverVolImageBlockDevice(DriverVolumeBlockDevice):
     def attach(self, context, instance, volume_api,
                virt_driver, wait_func=None):
         if not self.volume_id:
-            vol = self._create_volume(
+            self.volume_id, self.attachment_id = self._create_volume(
                 context, instance, volume_api, self.volume_size,
                 wait_func=wait_func, image_id=self.image_id)
 
-            self.volume_id = vol['id']
-
-            # TODO(mriedem): Create an attachment to reserve the volume and
-            # make us go down the new-style attach flow.
-
         super(DriverVolImageBlockDevice, self).attach(
             context, instance, volume_api, virt_driver)
+
 
 class DriverVolBlankBlockDevice(DriverVolumeBlockDevice):
 
@@ -773,15 +789,9 @@ class DriverVolBlankBlockDevice(DriverVolumeBlockDevice):
                virt_driver, wait_func=None):
         if not self.volume_id:
             vol_name = instance.uuid + '-blank-vol'
-
-            vol = self._create_volume(
+            self.volume_id, self.attachment_id = self._create_volume(
                 context, instance, volume_api, self.volume_size,
                 wait_func=wait_func, name=vol_name)
-
-            self.volume_id = vol['id']
-
-            # TODO(mriedem): Create an attachment to reserve the volume and
-            # make us go down the new-style attach flow.
 
         super(DriverVolBlankBlockDevice, self).attach(
             context, instance, volume_api, virt_driver)


### PR DESCRIPTION
Prior to this change, when the user passes a block-device-mapping to the server create api call,
the compatibility logic would fail to detect, that we do have a cinder 3.44+ api, and create legacy volume attachments.

Boot from Volume is apparently a major concern for driving the change, as the commit messages are referring to it,
but the change is affecting *all* cinder volume related attachments on server creation.

Essentially this is the change de5bce6ea, with all predating changing concerning block-devices, removing the volume-type change not part of rocky.
The code prior to this change 
- would check, if a newly created volume has an attachment-id, which it hasn't
- and since it hasn't a attachment-id, attach it with the legacy-code

The new code relies on 3.44 api (or later) and unconditionally creates the attachment, which should suite us fine, as we have migrated cinder already to a later version.
