### PR TITLE
Use tox to run flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,9 +27,7 @@ repos:
     hooks:
       - id: flake8
         name: flake8
-        additional_dependencies:
-          - hacking>=2.0,<3.0
         language: python
-        entry: flake8
+        entry: tox -epep8
         files: '^.*\.py$'
         exclude: '^(doc|releasenotes|tools)/.*$'


### PR DESCRIPTION
pre-commit uses a newer flake8 version, which causes new
warnings, which are partly in conflict with the old version
So we disable them instead.

Change-Id: I8a854268d3c7ea8d885915105917041430871010