### PR TITLE
Vmware: Query Drs state directly in driver

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -257,7 +257,7 @@ def _get_rule(cluster_config, rule_name):
             return rule
 
 
-def _is_drs_enabled(session, cluster):
+def is_drs_enabled(session, cluster):
     """Check if DRS is enabled on a given cluster"""
     drs_config = session._call_method(vim_util, "get_object_property", cluster,
                                       "configuration.drsConfig")

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -43,6 +43,7 @@ import nova.privsep.path
 from nova import rc_fields as fields
 from nova import utils
 from nova.virt import driver
+from nova.virt.vmwareapi import cluster_util
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import ds_util
 from nova.virt.vmwareapi import error_util
@@ -143,10 +144,8 @@ class VMwareVCDriver(driver.ComputeDriver):
                                       self._nodename,
                                       self._cluster_ref,
                                       self._datastore_regex)
-        host_stats = self._vc_state.get_host_stats()
-        self.capabilities['resource_scheduling'] = host_stats.get(
-            'resource_scheduling')
-
+        self.capabilities['resource_scheduling'] = \
+            cluster_util.is_drs_enabled(self._session, self._cluster_ref)
         # Register the OpenStack extension
         self._register_openstack_extension()
 

--- a/nova/virt/vmwareapi/host.py
+++ b/nova/virt/vmwareapi/host.py
@@ -26,7 +26,6 @@ from nova import context
 from nova import exception
 from nova import objects
 from nova.objects import fields as obj_fields
-from nova.virt.vmwareapi import cluster_util
 from nova.virt.vmwareapi import ds_util
 from nova.virt.vmwareapi import vim_util
 from nova.virt.vmwareapi import vm_util
@@ -124,8 +123,6 @@ class VCState(object):
              obj_fields.HVType.VMWARE,
              obj_fields.VMMode.HVM)]
         data["cpu_model"] = self.to_cpu_model()
-        data["resource_scheduling"] = cluster_util._is_drs_enabled(
-                                            self._session, self._cluster)
 
         self._stats = data
         if self._auto_service_disabled:


### PR DESCRIPTION
No need for an additional indirection, as the driver is the only
user of the information, and query the value directly

Change-Id: I6d44910c420de4c76b6112904ccfebe3ec923098