### PR TITLE
Vmware: Use WithRetrieval to get all results

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1315,7 +1315,7 @@ class VMwareAPIVMTestCase(test.TestCase,
         self._create_vm()
         vms = self.conn._session._call_method(vim_util, "get_objects",
                 "VirtualMachine", ['config.extraConfig["nvp.vm-uuid"]'])
-        vm_ref = vm_util._get_object_for_optionvalue(vms,
+        vm_ref = vm_util._get_object_for_optionvalue(vms.objects,
                                                      self.instance["uuid"])
         self.assertIsNotNone(vm_ref, 'VM Reference cannot be none')
 

--- a/nova/tests/unit/virt/vmwareapi/test_ds_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_ds_util.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from contextlib import contextmanager
 import re
 
 import mock
@@ -247,6 +248,7 @@ class DsUtilTestCase(test.NoDBTestCase):
                     'fake-browser', ds_path, 'fake-file')
             self.assertFalse(file_exists)
 
+    @contextmanager
     def _mock_get_datastore_calls(self, *datastores):
         """Mock vim_util calls made by get_datastore."""
 
@@ -277,23 +279,18 @@ class DsUtilTestCase(test.NoDBTestCase):
                 datastores_i[0] = iter(datastores)
                 return next(datastores_i[0])
 
-            # Continue returning results from the current iterator.
-            if (module == ds_util.vutil and
-                    method == 'continue_retrieval'):
-                try:
-                    return next(datastores_i[0])
-                except StopIteration:
-                    return None
-
-            if (method == 'continue_retrieval' or
-                method == 'cancel_retrieval'):
-                return
-
             # Sentinel that get_datastore's use of vim has changed
             self.fail('Unexpected vim call in get_datastore: %s' % method)
 
-        return mock.patch.object(self.session, '_call_method',
-                                 side_effect=fake_call_method)
+        def next_datastore(*args, **kwargs):
+            return next(datastores_i[0])
+
+        with mock.patch.object(self.session, '_call_method',
+                    side_effect=fake_call_method), \
+                mock.patch('oslo_vmware.vim_util.continue_retrieval',
+                    side_effect=next_datastore), \
+                mock.patch('oslo_vmware.vim_util.cancel_retrieval'):
+            yield
 
     def test_get_datastore(self):
         fake_objects = fake.FakeRetrieveResult()

--- a/nova/virt/vmwareapi/ds_util.py
+++ b/nova/virt/vmwareapi/ds_util.py
@@ -45,13 +45,13 @@ DcInfo = collections.namedtuple('DcInfo',
 _DS_DC_MAPPING = {}
 
 
-def _select_datastore(session, data_stores, best_match, datastore_regex=None,
+def _select_datastore(session, datastores, best_match, datastore_regex=None,
                       storage_policy=None,
                       allowed_ds_types=ALL_SUPPORTED_DS_TYPES):
     """Find the most preferable datastore in a given RetrieveResult object.
 
     :param session: vmwareapi session
-    :param data_stores: a RetrieveResult object from vSphere API call
+    :param datastores: an iterator to the results of the datastore list
     :param best_match: the current best match for datastore
     :param datastore_regex: an optional regular expression to match names
     :param storage_policy: storage policy for the datastore
@@ -61,14 +61,12 @@ def _select_datastore(session, data_stores, best_match, datastore_regex=None,
 
     if storage_policy:
         matching_ds = _filter_datastores_matching_storage_policy(
-            session, data_stores, storage_policy)
-        if not matching_ds:
-            return best_match
+            session, datastores, storage_policy)
     else:
-        matching_ds = data_stores
+        matching_ds = datastores
 
     # data_stores is actually a RetrieveResult object from vSphere API call
-    for obj_content in matching_ds.objects:
+    for obj_content in matching_ds:
         # the propset attribute "need not be set" by returning API
         if not hasattr(obj_content, 'propSet'):
             continue
@@ -82,7 +80,7 @@ def _select_datastore(session, data_stores, best_match, datastore_regex=None,
                     freespace=propdict['summary.freeSpace'])
             # favor datastores with more free space
             if (best_match is None or
-                new_ds.freespace > best_match.freespace):
+                    new_ds.freespace > best_match.freespace):
                 best_match = new_ds
 
     return best_match
@@ -124,25 +122,23 @@ def get_datastore(session, cluster, datastore_regex=None,
     if not datastore_ret:
         raise exception.DatastoreNotFound()
 
-    data_store_mors = datastore_ret.ManagedObjectReference
-    data_stores = session._call_method(vim_util,
+    datastore_mors = datastore_ret.ManagedObjectReference
+    result = session._call_method(vim_util,
                             "get_properties_for_a_collection_of_objects",
-                            "Datastore", data_store_mors,
+                            "Datastore", datastore_mors,
                             ["summary.type", "summary.name",
                              "summary.capacity", "summary.freeSpace",
                              "summary.accessible",
                              "summary.maintenanceMode"])
 
     best_match = None
-    while data_stores:
+    with vutil.WithRetrieval(session.vim, result) as datastores:
         best_match = _select_datastore(session,
-                                       data_stores,
+                                       datastores,
                                        best_match,
                                        datastore_regex,
                                        storage_policy,
                                        allowed_ds_types)
-        data_stores = session._call_method(vutil, 'continue_retrieval',
-                                           data_stores)
     if best_match:
         return best_match
 
@@ -150,17 +146,15 @@ def get_datastore(session, cluster, datastore_regex=None,
         raise exception.DatastoreNotFound(
             _("Storage policy %s did not match any datastores")
             % storage_policy)
-    elif datastore_regex:
+    if datastore_regex:
         raise exception.DatastoreNotFound(
             _("Datastore regex %s did not match any datastores")
             % datastore_regex.pattern)
-    else:
-        raise exception.DatastoreNotFound()
+    raise exception.DatastoreNotFound()
 
 
-def _get_allowed_datastores(data_stores, datastore_regex):
-    allowed = []
-    for obj_content in data_stores.objects:
+def _get_allowed_datastores(datastores, datastore_regex):
+    for obj_content in datastores:
         # the propset attribute "need not be set" by returning API
         if not hasattr(obj_content, 'propSet'):
             continue
@@ -169,12 +163,10 @@ def _get_allowed_datastores(data_stores, datastore_regex):
         if _is_datastore_valid(propdict,
                                datastore_regex,
                                ALL_SUPPORTED_DS_TYPES):
-            allowed.append(ds_obj.Datastore(ref=obj_content.obj,
+            yield (ds_obj.Datastore(ref=obj_content.obj,
                                     name=propdict['summary.name'],
                                     capacity=propdict['summary.capacity'],
                                     freespace=propdict['summary.freeSpace']))
-
-    return allowed
 
 
 def get_available_datastores(session, cluster=None, datastore_regex=None,
@@ -197,19 +189,15 @@ def get_available_datastores(session, cluster=None, datastore_regex=None,
         return []
     data_store_mors = ds.ManagedObjectReference
     # NOTE(garyk): use utility method to retrieve remote objects
-    data_stores = session._call_method(vim_util,
+    result = session._call_method(vim_util,
             "get_properties_for_a_collection_of_objects",
             "Datastore", data_store_mors,
             ["summary.type", "summary.name", "summary.accessible",
              "summary.maintenanceMode", "summary.capacity",
              "summary.freeSpace"])
 
-    allowed = []
-    while data_stores:
-        allowed.extend(_get_allowed_datastores(data_stores, datastore_regex))
-        data_stores = session._call_method(vutil, 'continue_retrieval',
-                                           data_stores)
-    return allowed
+    with vutil.WithRetrieval(session.vim, result) as datastores:
+        return list(_get_allowed_datastores(datastores, datastore_regex))
 
 
 def get_allowed_datastore_types(disk_type):
@@ -443,29 +431,36 @@ def get_sub_folders(session, ds_browser, ds_path):
     return set()
 
 
-def _filter_datastores_matching_storage_policy(session, data_stores,
+def _filter_datastores_matching_storage_policy(session, datastores,
                                                storage_policy):
     """Get datastores matching the given storage policy.
 
-    :param data_stores: the list of retrieve result wrapped datastore objects
+    :param datastores: an iterator over datastore results
     :param storage_policy: the storage policy name
-    :return: the list of datastores conforming to the given storage policy
+    :return: an iterator to datastores conforming to the given storage policy
     """
     profile_id = pbm.get_profile_id_by_name(session, storage_policy)
-    if profile_id:
-        factory = session.pbm.client.factory
-        ds_mors = [oc.obj for oc in data_stores.objects]
-        hubs = pbm.convert_datastores_to_hubs(factory, ds_mors)
-        matching_hubs = pbm.filter_hubs_by_profile(session, hubs,
-                                                   profile_id)
-        if matching_hubs:
-            matching_ds = pbm.filter_datastores_by_hubs(matching_hubs,
-                                                        ds_mors)
-            object_contents = [oc for oc in data_stores.objects
-                               if oc.obj in matching_ds]
-            data_stores.objects = object_contents
-            return data_stores
-    LOG.error("Unable to retrieve storage policy with name %s", storage_policy)
+    if not profile_id:
+        LOG.error("Unable to retrieve storage policy with name %s",
+                  storage_policy)
+        return
+
+    factory = session.pbm.client.factory
+
+    # The hub-id is the moref-value of the datastore
+    ds_mors = []
+    ref_to_oc = {}
+    for oc in datastores:
+        ds_mors.append(oc.obj)
+        ref_to_oc[vim_util.get_moref_value(oc.obj)] = oc
+
+    hubs = pbm.convert_datastores_to_hubs(factory, ds_mors)
+    matching_hubs = pbm.filter_hubs_by_profile(session, hubs,
+                                                profile_id)
+
+    # Now we have to map back all the matching ones
+    for hub in matching_hubs:
+        yield ref_to_oc[hub.hubId]
 
 
 def _update_datacenter_cache_from_objects(session, dcs):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2646,8 +2646,9 @@ class VMwareVMOps(object):
         """
         lst_vms = []
 
-        while retrieve_result:
-            for vm in retrieve_result.objects:
+        with vutil.WithRetrieval(self._session.vim, retrieve_result) \
+                as objects:
+            for vm in objects:
                 vm_uuid = None
                 conn_state = None
                 props = {}
@@ -2668,9 +2669,7 @@ class VMwareVMOps(object):
                     lst_vms.append((vm_uuid, props))
                 else:
                     lst_vms.append(vm_uuid)
-            retrieve_result = self._session._call_method(vutil,
-                                                         'continue_retrieval',
-                                                         retrieve_result)
+
         return lst_vms
 
     def instance_exists(self, instance):


### PR DESCRIPTION

In various places, own version of iterating over the results are implemented,
sometimes even faulty.
The following functions where only getting up to vmware.maximum_objects objects (100 by default)
vm_util.get_all_cluster_mors, vm_util.get_stats_from_cluster,
_SpecialVmSpawningServer._get_vms_on_host, _SpecialVmSpawningServer.free_host

Only in _SpecialVmSpawningServer._get_vms_on_host we might get over the 100 items,
and actually have missed ones.

Previously, the results were fetched in batches of up to vmware.maximum_objects items.
Using WithRetrieval yields an iterator to the results, which pages transparently to
the next request.
Receiver of the output of the results where changed to consume an iterator, where easily
possible.