### PR TITLE
VmWare: Fix deprecation warning in unit tests

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/fake.py
+++ b/nova/tests/unit/virt/vmwareapi/fake.py
@@ -793,7 +793,8 @@ class HostSystem(ManagedObject):
 
         product = DataObject()
         product.name = "VMware ESXi"
-        product.version = constants.MIN_VC_VERSION
+        # Avoid deprecation warning
+        product.version = constants.NEXT_MIN_VC_VERSION
         config = DataObject()
         config.product = product
         summary.config = config
@@ -1277,7 +1278,8 @@ class FakeVim(object):
 
         about_info = DataObject()
         about_info.name = "VMware vCenter Server"
-        about_info.version = constants.MIN_VC_VERSION
+        # Avoid deprecation warning
+        about_info.version = constants.NEXT_MIN_VC_VERSION
         about_info.instanceUuid = _FAKE_VCENTER_UUID
 
         service_content.about = about_info

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2356,7 +2356,7 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.assertEqual(CONF.reserved_host_memory_mb,
                          stats['memory_mb_reserved'])
         self.assertEqual('VMware vCenter Server', stats['hypervisor_type'])
-        self.assertEqual(5001000, stats['hypervisor_version'])
+        self.assertEqual(5005000, stats['hypervisor_version'])
         self.assertEqual(self.node_name, stats['hypervisor_hostname'])
         cpu_info = {'features': ['aes', 'avx'],
                     'vendor': 'Intel',


### PR DESCRIPTION
By setting the vcenter version to MIN_VC_VERSION (<NEXT_MIN_VC_VERSION),
the tests trigger logging the deprecation warning.
By setting it to NEXT_MIN_VC_VERSION, we can avoid that