### PR TITLE
api: Pre-query not deleted members in server groups

### DIFF
--- a/nova/api/openstack/compute/server_groups.py
+++ b/nova/api/openstack/compute/server_groups.py
@@ -16,6 +16,7 @@
 """The Server Group API Extension."""
 
 import collections
+import itertools
 
 from oslo_log import log as logging
 import webob
@@ -48,7 +49,12 @@ def _authorize_context(req, action):
     return context
 
 
-def _get_not_deleted(context, uuids):
+def _get_not_deleted(context, uuids, not_deleted_inst_uuids=None):
+    if not_deleted_inst_uuids:
+        # short-cut if we already pre-built a list of not deleted instances to
+        # be more efficient
+        return list(set(uuids) & not_deleted_inst_uuids)
+
     mappings = objects.InstanceMappingList.get_by_instance_uuids(
         context, uuids)
     inst_by_cell = collections.defaultdict(list)
@@ -94,7 +100,16 @@ def _should_enable_custom_max_server_rules(context, rules):
 class ServerGroupController(wsgi.Controller):
     """The Server group API controller for the OpenStack API."""
 
-    def _format_server_group(self, context, group, req):
+    def _format_server_group(self, context, group, req,
+                             not_deleted_inst_uuids=None):
+        """Format ServerGroup according to API version.
+
+        Displays only not-deleted members.
+
+        :param:not_deleted_inst_uuids: Pre-built set of instance-uuids for
+                                       multiple server-groups that are found to
+                                       be not deleted.
+        """
         # the id field has its value as the uuid of the server group
         # There is no 'uuid' key in server_group seen by clients.
         # In addition, clients see policies as a ["policy-name"] list;
@@ -114,7 +129,8 @@ class ServerGroupController(wsgi.Controller):
         members = []
         if group.members:
             # Display the instances that are not deleted.
-            members = _get_not_deleted(context, group.members)
+            members = _get_not_deleted(context, group.members,
+                                       not_deleted_inst_uuids)
         server_group['members'] = members
         # Add project id information to the response data for
         # API version v2.13
@@ -159,7 +175,12 @@ class ServerGroupController(wsgi.Controller):
             sgs = objects.InstanceGroupList.get_by_project_id(
                     context, project_id)
         limited_list = common.limited(sgs.objects, req)
-        result = [self._format_server_group(context, group, req)
+
+        members = list(itertools.chain.from_iterable(sg.members
+                                                     for sg in limited_list
+                                                     if sg.members))
+        not_deleted = set(_get_not_deleted(context, members))
+        result = [self._format_server_group(context, group, req, not_deleted)
                   for group in limited_list]
         return {'server_groups': result}
 


### PR DESCRIPTION
When retrieving multiple - or all - server groups, the code tries to
find not deleted members for each server group in every cell
individually. This is highly inefficient, which is especially noticable
when the number of server groups rises.

We change this to query all members of all server-groups we will reply
with (i.e. from the already limited list) in advance and pass this set
of existing uuids into the function formatting the server group. This is
more efficient, because we only do one large query instead of up to 1000
times the number of cells.

Change-Id: I3459ce7a8bec9a9e6f3a3b496a3e441078b86af0