### PR TITLE
vmware: Save the ComputeNode host name for later

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -146,6 +146,9 @@ class VMwareVCDriver(driver.ComputeDriver):
         virtapi._compute.additional_endpoints.append(
             special_spawning._SpecialVmSpawningServer(self))
 
+        # filled by init_host(). contains the ComputeNode host name
+        self._compute_host = None
+
     def _check_min_version(self):
         min_version = v_utils.convert_version_to_int(constants.MIN_VC_VERSION)
         next_min_ver = v_utils.convert_version_to_int(
@@ -193,6 +196,8 @@ class VMwareVCDriver(driver.ComputeDriver):
         vim = self._session.vim
         if vim is None:
             self._session._create_session()
+
+        self._compute_host = host
 
     def cleanup_host(self, host):
         self._session.logout()


### PR DESCRIPTION
When init_host() is called, we keep the provided host as an attribute so
we can later refer to it when e.g. getting all instances for the host
the driver is running for.

Change-Id: I261006a727125a87c204564f95ec8797060cd557