### PR TITLE
cluster_util: Fix adding to groupSpec

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -49,7 +49,7 @@ def _create_vm_group_spec(client_factory, group_info, vm_refs,
     group_spec = client_factory.create('ns0:ClusterGroupSpec')
     group_spec.operation = operation
     group_spec.info = group
-    return [group_spec]
+    return group_spec
 
 
 def _create_host_group_spec(client_factory, name, host_refs, operation="add",


### PR DESCRIPTION
_create_vm_group_spec() returned a list with one element and thus we
would append a group_spec in a list to the groupSpec list. Returning
just the ClusterGroupSpec object seems the better choice, given we only
have that one consumer of the function.

Change-Id: Id19cedd4808b9b58e5e734f8b1102f7bbbd3f619