### PR TITLE
VmWare: DRY getting the client factory

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -80,14 +80,15 @@ def fetch_cluster_properties(session, vm_ref):
     max_objects = 1
     vim = session.vim
     property_collector = vim.service_content.propertyCollector
+    client_factory = vim.client.factory
 
     traversal_spec = vutil.build_traversal_spec(
-        vim.client.factory,
+        client_factory,
         "v_to_r",
         "VirtualMachine",
         "resourcePool",
         False,
-        [vutil.build_traversal_spec(vim.client.factory,
+        [vutil.build_traversal_spec(client_factory,
                                     "r_to_c",
                                     "ResourcePool",
                                     "parent",
@@ -95,19 +96,19 @@ def fetch_cluster_properties(session, vm_ref):
                                     [])])
 
     object_spec = vutil.build_object_spec(
-        vim.client.factory,
+        client_factory,
         vm_ref,
         [traversal_spec])
     property_spec = vutil.build_property_spec(
-        vim.client.factory,
+        client_factory,
         "ClusterComputeResource",
         ["configurationEx"])
 
     property_filter_spec = vutil.build_property_filter_spec(
-        vim.client.factory,
+        client_factory,
         [property_spec],
         [object_spec])
-    options = vim.client.factory.create('ns0:RetrieveOptions')
+    options = client_factory.create('ns0:RetrieveOptions')
     options.maxObjects = max_objects
 
     pc_result = vim.RetrievePropertiesEx(property_collector,

--- a/nova/virt/vmwareapi/host.py
+++ b/nova/virt/vmwareapi/host.py
@@ -145,9 +145,10 @@ class VCState(object):
         max_objects = 100
         vim = self._session.vim
         property_collector = vim.service_content.propertyCollector
+        client_factory = vim.client.factory
 
         traversal_spec = vutil.build_traversal_spec(
-            vim.client.factory,
+            client_factory,
             "c_to_h",
             "ComputeResource",
             "host",
@@ -155,21 +156,21 @@ class VCState(object):
             [])
 
         object_spec = vutil.build_object_spec(
-            vim.client.factory,
+            client_factory,
             self._cluster,
             [traversal_spec])
         property_spec = vutil.build_property_spec(
-            vim.client.factory,
+            client_factory,
             "HostSystem",
             ["hardware.cpuPkg",
              "hardware.cpuInfo",
              "config.featureCapability"])
 
         property_filter_spec = vutil.build_property_filter_spec(
-            vim.client.factory,
+            client_factory,
             [property_spec],
             [object_spec])
-        options = vim.client.factory.create('ns0:RetrieveOptions')
+        options = client_factory.create('ns0:RetrieveOptions')
         options.maxObjects = max_objects
 
         pc_result = vim.RetrievePropertiesEx(property_collector,

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2262,7 +2262,8 @@ class VMwareVMOps(object):
         folder = self._get_project_folder(dc_info, instance.project_id,
                                           'Instances')
 
-        spec = vm_util.relocate_vm_spec(self._session.vim.client.factory,
+        client_factory = self._session.vim.client.factory
+        spec = vm_util.relocate_vm_spec(client_factory,
                                         res_pool=self._root_resource_pool,
                                         folder=folder, datastore=datastore.ref)
 
@@ -2290,10 +2291,10 @@ class VMwareVMOps(object):
                     raise exception.NotFound(msg)
 
                 # Update the network device backing
-                config_spec = self._session.vim.client.factory.create(
+                config_spec = client_factory.create(
                     'ns0:VirtualDeviceConfigSpec')
                 vm_util.set_net_device_backing(
-                    self._session.vim.client.factory, device, vif_info)
+                    client_factory, device, vif_info)
                 config_spec.operation = "edit"
                 config_spec.device = device
                 spec.deviceChange.append(config_spec)
@@ -3064,30 +3065,31 @@ class VMwareVMOps(object):
                 options=options)
 
     def _get_vm_monitor_spec(self, vim):
+        client_factory = vim.client.factory
         traversal_spec_vm = vutil.build_traversal_spec(
-            vim.client.factory,
+            client_factory,
             "h_to_vm",
             "HostSystem",
             "vm",
             False,
             [])
         traversal_spec = vutil.build_traversal_spec(
-            vim.client.factory,
+            client_factory,
             "c_to_h",
             "ComputeResource",
             "host",
             False,
             [traversal_spec_vm])
         object_spec = vutil.build_object_spec(
-            vim.client.factory,
+            client_factory,
             self._cluster,
             [traversal_spec])
         property_spec = vutil.build_property_spec(
-            vim.client.factory,
+            client_factory,
             "HostSystem",
             ["vm"])
         property_spec_vm = vutil.build_property_spec(
-            vim.client.factory,
+            client_factory,
             "VirtualMachine",
             ["config.instanceUuid",
              "config.managedBy",
@@ -3096,7 +3098,7 @@ class VMwareVMOps(object):
              "summary.guest.toolsRunningStatus",
             ])
         property_filter_spec = vutil.build_property_filter_spec(
-            vim.client.factory,
+            client_factory,
             [property_spec, property_spec_vm],
             [object_spec])
         return property_filter_spec


### PR DESCRIPTION
Follow the same pattern as in the other functions
Set the local variable client_factory to the client factory
of the current session and use that in the function