### PR TITLE
VmWare: Logging cache miss with PropertyCollector enabled

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2342,7 +2342,7 @@ class VMwareVMOps(object):
         vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
         if not vm_props or "runtime.powerState" not in vm_props:
             try:
-                if not CONF.vmware.use_property_collector:
+                if CONF.vmware.use_property_collector:
                     LOG.debug("VM instance data was not found on the cache.")
 
                 vm_props = self._session._call_method(


### PR DESCRIPTION
The logic is inverted: Only if use_property_collector is active, we actually expect
the cache to contain sensible values for the vm-state. So, only then it makes
sense to log a cache miss