### PR TITLE
Vmware: Refactor server groups

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_configdrive.py
+++ b/nova/tests/unit/virt/vmwareapi/test_configdrive.py
@@ -125,7 +125,7 @@ class ConfigDriveTestCase(test.TestCase):
         vmwareapi_fake.cleanup()
         nova.tests.unit.image.fake.FakeImageService_reset()
 
-    @mock.patch('nova.virt.vmwareapi.vm_util.vm_needs_special_spawning')
+    @mock.patch('nova.utils.vm_needs_special_spawning')
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata',
                        return_value='fake_metadata')
     @mock.patch.object(vmops.VMwareVMOps, '_find_image_template_vm',

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -263,7 +263,7 @@ class VMwareAPIVMTestCase(test.TestCase,
         """
         self.useFixture(
             fixtures.MonkeyPatch(
-                'nova.virt.vmwareapi.vm_util.vm_needs_special_spawning',
+                'nova.utils.vm_needs_special_spawning',
                 self._fake_vm_needs_special_spawning))
 
     def _fake_vm_needs_special_spawning(self, *args, **kwargs):
@@ -1685,7 +1685,8 @@ class VMwareAPIVMTestCase(test.TestCase,
 
     @mock.patch('nova.virt.vmwareapi.cluster_util.fetch_cluster_properties')
     @mock.patch('nova.virt.vmwareapi.cluster_util.delete_vm_group')
-    @mock.patch('nova.virt.vmwareapi.vm_util._get_server_groups')
+    @mock.patch.object(vmops.VMwareVMOps, '_get_server_groups',
+                                          return_value=[])
     @mock.patch('nova.virt.vmwareapi.vm_util.update_cluster_placement')
     def test_destroy_with_vm_group(self, mock_update_placement,
                                          mock_get_sg,

--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -152,24 +152,22 @@ def update_placement(session, cluster, vm_ref, group_infos):
     client_factory = session.vim.client.factory
     config_spec = client_factory.create('ns0:ClusterConfigSpecEx')
     config_spec.groupSpec = []
+    config_spec.rulesSpec = []
     for group_info in group_infos:
         group = _get_vm_group(cluster_config, group_info)
 
         if not group:
-            """Creating group"""
-            group_spec = _create_vm_group_spec(
-                client_factory, group_info, [vm_ref], operation="add",
-                group=group)
-            config_spec.groupSpec.append(group_spec)
-
-        if group:
+            # Creating group
+            operation = "add"
+        else:
             # VM group exists on the cluster which is assumed to be
             # created by VC admin. Add instance to this vm group and let
             # the placement policy defined by the VC admin take over
-            group_spec = _create_vm_group_spec(
-                client_factory, group_info, [vm_ref], operation="edit",
-                group=group)
-            config_spec.groupSpec.append(group_spec)
+            operation = "edit"
+        group_spec = _create_vm_group_spec(
+            client_factory, group_info, [vm_ref], operation=operation,
+            group=group)
+        config_spec.groupSpec.append(group_spec)
 
         # If server group policies are defined (by tenants), then
         # create/edit affinity/anti-affinity rules on cluster.
@@ -188,10 +186,7 @@ def update_placement(session, cluster, vm_ref, group_infos):
                 rules_spec = _create_cluster_rules_spec(
                     client_factory, rule_name, [vm_ref], policy=policy,
                     operation=operation, rule=rule)
-                if config_spec.rulesSpec is None:
-                    config_spec.rulesSpec = [rules_spec]
-                else:
-                    config_spec.rulesSpec.append(rules_spec)
+                config_spec.rulesSpec.append(rules_spec)
 
     reconfigure_cluster(session, cluster, config_spec)
 
@@ -310,10 +305,11 @@ def update_cluster_drs_vm_override(session, cluster, vm_ref, operation='add',
 
 
 @utils.synchronized('vmware-vm-group-policy')
-def clean_empty_vm_groups(session, cluster, group_names=None):
+def clean_empty_vm_groups(session, cluster, group_names=None, instance=None):
     """Delete all empty server groups
 
     Optionally filter the server groups to delete by `group_names`.
+    :param instance: Only for logging purposes
     """
     cluster_config = session._call_method(vutil,
         "get_object_property", cluster, "configurationEx")
@@ -327,8 +323,10 @@ def clean_empty_vm_groups(session, cluster, group_names=None):
             continue
 
         try:
-            LOG.debug("Deleting VM group %s", group.name)
+            LOG.debug("Deleting VM group %s", group.name, instance=instance)
             delete_vm_group(session, cluster, group)
-            LOG.debug("VM group %s deleted successfully", group.name)
+            LOG.debug("VM group %s deleted successfully", group.name,
+                instance=instance)
         except Exception as e:
-            LOG.warning("Deleting VM group %s failed: %s", group.name, e)
+            LOG.warning("Deleting VM group %s failed: %s", group.name, e,
+                instance=instance)

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -39,8 +39,6 @@ import nova.conf
 from nova import exception
 from nova.i18n import _
 from nova.network import model as network_model
-from nova import objects
-from nova.utils import vm_needs_special_spawning
 from nova.virt.vmwareapi import cluster_util
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import vim_util
@@ -351,8 +349,6 @@ VmdkInfo = collections.namedtuple('VmdkInfo', ['path', 'adapter_type',
                                                'disk_type',
                                                'capacity_in_bytes',
                                                'device'])
-
-GroupInfo = collections.namedtuple('GroupInfo', ['uuid', 'policies'])
 
 
 def _iface_id_option_value(client_factory, iface_id, port_index):
@@ -1622,33 +1618,10 @@ def get_hosts_and_reservations_for_cluster(session, cluster):
     return host_mors, _get_host_reservations_map(group_ret)
 
 
-def _get_server_groups(context, instance, include_provider_groups=False):
-    server_group_infos = []
-    try:
-        instance_group_object = objects.instance_group.InstanceGroup
-        server_group = instance_group_object.get_by_instance_uuid(
-            context, instance.uuid)
-        if server_group:
-            server_group_infos.append(GroupInfo(server_group.uuid,
-                                                server_group.policies))
-    except nova.exception.InstanceGroupNotFound:
-        pass
-
-    if include_provider_groups:
-        needs_empty_host = vm_needs_special_spawning(int(instance.memory_mb),
-                                                     instance.flavor)
-        if CONF.vmware.special_spawning_vm_group and not needs_empty_host:
-            name = CONF.vmware.special_spawning_vm_group
-            server_group_infos.append(GroupInfo(name, None))
-
-    return server_group_infos
-
-
-def update_cluster_placement(session, context, instance, cluster, vm_ref):
-    server_group_infos = _get_server_groups(context, instance,
-                                            include_provider_groups=True)
+def update_cluster_placement(session, instance, cluster, server_group_infos):
     if not server_group_infos:
         return
+    vm_ref = get_vm_ref(session, instance)
     cluster_util.update_placement(session, cluster, vm_ref, server_group_infos)
 
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -76,6 +76,9 @@ LOG = logging.getLogger(__name__)
 RESIZE_TOTAL_STEPS = 7
 
 
+GroupInfo = collections.namedtuple('GroupInfo', ['uuid', 'policies'])
+
+
 class VirtualMachineInstanceConfigInfo(object):
     """Parameters needed to create and configure a new instance."""
 
@@ -342,11 +345,6 @@ class VMwareVMOps(object):
         vm_ref = vm_util.create_vm(self._session, instance, vm_folder,
                                    config_spec, self._root_resource_pool)
 
-        vm_util.update_cluster_placement(self._session,
-                                         context,
-                                         instance,
-                                         self._cluster,
-                                         vm_ref)
         return vm_ref
 
     def _get_extra_specs(self, flavor, image_meta=None):
@@ -1129,6 +1127,12 @@ class VMwareVMOps(object):
         if serial_port_spec:
             reconfig_spec.deviceChange.append(serial_port_spec)
 
+    def update_cluster_placement(self, context, instance):
+        server_group_infos = self._get_server_groups(
+                context, instance, include_provider_groups=True)
+        vm_util.update_cluster_placement(self._session, instance,
+                                         self._cluster, server_group_infos)
+
     def spawn(self, context, instance, image_meta, injected_files,
               admin_password, network_info, block_device_info=None):
 
@@ -1173,6 +1177,8 @@ class VMwareVMOps(object):
         # Cache the vm_ref. This saves a remote call to the VC. This uses the
         # instance uuid.
         vm_util.vm_ref_cache_update(instance.uuid, vm_ref)
+
+        self.update_cluster_placement(context, instance)
 
         # Update the Neutron VNIC index
         self._update_vnic_index(context, instance, network_info)
@@ -1616,11 +1622,40 @@ class VMwareVMOps(object):
             self._session._wait_for_task(reset_task)
             LOG.debug("Did hard reboot of VM", instance=instance)
 
+    def _get_server_groups(self, context, instance,
+                           include_provider_groups=False):
+        server_group_infos = []
+        try:
+            instance_group_object = objects.instance_group.InstanceGroup
+            server_group = instance_group_object.get_by_instance_uuid(
+                context, instance.uuid)
+            if server_group:
+                server_group_infos.append(GroupInfo(server_group.uuid,
+                                                    server_group.policies))
+        except nova.exception.InstanceGroupNotFound:
+            pass
+
+        if include_provider_groups:
+            needs_empty_host = utils.vm_needs_special_spawning(
+                int(instance.memory_mb), instance.flavor)
+            if CONF.vmware.special_spawning_vm_group and not needs_empty_host:
+                name = CONF.vmware.special_spawning_vm_group
+                server_group_infos.append(GroupInfo(name, None))
+
+        return server_group_infos
+
+    def cleanup_server_groups(self, context, instance):
+        server_group_infos = self._get_server_groups(context, instance)
+        server_group_uuids = set(group_info.uuid
+                                 for group_info in server_group_infos)
+        cluster_util.clean_empty_vm_groups(self._session, self._cluster,
+                                           server_group_uuids,
+                                           instance=instance)
+
     def _destroy_instance(self, context, instance, destroy_disks=True):
         # Destroy a VM instance
         try:
             vm_ref = vm_util.get_vm_ref(self._session, instance)
-            server_group_infos = vm_util._get_server_groups(context, instance)
             lst_properties = ["config.files.vmPathName", "runtime.powerState",
                               "datastore"]
             props = self._session._call_method(vutil,
@@ -1651,10 +1686,7 @@ class VMwareVMOps(object):
                             excep, instance=instance)
 
             # Delete the VM groups it was in, if they're empty now
-            server_group_uuids = set(group_info.uuid
-                                     for group_info in server_group_infos)
-            cluster_util.clean_empty_vm_groups(self._session, self._cluster,
-                                               server_group_uuids)
+            self.cleanup_server_groups(context, instance)
 
             # Delete the folder holding the VM related content on
             # the datastore.
@@ -2141,10 +2173,7 @@ class VMwareVMOps(object):
                     LOG.error("Relocating the VM failed: %s", e,
                               instance=instance)
             else:
-                vm_util.update_cluster_placement(self._session,
-                                                 context, instance,
-                                                 self._cluster,
-                                                 vm_ref)
+                self.update_cluster_placement(context, instance)
             finally:
                 self._attach_volumes(instance, block_device_info, adapter_type)
 
@@ -2186,8 +2215,7 @@ class VMwareVMOps(object):
                     self._attach_volumes(instance, block_device_info,
                                          adapter_type)
 
-            vm_util.update_cluster_placement(self._session, context,
-                                             instance, self._cluster, vm_ref)
+            self.update_cluster_placement(context, instance)
 
         self._update_instance_progress(context, instance,
                                        step=2,


### PR DESCRIPTION
Previously vmops was calling the private function
`vm_util._get_server_groups` and that function would access to nova.object.
All other code seem to work more the way, that the nova.object retrieval is
responsibility of a VmOps (or VolumeOps) instance. `vm_util` only works
with vmware-objects (plus passed instances).

Additionally, `update_cluster_placement` was called in
`VMwareVMOps.build_virtual_machine`, which is also called for creating
a virtual machine for a vm-template out of an image.
In that case, the server-groups of the instance requiring the image
would be wrongly applied to the vm-template of the image.