### PR TITLE
api: update server group members

### DIFF
--- a/nova/api/openstack/compute/routes.py
+++ b/nova/api/openstack/compute/routes.py
@@ -705,6 +705,7 @@ ROUTE_LIST = (
     }),
     ('/os-server-groups/{id}', {
         'GET': [server_groups_controller, 'show'],
+        'PUT': [server_groups_controller, 'update'],
         'DELETE': [server_groups_controller, 'delete']
     }),
     ('/os-services', {

--- a/nova/api/openstack/compute/schemas/server_groups.py
+++ b/nova/api/openstack/compute/schemas/server_groups.py
@@ -83,3 +83,18 @@ server_groups_query_param = {
     # For backward compatible changes
     'additionalProperties': True
 }
+
+update = {
+    'type': 'object',
+    'properties': {
+        'add_members': {
+            'type': 'array',
+            'items': parameter_types.server_id,
+        },
+        'remove_members': {
+            'type': 'array',
+            'items': parameter_types.server_id,
+        }
+    },
+    'additionalProperties': False
+}

--- a/nova/api/openstack/compute/server_groups.py
+++ b/nova/api/openstack/compute/server_groups.py
@@ -49,17 +49,18 @@ def _authorize_context(req, action):
     return context
 
 
-def _get_not_deleted(context, uuids, not_deleted_inst_uuids=None):
-    if not_deleted_inst_uuids:
+def _get_not_deleted(context, uuids, not_deleted_inst=None):
+    if not_deleted_inst:
         # short-cut if we already pre-built a list of not deleted instances to
         # be more efficient
-        return list(set(uuids) & not_deleted_inst_uuids)
+        return {u: not_deleted_inst[u] for u in uuids
+                if u in not_deleted_inst}
 
     mappings = objects.InstanceMappingList.get_by_instance_uuids(
         context, uuids)
     inst_by_cell = collections.defaultdict(list)
     cell_mappings = {}
-    found_inst_uuids = []
+    found_inst = {}
 
     # Get a master list of cell mappings, and a list of instance
     # uuids organized by cell
@@ -67,7 +68,7 @@ def _get_not_deleted(context, uuids, not_deleted_inst_uuids=None):
         if not im.cell_mapping:
             # Not scheduled yet, so just throw it in the final list
             # and move on
-            found_inst_uuids.append(im.instance_uuid)
+            found_inst[im.instance_uuid] = None
             continue
         if im.cell_mapping.uuid not in cell_mappings:
             cell_mappings[im.cell_mapping.uuid] = im.cell_mapping
@@ -81,11 +82,11 @@ def _get_not_deleted(context, uuids, not_deleted_inst_uuids=None):
                   {'cell': cell_mapping.identity, 'num': len(uuids)})
         filters = {'uuid': inst_uuids, 'deleted': False}
         with nova_context.target_cell(context, cell_mapping) as ctx:
-            found_inst_uuids.extend([
-                inst.uuid for inst in objects.InstanceList.get_by_filters(
-                    ctx, filters=filters)])
+            instances = objects.InstanceList.get_by_filters(
+                            ctx, filters=filters)
+            found_inst.update({inst.uuid: inst.host for inst in instances})
 
-    return found_inst_uuids
+    return found_inst
 
 
 def _should_enable_custom_max_server_rules(context, rules):
@@ -101,14 +102,14 @@ class ServerGroupController(wsgi.Controller):
     """The Server group API controller for the OpenStack API."""
 
     def _format_server_group(self, context, group, req,
-                             not_deleted_inst_uuids=None):
+                             not_deleted_inst=None):
         """Format ServerGroup according to API version.
 
         Displays only not-deleted members.
 
-        :param:not_deleted_inst_uuids: Pre-built set of instance-uuids for
-                                       multiple server-groups that are found to
-                                       be not deleted.
+        :param:not_deleted_inst: Pre-built dict of instance-uuid: host for
+                                 multiple server-groups that are found to be
+                                 not deleted.
         """
         # the id field has its value as the uuid of the server group
         # There is no 'uuid' key in server_group seen by clients.
@@ -129,8 +130,8 @@ class ServerGroupController(wsgi.Controller):
         members = []
         if group.members:
             # Display the instances that are not deleted.
-            members = _get_not_deleted(context, group.members,
-                                       not_deleted_inst_uuids)
+            members = list(_get_not_deleted(context, group.members,
+                           not_deleted_inst))
         server_group['members'] = members
         # Add project id information to the response data for
         # API version v2.13
@@ -179,7 +180,7 @@ class ServerGroupController(wsgi.Controller):
         members = list(itertools.chain.from_iterable(sg.members
                                                      for sg in limited_list
                                                      if sg.members))
-        not_deleted = set(_get_not_deleted(context, members))
+        not_deleted = _get_not_deleted(context, members)
         result = [self._format_server_group(context, group, req, not_deleted)
                   for group in limited_list]
         return {'server_groups': result}

--- a/nova/api/openstack/compute/server_groups.py
+++ b/nova/api/openstack/compute/server_groups.py
@@ -243,3 +243,108 @@ class ServerGroupController(wsgi.Controller):
                 raise exc.HTTPForbidden(explanation=msg)
 
         return {'server_group': self._format_server_group(context, sg, req)}
+
+    @wsgi.Controller.api_version("2.64")
+    @validation.schema(schema.update)
+    @wsgi.expected_errors((400, 404))
+    def update(self, req, id, body):
+        """Update a server-group's members
+
+        Striving for idempotency, we accept already removed or already
+        contained members.
+
+        We always remove first and then check if we can add the requested
+        members. That way, removing an instance for a host and adding another
+        one works in one request.
+
+        We do all requested changes or no change.
+        """
+        context = _authorize_context(req, 'update')
+        try:
+            sg = objects.InstanceGroup.get_by_uuid(context, id)
+        except nova.exception.InstanceGroupNotFound as e:
+            raise webob.exc.HTTPNotFound(explanation=e.format_message())
+
+        members_to_remove = set(body.get('remove_members', []))
+        members_to_add = set(body.get('add_members', []))
+        LOG.info('Called update for server-group %s with add_members: %s and '
+                 'remove_members %s',
+                 id, ', '.join(members_to_add), ', '.join(members_to_remove))
+
+        overlap = members_to_remove & members_to_add
+        if overlap:
+            msg = ('Parameters "add_members" and "remove_members" are '
+                  'overlapping in {}'.format(', '.join(overlap)))
+            raise exc.HTTPBadRequest(explanation=msg)
+
+        if not members_to_remove and not members_to_add:
+            LOG.info("No update requested.")
+            formatted_sg = self._format_server_group(context, sg, req)
+            return {'server_group': formatted_sg}
+
+        # don't do work if it's not necessary. we might be able to get a fast
+        # way out if this request is already fulfilled
+        members_to_remove = members_to_remove & set(sg.members)
+        members_to_add = members_to_add - set(sg.members)
+
+        if not members_to_remove and not members_to_add:
+            LOG.info("State already satisfied.")
+            formatted_sg = self._format_server_group(context, sg, req)
+            return {'server_group': formatted_sg}
+
+        # retrieve all the instances to add, failing if one doesn't exist,
+        # because we need to check the hosts against the policy and adding
+        # non-existent instances doesn't make sense
+        found_instances_hosts = _get_not_deleted(context, members_to_add)
+        missing_uuids = members_to_add - set(found_instances_hosts)
+        if missing_uuids:
+            msg = ("One or more members in add_members cannot be found: {}"
+                   .format(', '.join(missing_uuids)))
+            raise exc.HTTPBadRequest(explanation=msg)
+
+        # check if the policy is still valid with these changes
+        if sg.policy in ('affinity', 'anti-affinity'):
+            current_members_hosts = _get_not_deleted(context, sg.members)
+            current_hosts = set(h for u, h in current_members_hosts.items()
+                                if u not in members_to_remove)
+            if sg.policy == 'affinity':
+                outliers = [u for u, h in found_instances_hosts.items()
+                            if h and h not in current_hosts]
+            elif sg.policy == 'anti-affinity':
+                outliers = [u for u, h in found_instances_hosts.items()
+                            if h and h in current_hosts]
+            else:
+                outliers = None
+                LOG.warning('server-group update check not implemented for '
+                            'policy %s', sg.policy)
+            if outliers:
+                LOG.info('Update of server-group %s with policy %s aborted: '
+                         'policy violation by %s',
+                         id, sg.policy, ', '.join(outliers))
+                msg = ("Adding instance(s) {} would violate policy '{}'."
+                       .format(', '.join(outliers), sg.policy))
+                raise exc.HTTPBadRequest(explanation=msg)
+
+        # update the server group and save it
+        if members_to_remove:
+            objects.InstanceGroup.remove_members(context, sg.id,
+                                                 members_to_remove, sg.uuid)
+        if members_to_add:
+            try:
+                objects.InstanceGroup.add_members(context, id, members_to_add)
+            except Exception:
+                LOG.exception('Failed to add members.')
+                if members_to_remove:
+                    LOG.info('Trying to add removed members again after '
+                             'error.')
+                    objects.InstanceGroup.add_members(context, id,
+                                                      members_to_remove)
+                raise
+
+        LOG.info("Changed server-group %s in DB.", id)
+
+        # refresh InstanceGroup object, because we changed it directly in the
+        # DB.
+        sg.refresh()
+
+        return {'server_group': self._format_server_group(context, sg, req)}

--- a/nova/api/openstack/compute/server_groups.py
+++ b/nova/api/openstack/compute/server_groups.py
@@ -302,6 +302,19 @@ class ServerGroupController(wsgi.Controller):
                    .format(', '.join(missing_uuids)))
             raise exc.HTTPBadRequest(explanation=msg)
 
+        # check if (some of) the VMs are already members of another
+        # instance_group. We cannot support this as they might contradict.
+        found_server_groups = \
+            objects.InstanceGroupList.get_by_instance_uuids(context,
+                                                            members_to_add)
+        other_server_groups = [_x.uuid for _x in found_server_groups
+                               if _x.uuid != id]
+        if other_server_groups:
+            msg = ("One ore more members in add_members is already assigned "
+                   "to another server group. Server groups: {}"
+                   .format(', '.join(other_server_groups)))
+            raise exc.HTTPBadRequest(explanation=msg)
+
         # check if the policy is still valid with these changes
         if sg.policy in ('affinity', 'anti-affinity'):
             current_members_hosts = _get_not_deleted(context, sg.members)

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -769,6 +769,21 @@ def notify_about_server_group_add_member(context, group_id):
 
 
 @rpc.if_notifications_enabled
+def notify_about_server_group_remove_member(context, group_id):
+    group = objects.InstanceGroup.get_by_uuid(context, group_id)
+    payload = sg_notification.ServerGroupPayload(group)
+    notification = sg_notification.ServerGroupNotification(
+        priority=fields.NotificationPriority.INFO,
+        publisher=notification_base.NotificationPublisher(
+            host=CONF.host, source=fields.NotificationSource.API),
+        event_type=notification_base.EventType(
+            object='server_group',
+            action=fields.NotificationAction.REMOVE_MEMBER),
+        payload=payload)
+    notification.emit(context)
+
+
+@rpc.if_notifications_enabled
 def notify_about_instance_rebuild(context, instance, host,
                                   action=fields.NotificationAction.REBUILD,
                                   phase=None,

--- a/nova/objects/fields.py
+++ b/nova/objects/fields.py
@@ -852,6 +852,7 @@ class NotificationAction(BaseNovaEnum):
     ADD_HOST = 'add_host'
     REMOVE_HOST = 'remove_host'
     ADD_MEMBER = 'add_member'
+    REMOVE_MEMBER = 'remove_member'
     UPDATE_METADATA = 'update_metadata'
     LOCK = 'lock'
     UNLOCK = 'unlock'
@@ -866,8 +867,9 @@ class NotificationAction(BaseNovaEnum):
            LIVE_MIGRATION_ROLLBACK_DEST, REBUILD, INTERFACE_DETACH,
            RESIZE_CONFIRM, RESIZE_PREP, RESIZE_REVERT, SHELVE_OFFLOAD,
            SOFT_DELETE, TRIGGER_CRASH_DUMP, UNRESCUE, UNSHELVE, ADD_HOST,
-           REMOVE_HOST, ADD_MEMBER, UPDATE_METADATA, LOCK, UNLOCK,
-           REBUILD_SCHEDULED, UPDATE_PROP, LIVE_MIGRATION_FORCE_COMPLETE)
+           REMOVE_HOST, ADD_MEMBER, REMOVE_MEMBER, UPDATE_METADATA, LOCK,
+           UNLOCK, REBUILD_SCHEDULED, UPDATE_PROP,
+           LIVE_MIGRATION_FORCE_COMPLETE)
 
 
 # TODO(rlrossit): These should be changed over to be a StateMachine enum from

--- a/nova/objects/instance_group.py
+++ b/nova/objects/instance_group.py
@@ -328,9 +328,6 @@ class InstanceGroup(base.NovaPersistentObject, base.NovaObject,
     @staticmethod
     @db_api.api_context_manager.writer
     def _remove_members_in_db(context, group_id, instance_uuids):
-        # There is no public method provided for removing members because the
-        # user-facing API doesn't allow removal of instance group members. We
-        # need to be able to remove members to address quota races.
         context.session.query(api_models.InstanceGroupMember).\
             filter_by(group_id=group_id).\
             filter(api_models.InstanceGroupMember.instance_uuid.
@@ -483,6 +480,16 @@ class InstanceGroup(base.NovaPersistentObject, base.NovaObject,
                                                        "addmember", payload)
         compute_utils.notify_about_server_group_add_member(context, group_uuid)
         return list(members)
+
+    @base.remotable_classmethod
+    def remove_members(cls, context, group_id, instance_uuids, group_uuid):
+        payload = {'server_group_id': group_uuid,
+                   'instance_uuids': instance_uuids}
+        cls._remove_members_in_db(context, group_id, instance_uuids)
+        compute_utils.notify_about_server_group_update(context,
+                                                       "removemember", payload)
+        compute_utils.notify_about_server_group_remove_member(context,
+                                                              group_uuid)
 
     @base.remotable
     def get_hosts(self, exclude=None):

--- a/nova/objects/instance_group.py
+++ b/nova/objects/instance_group.py
@@ -557,6 +557,21 @@ class InstanceGroupList(base.ObjectListBase, base.NovaObject):
             counts['user'] = {'server_groups': query.count()}
         return counts
 
+    @staticmethod
+    @db_api.api_context_manager.reader
+    def _get_from_db_by_instance_uuids(context, instance_uuids):
+        if not instance_uuids:
+            return []
+
+        members = set(instance_uuids)
+        groups = context.session.query(api_models.InstanceGroup).\
+            join(api_models.InstanceGroupMember,
+            api_models.InstanceGroupMember.group_id == api_models.InstanceGroup.id).\
+            filter(api_models.InstanceGroupMember.instance_uuid.in_(members)).\
+            options(joinedload('_policies')).\
+            options(contains_eager('_members')).all()
+        return groups
+
     @base.remotable_classmethod
     def get_by_project_id(cls, context, project_id):
         api_db_groups = cls._get_from_db(context, project_id=project_id)
@@ -583,3 +598,10 @@ class InstanceGroupList(base.ObjectListBase, base.NovaObject):
                      'user': {'server_groups': <count across user>}}
         """
         return cls._get_counts_from_db(context, project_id, user_id=user_id)
+
+    @base.remotable_classmethod
+    def get_by_instance_uuids(cls, context, instance_uuids):
+        api_db_groups = cls._get_from_db_by_instance_uuids(context,
+                                                           instance_uuids)
+        return base.obj_make_list(context, cls(context), objects.InstanceGroup,
+                                  api_db_groups)

--- a/nova/policies/server_groups.py
+++ b/nova/policies/server_groups.py
@@ -73,6 +73,17 @@ server_groups_policies = [
             }
         ]
     ),
+    policy.DocumentedRuleDefault(
+        POLICY_ROOT % 'update',
+        BASE_POLICY_RULE,
+        "Update members of a server group",
+        [
+            {
+                'path': '/os-server-groups/{server_group_id}',
+                'method': 'PUT'
+            }
+        ]
+    ),
 ]
 
 

--- a/nova/rpc.py
+++ b/nova/rpc.py
@@ -368,6 +368,7 @@ class LegacyValidatingNotifier(object):
         'scheduler.select_destinations.end',
         'scheduler.select_destinations.start',
         'servergroup.addmember',
+        'servergroup.removemember',
         'servergroup.create',
         'servergroup.delete',
         'volume.usage',

--- a/nova/tests/unit/api/openstack/compute/test_server_groups.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_groups.py
@@ -857,7 +857,8 @@ class ServerGroupTestV264(ServerGroupTestV213):
         self.assertRaises(webob.exc.HTTPNotFound,
             self.controller.update, req, uuidsentinel.group1, body={})
 
-    def test_update_server_group_empty(self):
+    @mock.patch('nova.compute.api.API.sync_server_group')
+    def test_update_server_group_empty(self, mock_sync):
         """We do not fail if the user doesn't request any changes"""
         req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
         ctx = context.RequestContext('fake_user', 'fake')
@@ -867,6 +868,7 @@ class ServerGroupTestV264(ServerGroupTestV213):
         self.assertEqual(3, len(result_members))
         for member in members:
             self.assertIn(member, result_members)
+        mock_sync.assert_not_called()
 
     def test_update_server_group_add_remove_overlap(self):
         """We do not accept changes, if there's a server to be both added and
@@ -886,7 +888,8 @@ class ServerGroupTestV264(ServerGroupTestV213):
                       'overlapping in {}'.format(uuidsentinel.uuid2),
                       six.text_type(result))
 
-    def test_update_server_group_remove_nonexisting(self):
+    @mock.patch('nova.compute.api.API.sync_server_group')
+    def test_update_server_group_remove_nonexisting(self, mock_sync):
         """Don't fail if the user tries to remove a server not being member of
         the server group.
         """
@@ -901,8 +904,10 @@ class ServerGroupTestV264(ServerGroupTestV213):
         self.assertEqual(3, len(result_members))
         for member in members:
             self.assertIn(member, result_members)
+        mock_sync.assert_not_called()
 
-    def test_update_server_group_add_already_added(self):
+    @mock.patch('nova.compute.api.API.sync_server_group')
+    def test_update_server_group_add_already_added(self, mock_sync):
         """Don't fail if the user adds a server that's already a member of the
         server group.
         """
@@ -917,6 +922,7 @@ class ServerGroupTestV264(ServerGroupTestV213):
         self.assertEqual(3, len(result_members))
         for member in members:
             self.assertIn(member, result_members)
+        mock_sync.assert_not_called()
 
     def test_update_server_group_add_against_policy_affinity(self):
         """Fail if adding the server would break the policy."""
@@ -964,11 +970,11 @@ class ServerGroupTestV264(ServerGroupTestV213):
                       "'anti-affinity'.".format(new_instance.uuid),
                       six.text_type(result))
 
-    def test_update_server_group_add_with_remove_fixes_policy(self):
+    @mock.patch('nova.compute.api.API.sync_server_group')
+    def test_update_server_group_add_with_remove_fixes_policy(self, mock_sync):
         """Don't fail if adding a server would break the policy, but the remove
         in the same request fixes that.
         """
-        """Fail if adding the server would break the policy."""
         req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
         ctx = context.RequestContext('fake_user', 'fake')
 
@@ -991,6 +997,9 @@ class ServerGroupTestV264(ServerGroupTestV213):
         self.assertEqual(2, len(result_members))
         for member in [instances[0].uuid, new_instance.uuid]:
             self.assertIn(member, result_members)
+        req_context = req.environ['nova.context']
+        mock_sync.assert_called_with(req_context, set(['host2']),
+                                     ig_uuid)
 
     def test_update_server_group_add_nonexisting_instance(self):
         """Fail if the instances the user tries to add does not exist."""
@@ -1006,7 +1015,8 @@ class ServerGroupTestV264(ServerGroupTestV213):
                       '{}'.format(uuidsentinel.uuid1),
                       six.text_type(result))
 
-    def test_update_server_group_add_instance_multiple_cells(self):
+    @mock.patch('nova.compute.api.API.sync_server_group')
+    def test_update_server_group_add_instance_multiple_cells(self, mock_sync):
         """Don't fail if the instance the user tries to add is in another cell.
         """
         req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
@@ -1026,8 +1036,13 @@ class ServerGroupTestV264(ServerGroupTestV213):
             self.assertIn(member, result_members)
         for instance in new_instances:
             self.assertIn(instance.uuid, result_members)
+        expected_hosts = \
+            set([i.host for i in instances] + [i.host for i in new_instances])
+        req_context = req.environ['nova.context']
+        mock_sync.assert_called_with(req_context, expected_hosts, ig_uuid)
 
-    def test_update_server_group_add_against_soft_policy(self):
+    @mock.patch('nova.compute.api.API.sync_server_group')
+    def test_update_server_group_add_against_soft_policy(self, mock_sync):
         """Don't fail if the policy would fail, but it's a soft-* policy - they
         are best-effort by design.
         """
@@ -1051,6 +1066,8 @@ class ServerGroupTestV264(ServerGroupTestV213):
         self.assertEqual(2, len(result_members))
         for member in [instances[0].uuid, new_instance.uuid]:
             self.assertIn(member, result_members)
+        req_context = req.environ['nova.context']
+        mock_sync.assert_called_with(req_context, set(['host1']), ig_uuid)
 
     @mock.patch('nova.objects.InstanceGroupList.get_by_instance_uuids')
     def test_update_server_group_add_already_in_other(self, mock_gbiu):

--- a/nova/tests/unit/api/openstack/compute/test_server_groups.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_groups.py
@@ -185,12 +185,12 @@ class ServerGroupTestV21(test.NoDBTestCase):
             "Policy doesn't allow %s to be performed." % rule_name,
             exc.format_message())
 
-    def _create_instance(self, ctx, cell):
+    def _create_instance(self, ctx, cell, host='host1'):
         with context.target_cell(ctx, cell) as cctx:
             instance = objects.Instance(context=cctx,
                                         image_ref=uuidsentinel.fake_image_ref,
                                         node='node1', reservation_id='a',
-                                        host='host1', project_id='fake',
+                                        host=host, project_id='fake',
                                         vm_state='fake',
                                         system_metadata={'key': 'value'})
             instance.create()
@@ -202,10 +202,10 @@ class ServerGroupTestV21(test.NoDBTestCase):
         im.create()
         return instance
 
-    def _create_instance_group(self, context, members):
+    def _create_instance_group(self, context, members, policy=None):
         ig = objects.InstanceGroup(context=context, name='fake_name',
                   user_id='fake_user', project_id='fake',
-                  members=members)
+                  members=members, policy=policy)
         ig.create()
         return ig.uuid
 
@@ -848,3 +848,206 @@ class ServerGroupTestV264(ServerGroupTestV213):
         sgroup = server_group_template(unknown='unknown')
         self.assertRaises(self.validation_error, self.controller.create,
                           req, body={'server_group': sgroup})
+
+    def test_update_server_group_not_found(self):
+        """We raise a 404 if the server group does not exist."""
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+        (ig_uuid, instances, members) = self._create_groups_and_instances(ctx)
+        self.assertRaises(webob.exc.HTTPNotFound,
+            self.controller.update, req, uuidsentinel.group1, body={})
+
+    def test_update_server_group_empty(self):
+        """We do not fail if the user doesn't request any changes"""
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+        (ig_uuid, instances, members) = self._create_groups_and_instances(ctx)
+        res_dict = self.controller.update(req, ig_uuid, body={})
+        result_members = res_dict['server_group']['members']
+        self.assertEqual(3, len(result_members))
+        for member in members:
+            self.assertIn(member, result_members)
+
+    def test_update_server_group_add_remove_overlap(self):
+        """We do not accept changes, if there's a server to be both added and
+        removed, because the result would depend on implementation details if
+        we remove first or add first.
+        """
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+        (ig_uuid, instances, members) = self._create_groups_and_instances(ctx)
+        body = {
+            'add_members': [uuidsentinel.uuid1, uuidsentinel.uuid2],
+            'remove_members': [uuidsentinel.uuid2, uuidsentinel.uuid3],
+        }
+        result = self.assertRaises(webob.exc.HTTPBadRequest,
+            self.controller.update, req, ig_uuid, body=body)
+        self.assertIn('Parameters "add_members" and "remove_members" are '
+                      'overlapping in {}'.format(uuidsentinel.uuid2),
+                      six.text_type(result))
+
+    def test_update_server_group_remove_nonexisting(self):
+        """Don't fail if the user tries to remove a server not being member of
+        the server group.
+        """
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+        (ig_uuid, instances, members) = self._create_groups_and_instances(ctx)
+        body = {
+            'remove_members': [uuidsentinel.uuid4],
+        }
+        res_dict = self.controller.update(req, ig_uuid, body=body)
+        result_members = res_dict['server_group']['members']
+        self.assertEqual(3, len(result_members))
+        for member in members:
+            self.assertIn(member, result_members)
+
+    def test_update_server_group_add_already_added(self):
+        """Don't fail if the user adds a server that's already a member of the
+        server group.
+        """
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+        (ig_uuid, instances, members) = self._create_groups_and_instances(ctx)
+        body = {
+            'add_members': [members[0]],
+        }
+        res_dict = self.controller.update(req, ig_uuid, body=body)
+        result_members = res_dict['server_group']['members']
+        self.assertEqual(3, len(result_members))
+        for member in members:
+            self.assertIn(member, result_members)
+
+    def test_update_server_group_add_against_policy_affinity(self):
+        """Fail if adding the server would break the policy."""
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        instances = [self._create_instance(ctx, cell1, host='host1')]
+
+        ig_uuid = self._create_instance_group(ctx, [i.uuid for i in instances],
+                                         policy='affinity')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        new_instance = self._create_instance(ctx, cell1, host='host2')
+
+        body = {
+            'add_members': [new_instance.uuid],
+        }
+        result = self.assertRaises(webob.exc.HTTPBadRequest,
+            self.controller.update, req, ig_uuid, body=body)
+        self.assertIn("Adding instance(s) {} would violate policy 'affinity'."
+                      .format(new_instance.uuid),
+                      six.text_type(result))
+
+    def test_update_server_group_add_against_policy_anti_affinity(self):
+        """Fail if adding the server would break the policy."""
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        instances = [self._create_instance(ctx, cell1, host='host1')]
+
+        ig_uuid = self._create_instance_group(ctx, [i.uuid for i in instances],
+                                         policy='anti-affinity')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        new_instance = self._create_instance(ctx, cell1, host='host1')
+
+        body = {
+            'add_members': [new_instance.uuid],
+        }
+        result = self.assertRaises(webob.exc.HTTPBadRequest,
+            self.controller.update, req, ig_uuid, body=body)
+        self.assertIn("Adding instance(s) {} would violate policy "
+                      "'anti-affinity'.".format(new_instance.uuid),
+                      six.text_type(result))
+
+    def test_update_server_group_add_with_remove_fixes_policy(self):
+        """Don't fail if adding a server would break the policy, but the remove
+        in the same request fixes that.
+        """
+        """Fail if adding the server would break the policy."""
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        instances = [self._create_instance(ctx, cell1, host='host1'),
+                     self._create_instance(ctx, cell1, host='host2')]
+
+        ig_uuid = self._create_instance_group(ctx, [i.uuid for i in instances],
+                                         policy='anti-affinity')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        new_instance = self._create_instance(ctx, cell1, host='host2')
+
+        body = {
+            'add_members': [new_instance.uuid],
+            'remove_members': [instances[1].uuid],
+        }
+        res_dict = self.controller.update(req, ig_uuid, body=body)
+        result_members = res_dict['server_group']['members']
+        self.assertEqual(2, len(result_members))
+        for member in [instances[0].uuid, new_instance.uuid]:
+            self.assertIn(member, result_members)
+
+    def test_update_server_group_add_nonexisting_instance(self):
+        """Fail if the instances the user tries to add does not exist."""
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+        (ig_uuid, instances, members) = self._create_groups_and_instances(ctx)
+        body = {
+            'add_members': [uuidsentinel.uuid1],
+        }
+        result = self.assertRaises(webob.exc.HTTPBadRequest,
+            self.controller.update, req, ig_uuid, body=body)
+        self.assertIn('One or more members in add_members cannot be found: '
+                      '{}'.format(uuidsentinel.uuid1),
+                      six.text_type(result))
+
+    def test_update_server_group_add_instance_multiple_cells(self):
+        """Don't fail if the instance the user tries to add is in another cell.
+        """
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+        (ig_uuid, instances, members) = self._create_groups_and_instances(ctx)
+        cell1 = self.cells[uuidsentinel.cell1]
+        cell2 = self.cells[uuidsentinel.cell2]
+        new_instances = [self._create_instance(ctx, cell1),
+                         self._create_instance(ctx, cell2)]
+        body = {
+            'add_members': [i.uuid for i in new_instances],
+        }
+        res_dict = self.controller.update(req, ig_uuid, body=body)
+        result_members = res_dict['server_group']['members']
+        self.assertEqual(5, len(result_members))
+        for member in members:
+            self.assertIn(member, result_members)
+        for instance in new_instances:
+            self.assertIn(instance.uuid, result_members)
+
+    def test_update_server_group_add_against_soft_policy(self):
+        """Don't fail if the policy would fail, but it's a soft-* policy - they
+        are best-effort by design.
+        """
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        instances = [self._create_instance(ctx, cell1, host='host1')]
+
+        ig_uuid = self._create_instance_group(ctx, [i.uuid for i in instances],
+                                         policy='soft-anti-affinity')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        new_instance = self._create_instance(ctx, cell1, host='host1')
+
+        body = {
+            'add_members': [new_instance.uuid],
+        }
+        res_dict = self.controller.update(req, ig_uuid, body=body)
+        result_members = res_dict['server_group']['members']
+        self.assertEqual(2, len(result_members))
+        for member in [instances[0].uuid, new_instance.uuid]:
+            self.assertIn(member, result_members)

--- a/nova/tests/unit/api/openstack/compute/test_server_groups.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_groups.py
@@ -1051,3 +1051,34 @@ class ServerGroupTestV264(ServerGroupTestV213):
         self.assertEqual(2, len(result_members))
         for member in [instances[0].uuid, new_instance.uuid]:
             self.assertIn(member, result_members)
+
+    @mock.patch('nova.objects.InstanceGroupList.get_by_instance_uuids')
+    def test_update_server_group_add_already_in_other(self, mock_gbiu):
+        """If any of the servers is already part of another server-group, we
+        fail.
+        """
+        req = fakes.HTTPRequest.blank('', version=self.wsgi_api_version)
+        ctx = context.RequestContext('fake_user', 'fake')
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        instances = [self._create_instance(ctx, cell1, host='host1')]
+
+        ig_uuid = self._create_instance_group(ctx, [i.uuid for i in instances])
+
+        cell1 = self.cells[uuidsentinel.cell1]
+        new_instance = self._create_instance(ctx, cell1, host='host1')
+        ig_uuid2 = self._create_instance_group(ctx, [new_instance.uuid])
+
+        mock_gbiu.return_value = objects.InstanceGroupList(
+                objects=[objects.InstanceGroup(
+                    **server_group_db({'id': ig_uuid}))])
+
+        body = {
+            'add_members': [instances[0].uuid],
+        }
+        result = self.assertRaises(webob.exc.HTTPBadRequest,
+            self.controller.update, req, ig_uuid2, body=body)
+        self.assertIn('One ore more members in add_members is already '
+                      'assigned to another server group. Server groups: {}'
+                      .format(ig_uuid),
+                      six.text_type(result))

--- a/nova/tests/unit/notifications/objects/test_notification.py
+++ b/nova/tests/unit/notifications/objects/test_notification.py
@@ -370,7 +370,7 @@ notification_object_data = {
     'AuditPeriodPayload': '1.0-2b429dd307b8374636703b843fa3f9cb',
     'BandwidthPayload': '1.0-ee2616a7690ab78406842a2b68e34130',
     'BlockDevicePayload': '1.0-29751e1b6d41b1454e36768a1e764df8',
-    'EventType': '1.15-a93b5b3b54ebf6c5a158dfcd985d15c5',
+    'EventType': '1.15-0ffb9aab95c08a4e727c60d3ae6d2602',
     'ExceptionNotification': '1.0-a73147b93b520ff0061865849d3dfa56',
     'ExceptionPayload': '1.1-6c43008bd81885a63bc7f7c629f0793b',
     'FlavorNotification': '1.0-a73147b93b520ff0061865849d3dfa56',

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1104,7 +1104,7 @@ object_data = {
     'InstanceFault': '1.2-7ef01f16f1084ad1304a513d6d410a38',
     'InstanceFaultList': '1.2-6bb72de2872fe49ded5eb937a93f2451',
     'InstanceGroup': '1.11-a26b476ba20883380476d4cb8c4b8d41',
-    'InstanceGroupList': '1.8-90f8f1a445552bb3bbc9fa1ae7da27d4',
+    'InstanceGroupList': '1.8-feac6a7c1f4519e069db17e9e6efcff2',
     'InstanceInfoCache': '1.5-cd8b96fefe0fc8d4d337243ba0bf0e1e',
     'InstanceList': '2.4-d2c5723da8c1d08e07cb00160edfd292',
     'InstanceMapping': '1.1-808df83f25987578ed3b187e16b47405',

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1103,7 +1103,7 @@ object_data = {
     'InstanceExternalEvent': '1.2-23eb6ba79cde5cd06d3445f845ba4589',
     'InstanceFault': '1.2-7ef01f16f1084ad1304a513d6d410a38',
     'InstanceFaultList': '1.2-6bb72de2872fe49ded5eb937a93f2451',
-    'InstanceGroup': '1.11-852ac511d30913ee88f3c3a869a8f30a',
+    'InstanceGroup': '1.11-a26b476ba20883380476d4cb8c4b8d41',
     'InstanceGroupList': '1.8-90f8f1a445552bb3bbc9fa1ae7da27d4',
     'InstanceInfoCache': '1.5-cd8b96fefe0fc8d4d337243ba0bf0e1e',
     'InstanceList': '2.4-d2c5723da8c1d08e07cb00160edfd292',

--- a/nova/tests/unit/test_policy.py
+++ b/nova/tests/unit/test_policy.py
@@ -429,6 +429,7 @@ class RealRolePolicyTestCase(test.NoDBTestCase):
 "os_compute_api:os-server-groups:show",
 "os_compute_api:os-server-groups:create",
 "os_compute_api:os-server-groups:delete",
+"os_compute_api:os-server-groups:update",
 "os_compute_api:os-shelve:shelve",
 "os_compute_api:os-shelve:unshelve",
 "os_compute_api:os-volumes",


### PR DESCRIPTION
Customers want to be able to update the members of a server-group not only during spawning of an instance, e.g. to spawn a second instance for a service because of new requirements, while the first instance was not spawned in a server-group.

This is a pure api/DB change and does not reflect on any underlying system like the VMware hypervisor.