### PR TITLE
VMware: cluster_util group and rule creation refactoring

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -211,43 +211,57 @@ def update_placement(session, cluster, vm_ref, group_infos):
     reconfigure_cluster(session, cluster, config_spec)
 
 
+def create_vm_rule(client_factory, name, vm_refs, policy='affinity',
+                   rule=None):
+    """Create a ClusterAffinityRuleSpec or ClusterAntiAffinityRuleSpec object
+
+    :param:policy: Defines with of the object types is created. "affinity" and
+                   "soft-affinity" map to ClusterAffinityRuleSpec,
+                   "anti-affinity" and "soft-anti-affinity" map to
+                   ClusterAntiAffinityRuleSpec. Ignored if "rule" is given
+    :param:rule: if given, don't create any object, but instead update the
+                 given object's attributes. "policy" is ignored here.
+    """
+    if rule is None:
+        if policy in ('affinity', 'soft-affinity'):
+            obj_type = 'ns0:ClusterAffinityRuleSpec'
+        elif policy in ('anti-affinity', 'soft-anti-affinity'):
+            obj_type = 'ns0:ClusterAntiAffinityRuleSpec'
+        else:
+            msg = 'Policy {} is not supported.'.format(policy)
+            raise exception.ValidationError(msg)
+
+        rule = client_factory.create(obj_type)
+
+    rule.name = name
+    rule.enabled = True
+    rule.vm = vm_refs
+
+    return rule
+
+
+def create_rule_spec(client_factory, rule, operation='add'):
+    """Create a ClusterRuleSpec object"""
+    rule_spec = client_factory.create('ns0:ClusterRuleSpec')
+    rule_spec.operation = operation
+    rule_spec.info = rule
+    if operation == 'remove':
+        rule_spec.removeKey = rule.key
+    return rule_spec
+
+
 def _create_cluster_rules_spec(client_factory, name, vm_refs,
                                policy='affinity', operation="add",
                                rule=None):
-
-    rules_spec = client_factory.create('ns0:ClusterRuleSpec')
-    rules_spec.operation = operation
-    if policy == 'affinity' or policy == 'soft-affinity':
-        policy_class = 'ns0:ClusterAffinityRuleSpec'
-    elif policy == 'anti-affinity' or policy == 'soft-anti-affinity':
-        policy_class = 'ns0:ClusterAntiAffinityRuleSpec'
-    else:
-        msg = _('%s policy is not supported.') % policy
-        raise exception.Invalid(msg)
-
-    rules_info = client_factory.create(policy_class)
-    rules_info.name = name
-    rules_info.enabled = True
-    rules_info.mandatory = True
-    if operation == "edit":
-        rules_info.vm = rule.vm + vm_refs
-        rules_info.key = rule.key
-        rules_info.ruleUuid = rule.ruleUuid
-    else:
-        rules_info.vm = vm_refs
-
-    rules_spec.info = rules_info
-    return rules_spec
+    if operation == 'edit':
+        vm_refs = vm_refs + rule.vm
+    rule = create_vm_rule(client_factory, name, vm_refs, policy, rule)
+    return create_rule_spec(client_factory, rule, operation)
 
 
 def _create_cluster_group_rules_spec(client_factory, name, vm_group_name,
                                      host_group_name, policy='affinity',
                                      rule=None):
-    operation = 'add' if rule is None else 'edit'
-
-    rules_spec = client_factory.create('ns0:ClusterRuleSpec')
-    rules_spec.operation = operation
-
     rules_info = client_factory.create('ns0:ClusterVmHostRuleInfo')
     rules_info.name = name
     rules_info.enabled = True
@@ -265,8 +279,8 @@ def _create_cluster_group_rules_spec(client_factory, name, vm_group_name,
         rules_info.key = rule.key
         rules_info.ruleUuid = rule.ruleUuid
 
-    rules_spec.info = rules_info
-    return rules_spec
+    operation = 'add' if rule is None else 'edit'
+    return create_rule_spec(client_factory, rules_info, operation)
 
 
 def _get_rule(cluster_config, rule_name):

--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -31,28 +31,25 @@ def reconfigure_cluster(session, cluster, config_spec):
     session.wait_for_task(reconfig_task)
 
 
-def _create_vm_group_spec(client_factory, group_info, vm_refs,
-                          operation="add", group=None):
+def create_vm_group(client_factory, name, vm_refs, group=None):
+    """Create a ClusterVmGroup object
+
+    :param:group: if given, update this ClusterVmGroup object instead of
+                  creating a new one
+    """
     group = group or client_factory.create('ns0:ClusterVmGroup')
-    group.name = group_info.uuid
+    group.name = name
+    group.vm = vm_refs
 
-    # On vCenter UI, it is not possible to create VM group without
-    # VMs attached to it. But, using APIs, it is possible to create
-    # VM group without VMs attached. Therefore, check for existence
-    # of vm attribute in the group to avoid exceptions
-    if hasattr(group, 'vm'):
-        group.vm += vm_refs
-    else:
-        group.vm = vm_refs
-
-    group_spec = client_factory.create('ns0:ClusterGroupSpec')
-    group_spec.operation = operation
-    group_spec.info = group
-    return group_spec
+    return group
 
 
-def _create_host_group_spec(client_factory, name, host_refs, operation="add",
-                            group=None):
+def create_host_group(client_factory, name, host_refs, group=None):
+    """Create a ClusterHostGroup object
+
+    :param:group: if given, update the ClusterHostGroup object instead of
+                  creating a new one
+    """
     group = group or client_factory.create('ns0:ClusterHostGroup')
     group.name = name
 
@@ -61,10 +58,37 @@ def _create_host_group_spec(client_factory, name, host_refs, operation="add",
     else:
         group.host = host_refs
 
+    return group
+
+
+def create_group_spec(client_factory, group, operation):
+    """Create a ClusterGroupSpec object"""
+    if operation not in ('add', 'edit', 'remove'):
+        msg = 'Invalid operation for ClusterGroupSpec: {}'.format(operation)
+        raise exception.ValidationError(msg)
+
     group_spec = client_factory.create('ns0:ClusterGroupSpec')
     group_spec.operation = operation
     group_spec.info = group
+    if operation == 'remove':
+        group_spec.removeKey = group.name
+
     return group_spec
+
+
+def _create_vm_group_spec(client_factory, group_info, vm_refs,
+                          operation="add", group=None):
+    if group:
+        # On vCenter UI, it is not possible to create VM group without
+        # VMs attached to it. But, using APIs, it is possible to create
+        # VM group without VMs attached. Therefore, check for existence
+        # of vm attribute in the group to avoid exceptions
+        if hasattr(group, 'vm'):
+            vm_refs = vm_refs + group.vm
+
+    group = create_vm_group(client_factory, group_info.uuid, vm_refs, group)
+
+    return create_group_spec(client_factory, group, operation)
 
 
 def _get_vm_group(cluster_config, group_info):
@@ -129,12 +153,9 @@ def delete_vm_group(session, cluster, vm_group):
      vm group
      """
     client_factory = session.vim.client.factory
-    group_spec = client_factory.create('ns0:ClusterGroupSpec')
     groups = []
 
-    group_spec.info = vm_group
-    group_spec.operation = "remove"
-    group_spec.removeKey = vm_group.name
+    group_spec = create_group_spec(client_factory, vm_group, "remove")
     groups.append(group_spec)
 
     config_spec = client_factory.create('ns0:ClusterConfigSpecEx')

--- a/nova/virt/vmwareapi/special_spawning.py
+++ b/nova/virt/vmwareapi/special_spawning.py
@@ -147,10 +147,8 @@ class _SpecialVmSpawningServer(object):
 
         client_factory = self._session.vim.client.factory
 
-        group_spec = client_factory.create('ns0:ClusterGroupSpec')
-        group_spec.operation = 'remove'
-        group_spec.removeKey = group.name
-
+        group_spec = cluster_util.create_group_spec(client_factory, group,
+                                                    'remove')
         config_spec = client_factory.create('ns0:ClusterConfigSpecEx')
         config_spec.groupSpec = [group_spec]
         cluster_util.reconfigure_cluster(self._session, self._cluster,
@@ -271,9 +269,11 @@ class _SpecialVmSpawningServer(object):
             # we need to either create the group from scratch or at least add a
             # host to it
             operation = 'add' if group is None else 'edit'
-            group_spec = cluster_util._create_host_group_spec(client_factory,
+            group = cluster_util.create_host_group(client_factory,
                 CONF.vmware.bigvm_deployment_free_host_hostgroup_name,
-                [host_ref], operation, group)
+                [host_ref], group)
+            group_spec = cluster_util.create_group_spec(client_factory,
+                group, operation)
             config_spec.groupSpec = [group_spec]
 
             # create the appropriate rule for VMs to leave the host


### PR DESCRIPTION
The interface for creating rules/groups in `cluster_util` was very limiting as it was only written with the local function for applying server-groups on vm-creation.

With us trying to implement a sync-loop for server-groups, we need a little more freedom. There are explicit functions for creating vm/host groups and vm rules and their appropriate specs for applying those rules/groups to a `ClusterConfigSpecEx` now, and the old interface is available modul-local for compatibility, reusing the new functions.