### PR TITLE
vmware: Use a prefix in DRS groups and rules

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1696,9 +1696,9 @@ class VMwareAPIVMTestCase(test.TestCase,
         the vm group
         """
         self._create_vm()
-        fake_server_group = collections.namedtuple('GroupInfo', ['uuid',
+        fake_server_group = collections.namedtuple('GroupInfo', ['name',
                                                                 'policies'])
-        fake_server_group.uuid = 'test_group'
+        fake_server_group.name = 'test_group'
         mock_get_sg.return_value = [fake_server_group]
         fake_factory = vmwareapi_fake.FakeFactory()
 

--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -87,7 +87,7 @@ def _create_vm_group_spec(client_factory, group_info, vm_refs,
         if hasattr(group, 'vm'):
             vm_refs = vm_refs + group.vm
 
-    group = create_vm_group(client_factory, group_info.uuid, vm_refs, group)
+    group = create_vm_group(client_factory, group_info.name, vm_refs, group)
 
     return create_group_spec(client_factory, group, operation)
 
@@ -96,7 +96,7 @@ def _get_vm_group(cluster_config, group_info):
     if not hasattr(cluster_config, 'group'):
         return
     for group in cluster_config.group:
-        if group.name == group_info.uuid:
+        if group.name == group_info.name:
             return group
 
 
@@ -254,7 +254,7 @@ def update_placement(session, cluster, vm_ref, group_infos):
             # VM group does not exist on cluster
             policy = group_info.policies[0]
             if policy != 'soft-affinity':
-                rule_name = "%s-%s" % (group_info.uuid, policy)
+                rule_name = "%s-%s" % (group_info.name, policy)
                 rule = _get_rule(cluster_config, rule_name)
                 operation = "edit" if rule else "add"
                 rules_spec = _create_cluster_rules_spec(

--- a/nova/virt/vmwareapi/constants.py
+++ b/nova/virt/vmwareapi/constants.py
@@ -238,3 +238,9 @@ VALID_OS_TYPES = set([
 POWER_STATES = {'poweredOff': power_state.SHUTDOWN,
                 'poweredOn': power_state.RUNNING,
                 'suspended': power_state.SUSPENDED}
+
+
+# Prefix used in the name of DRS groups and rules created by the driver to
+# distinguish between what has been automatically created and what is
+# admin-created.
+DRS_PREFIX = 'NOVA_'

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -76,7 +76,7 @@ LOG = logging.getLogger(__name__)
 RESIZE_TOTAL_STEPS = 7
 
 
-GroupInfo = collections.namedtuple('GroupInfo', ['uuid', 'policies'])
+GroupInfo = collections.namedtuple('GroupInfo', ['name', 'policies'])
 
 
 class VirtualMachineInstanceConfigInfo(object):
@@ -1633,7 +1633,8 @@ class VMwareVMOps(object):
             server_group = instance_group_object.get_by_instance_uuid(
                 context, instance.uuid)
             if server_group:
-                server_group_infos.append(GroupInfo(server_group.uuid,
+                name = '{}{}'.format(constants.DRS_PREFIX, server_group.uuid)
+                server_group_infos.append(GroupInfo(name,
                                                     server_group.policies))
         except nova.exception.InstanceGroupNotFound:
             pass
@@ -1649,7 +1650,7 @@ class VMwareVMOps(object):
 
     def cleanup_server_groups(self, context, instance):
         server_group_infos = self._get_server_groups(context, instance)
-        server_group_uuids = set(group_info.uuid
+        server_group_uuids = set(group_info.name
                                  for group_info in server_group_infos)
         cluster_util.clean_empty_vm_groups(self._session, self._cluster,
                                            server_group_uuids,


### PR DESCRIPTION
We want to create a sync-loop for applying/removing server-groups
changed by the user via API. For this we need to be able to distinguish
between driver-created DRS groups/rules and admin-created ones. To do
this, we introduce a prefix for the DRS group/rule name, which will work
as an identifier later on.

Since we're now using not only a UUID, but a UUID with a prefix, we
change GroupInfo to have a "name" attribute instead of a "uuid"
attribute.

As we're changing how DRS groups/rules look, we need a migration to run
before deploying this to production.

Change-Id: I07ecd1953a85d0f53082fa9b0c49b80c2c9bf9d3

---

We have a migration script ready in the toolbox repository.