### PR TITLE
Vmware: Make live-migration hv-version check optional

### DIFF
--- a/nova/conductor/tasks/live_migrate.py
+++ b/nova/conductor/tasks/live_migrate.py
@@ -260,10 +260,11 @@ class LiveMigrationTask(base.TaskBase):
         if source_type != destination_type:
             raise exception.InvalidHypervisorType()
 
-        source_version = source_info.hypervisor_version
-        destination_version = destination_info.hypervisor_version
-        if source_version > destination_version:
-            raise exception.DestinationHypervisorTooOld()
+        if not CONF.workarounds.enable_live_migration_to_old_hypervisor:
+            source_version = source_info.hypervisor_version
+            destination_version = destination_info.hypervisor_version
+            if source_version > destination_version:
+                raise exception.DestinationHypervisorTooOld()
         return source_info, destination_info
 
     def _call_livem_checks_on_host(self, destination):

--- a/nova/conf/workarounds.py
+++ b/nova/conf/workarounds.py
@@ -276,6 +276,24 @@ Related options:
 * ``[libvirt]/images_type`` (rbd)
 * ``instances_path``
 """),
+
+    cfg.BoolOpt(
+        'enable_live_migration_to_old_hypervisor',
+        default=False,
+        help="""
+Disables the version check between source and destination hypervisor.
+
+When live migrating from one host to another, it is usually ensured that the
+destination host is at least of the same version, but some hypervisors
+(i.e. Vmware) allow migration from a newer hypervisor version to an older one.
+This disables the check until a more proper way of validating compatibility has
+been implemented.
+
+Related options:
+
+* ``compute_driver`` (vmwareapi.VMwareVCDriver)
+
+"""),
 ]
 
 


### PR DESCRIPTION
Vsphere can migrate just fine from newer to older vcenters,
but the live-migration pre-check tests for that.

It is more a work-around to make an option for that,
as a proper solution would delegate that to the driver.