### PR TITLE
VmWare: Remove unused legacy_nodename regex

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -76,13 +76,6 @@ class VMwareVCDriver(driver.ComputeDriver):
         "supports_trusted_certs": False,
     }
 
-    # Legacy nodename is of the form: <mo id>(<cluster name>)
-    # e.g. domain-26(TestCluster)
-    # We assume <mo id> consists of alphanumeric, _ and -.
-    # We assume cluster name is everything between the first ( and the last ).
-    # We pull out <mo id> for re-use.
-    LEGACY_NODENAME = re.compile('([\w-]+)\(.+\)')
-
     # The vCenter driver includes API that acts on ESX hosts or groups
     # of ESX hosts in clusters or non-cluster logical-groupings.
     #


### PR DESCRIPTION
The regex isn't used anywhere, and uses an unescaped format

Change-Id: I76aaf133af517eb70fcaf3783953625c63141083