### PR TITLE
VMware: warmup moref cache

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -207,14 +207,16 @@ class VMwareVMOpsTestCase(test.TestCase):
         path = ds_obj.DatastorePath(ds_name, base_name)
         return ds_name, ds_ref, ops, path, dc_ref
 
+    @mock.patch.object(vmops.VMwareVMOps, 'update_vmref_cache')
     @mock.patch.object(ds_util, 'mkdir')
-    def test_create_folder_if_missing(self, mock_mkdir):
+    def test_create_folder_if_missing(self, mock_mkdir, cache_mock):
         ds_name, ds_ref, ops, path, dc = self._setup_create_folder_mocks()
         ops._create_folder_if_missing(ds_name, ds_ref, 'folder')
         mock_mkdir.assert_called_with(ops._session, path, dc)
 
+    @mock.patch.object(vmops.VMwareVMOps, 'update_vmref_cache')
     @mock.patch.object(ds_util, 'mkdir')
-    def test_create_folder_if_missing_exception(self, mock_mkdir):
+    def test_create_folder_if_missing_exception(self, mock_mkdir, cache_mock):
         ds_name, ds_ref, ops, path, dc = self._setup_create_folder_mocks()
         ds_util.mkdir.side_effect = vexc.FileAlreadyExistsException()
         ops._create_folder_if_missing(ds_name, ds_ref, 'folder')

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -159,6 +159,9 @@ class VMwareVMOps(object):
                                                         self._base_folder)
         self._network_api = network.API()
 
+        # pre-warm the cache, so we don't have to do extra queries per instance
+        self.update_vmref_cache()
+
     def _get_base_folder(self):
         # Enable more than one compute node to run on the same host
         if CONF.vmware.cache_prefix:
@@ -3111,3 +3114,13 @@ class VMwareVMOps(object):
             [property_spec, property_spec_vm],
             [object_spec])
         return property_filter_spec
+
+    def update_vmref_cache(self):
+        """List all VMs in the cluster and cache their morefs"""
+        props = ['config.instanceUuid']
+        instances = self._list_instances_in_cluster(props, include_moref=True)
+        for vm_uuid, props in instances:
+            if vm_uuid != props.get('config.instanceUuid'):
+                continue
+
+            vm_util.vm_ref_cache_update(vm_uuid, props['obj'])

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2666,11 +2666,15 @@ class VMwareVMOps(object):
                         self._unregister_template_vm(templ_vm_ref)
 
     def _get_valid_vms_from_retrieve_result(self, retrieve_result,
-                                            return_properties=False):
+                                            return_properties=False,
+                                            include_moref=False):
         """Returns list of valid vms from RetrieveResult object.
 
         If `return_properties` is True, it will also return the properties of
         these VMs, thus returning a tuple (vm_uuid, properties).
+
+        If `include_moref' is True, it will return a tuple as above and the
+        properties will include a special "obj" key containing the moref.
         """
         lst_vms = []
 
@@ -2692,6 +2696,9 @@ class VMwareVMOps(object):
                 # Ignoring the orphaned or inaccessible VMs
                 if conn_state in ["orphaned", "inaccessible"]:
                     continue
+
+                if include_moref:
+                    props['obj'] = vm.obj
 
                 if return_properties:
                     lst_vms.append((vm_uuid, props))
@@ -2928,7 +2935,8 @@ class VMwareVMOps(object):
 
         return lst_vm_names
 
-    def _list_instances_in_cluster(self, additional_properties=None):
+    def _list_instances_in_cluster(self, additional_properties=None,
+                                   include_moref=False):
         """Lists the VM instances that are registered with vCenter cluster."""
         properties = ['runtime.connectionState',
                       'config.extraConfig["nvp.vm-uuid"]']
@@ -2941,9 +2949,10 @@ class VMwareVMOps(object):
             vms = self._session._call_method(
                 vim_util, 'get_inner_objects', self._root_resource_pool, 'vm',
                 'VirtualMachine', properties)
-        return_properties = additional_properties is not None
+        return_properties = additional_properties is not None or include_moref
         lst_vm_names = self._get_valid_vms_from_retrieve_result(vms,
-                                        return_properties=return_properties)
+                                        return_properties=return_properties,
+                                        include_moref=include_moref)
 
         return lst_vm_names
 


### PR DESCRIPTION
In the upcoming sync-loop for DRS rules, we need to map all instance UUIDs mentioned in a server-group to a moref. The idea is, to use the cache for this. Therefore and to reduce the number of queries to the vCenter, we pre-fill the cache.