### PR TITLE
VmWare: Don't repeat yourself with hardware devices

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -539,7 +539,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         devices.append(ide_controller)
         fake._update_object("VirtualMachine", vm)
         # return the scsi type, not ide
-        hardware_device = vm.get("config.hardware.device")
+        hardware_device = vm.get("config.hardware.device").VirtualDevice
         self.assertEqual(constants.DEFAULT_ADAPTER_TYPE,
                          vm_util.get_scsi_adapter_type(hardware_device))
 
@@ -558,7 +558,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         hardware_device = vm.get("config.hardware.device")
         self.assertRaises(exception.StorageError,
                           vm_util.get_scsi_adapter_type,
-                          hardware_device)
+                          hardware_device.VirtualDevice)
 
     def test_find_allocated_slots(self):
         disk1 = fake.VirtualDisk(200, 0)

--- a/nova/virt/vmwareapi/vif.py
+++ b/nova/virt/vmwareapi/vif.py
@@ -192,8 +192,6 @@ def get_vif_info(session, cluster, is_neutron, vif_model, network_info):
 
 def get_network_device(hardware_devices, mac_address):
     """Return the network device with MAC 'mac_address'."""
-    if hardware_devices.__class__.__name__ == "ArrayOfVirtualDevice":
-        hardware_devices = hardware_devices.VirtualDevice
     for device in hardware_devices:
         if device.__class__.__name__ in vm_util.ALL_SUPPORTED_NETWORK_DEVICES:
             if hasattr(device, 'macAddress'):

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -45,10 +45,7 @@ class VMwareVolumeOps(object):
                           device_name=None, disk_io_limits=None):
         """Attach disk to VM by reconfiguration."""
         client_factory = self._session.vim.client.factory
-        devices = self._session._call_method(vutil,
-                                             "get_object_property",
-                                             vm_ref,
-                                             "config.hardware.device")
+        devices = vm_util.get_hardware_devices(self._session, vm_ref)
         (controller_key, unit_number,
          controller_spec) = vm_util.allocate_controller_key_and_unit_number(
                                                               client_factory,
@@ -315,11 +312,8 @@ class VMwareVolumeOps(object):
 
     def _get_vmdk_base_volume_device(self, volume_ref):
         # Get the vmdk file name that the VM is pointing to
-        hardware_devices = self._session._call_method(
-                                                    vutil,
-                                                    "get_object_property",
-                                                    volume_ref,
-                                                    "config.hardware.device")
+        hardware_devices = vm_util.get_hardware_devices(self._session,
+                                                        volume_ref)
         return vm_util.get_vmdk_volume_disk(hardware_devices)
 
     def _attach_volume_vmdk(self, connection_info, instance,
@@ -372,8 +366,8 @@ class VMwareVolumeOps(object):
                 reason=_("Unable to find iSCSI Target"))
         if adapter_type is None:
             # Get the vmdk file name that the VM is pointing to
-            hardware_devices = self._session._call_method(
-                vutil, "get_object_property", vm_ref, "config.hardware.device")
+            hardware_devices = vm_util.get_hardware_devices(self._session,
+                                                            vm_ref)
             adapter_type = vm_util.get_scsi_adapter_type(hardware_devices)
 
         self.attach_disk_to_vm(vm_ref, instance,
@@ -500,10 +494,7 @@ class VMwareVolumeOps(object):
 
     def _get_vmdk_backed_disk_device(self, vm_ref, connection_info_data):
         # Get the vmdk file name that the VM is pointing to
-        hardware_devices = self._session._call_method(vutil,
-                                                      "get_object_property",
-                                                      vm_ref,
-                                                      "config.hardware.device")
+        hardware_devices = vm_util.get_hardware_devices(self._session, vm_ref)
 
         # Get disk uuid
         disk_uuid = self._get_volume_uuid(vm_ref,
@@ -525,12 +516,7 @@ class VMwareVolumeOps(object):
 
         device = self._get_vmdk_backed_disk_device(vm_ref, data)
 
-        hardware_devices = self._session._call_method(vutil,
-                                                "get_object_property",
-                                                vm_ref,
-                                                "config.hardware.device")
-        if hardware_devices.__class__.__name__ == "ArrayOfVirtualDevice":
-            hardware_devices = hardware_devices.VirtualDevice
+        hardware_devices = vm_util.get_hardware_devices(self._session, vm_ref)
         adapter_type = None
         for hw_device in hardware_devices:
             if hw_device.key == device.controllerKey:
@@ -574,10 +560,7 @@ class VMwareVolumeOps(object):
                 reason=_("Unable to find iSCSI Target"))
 
         # Get the vmdk file name that the VM is pointing to
-        hardware_devices = self._session._call_method(vutil,
-                                                      "get_object_property",
-                                                      vm_ref,
-                                                      "config.hardware.device")
+        hardware_devices = vm_util.get_hardware_devices(self._session, vm_ref)
         device = vm_util.get_rdm_disk(hardware_devices, uuid)
         if device is None:
             raise exception.DiskNotFound(message=_("Unable to find volume"))


### PR DESCRIPTION
The code was getting the hardware devices in multiple places directly,
and then (often, but not always) normalising the array.

Functions getting the device array then also had to normalise the array again.

By consolidating the retrieval and the normalisation in a function,
the code becomes less repetitive