### PR TITLE
vmware: Make volume attach and extraConfig update atomic

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1993,11 +1993,8 @@ class VMwareAPIVMTestCase(test.TestCase,
             mock.patch.object(volumeops.VMwareVolumeOps, '_get_volume_ref'),
             mock.patch.object(vm_util, 'get_vmdk_info',
                               return_value=vmdk_info),
-            mock.patch.object(volumeops.VMwareVolumeOps, 'attach_disk_to_vm'),
-            mock.patch.object(volumeops.VMwareVolumeOps,
-                              '_update_volume_details')
-        ) as (get_vm_ref, get_volume_ref, get_vmdk_info,
-              attach_disk_to_vm, update_volume_details):
+            mock.patch.object(volumeops.VMwareVolumeOps, 'attach_disk_to_vm')
+        ) as (get_vm_ref, get_volume_ref, get_vmdk_info, attach_disk_to_vm):
             self.conn.attach_volume(None, connection_info, self.instance,
                                     '/dev/vdc')
 
@@ -2007,10 +2004,9 @@ class VMwareAPIVMTestCase(test.TestCase,
                 connection_info['data']['volume'])
             self.assertTrue(get_vmdk_info.called)
             attach_disk_to_vm.assert_called_once_with(mock.sentinel.vm_ref,
-                self.instance, adapter_type, disk_type, vmdk_path='fake-path')
-            update_volume_details.assert_called_once_with(
-                mock.sentinel.vm_ref, connection_info['data']['volume_id'],
-                disk_uuid)
+                self.instance, adapter_type, disk_type, vmdk_path='fake-path',
+                volume_uuid=connection_info['data']['volume_id'],
+                backing_uuid=disk_uuid)
 
     def test_detach_vmdk_disk_from_vm(self):
         self._create_vm()

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -829,15 +829,15 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         spec.tools.beforeGuestStandby = True
         return spec
 
-    def test_get_vm_extra_config_spec(self):
+    def test_create_extra_config(self):
 
         fake_factory = fake.FakeFactory()
         extra_opts = {mock.sentinel.key: mock.sentinel.value}
-        res = vm_util.get_vm_extra_config_spec(fake_factory, extra_opts)
+        res = vm_util.create_extra_config(fake_factory, extra_opts)
 
-        self.assertEqual(1, len(res.extraConfig))
-        self.assertEqual(mock.sentinel.key, res.extraConfig[0].key)
-        self.assertEqual(mock.sentinel.value, res.extraConfig[0].value)
+        self.assertEqual(1, len(res))
+        self.assertEqual(mock.sentinel.key, res[0].key)
+        self.assertEqual(mock.sentinel.value, res[0].value)
 
     def test_get_vm_create_spec(self):
         extra_specs = vm_util.ExtraSpecs()

--- a/nova/tests/unit/virt/vmwareapi/test_volumeops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_volumeops.py
@@ -149,22 +149,20 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
             get_vm_state.assert_called_once_with(self._volumeops._session,
                                                  instance)
 
-    @mock.patch.object(vm_util, 'get_vm_extra_config_spec',
+    @mock.patch.object(vm_util, 'create_extra_config',
                        return_value=mock.sentinel.extra_config)
-    @mock.patch.object(vm_util, 'reconfigure_vm')
-    def test_update_volume_details(self, reconfigure_vm,
-                                   get_vm_extra_config_spec):
+    def test_add_volume_details_to_config_spec(self, create_extra_config):
             volume_uuid = '26f5948e-52a3-4ee6-8d48-0a379afd0828'
             device_uuid = '0d86246a-2adb-470d-a9f7-bce09930c5d'
-            self._volumeops._update_volume_details(
-                mock.sentinel.vm_ref, volume_uuid, device_uuid)
+            config_spec = mock.Mock()
+            self._volumeops._add_volume_details_to_config_spec(
+                config_spec, volume_uuid, device_uuid)
 
-            get_vm_extra_config_spec.assert_called_once_with(
+            create_extra_config.assert_called_once_with(
                 self._volumeops._session.vim.client.factory,
                 {'volume-%s' % volume_uuid: device_uuid})
-            reconfigure_vm.assert_called_once_with(self._volumeops._session,
-                                                   mock.sentinel.vm_ref,
-                                                   mock.sentinel.extra_config)
+            self.assertEqual(mock.sentinel.extra_config,
+                             config_spec.extraConfig)
 
     def _fake_connection_info(self):
         return {'driver_volume_type': 'vmdk',
@@ -248,12 +246,11 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
                               return_value='fake-disk-type'),
             mock.patch.object(self._volumeops, '_consolidate_vmdk_volume'),
             mock.patch.object(self._volumeops, 'detach_disk_from_vm'),
-            mock.patch.object(self._volumeops, '_update_volume_details'),
             mock.patch.object(self._volumeops._session, '_call_method',
                               return_value=[virtual_controller])
         ) as (get_vm_ref, get_volume_ref, get_vmdk_backed_disk_device,
               _get_device_disk_type, consolidate_vmdk_volume,
-              detach_disk_from_vm, update_volume_details, session_call_method):
+              detach_disk_from_vm, session_call_method):
 
             connection_info = {'driver_volume_type': 'vmdk',
                                'serial': 'volume-fake-id',
@@ -277,11 +274,9 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
                 instance, mock.sentinel.vm_ref, virtual_disk,
                 mock.sentinel.volume_ref, adapter_type=adapter_type,
                 disk_type='fake-disk-type')
-            detach_disk_from_vm.assert_called_once_with(mock.sentinel.vm_ref,
-                                                        instance,
-                                                        virtual_disk)
-            update_volume_details.assert_called_once_with(
-                mock.sentinel.vm_ref, connection_info['data']['volume_id'], "")
+            detach_disk_from_vm.assert_called_once_with(
+                mock.sentinel.vm_ref, instance, virtual_disk,
+                volume_uuid=connection_info['data']['volume_id'])
 
     def test_detach_volume_vmdk_invalid(self):
         client_factory = self._volumeops._session.vim.client.factory
@@ -436,11 +431,10 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
             mock.patch.object(vm_util, 'get_vmdk_info',
                               return_value=vmdk_info),
             mock.patch.object(self._volumeops, 'attach_disk_to_vm'),
-            mock.patch.object(self._volumeops, '_update_volume_details'),
             mock.patch.object(vm_util, 'get_vm_state',
                               return_value=vm_state)
         ) as (get_vm_ref, get_volume_ref, get_vmdk_info, attach_disk_to_vm,
-              update_volume_details, get_vm_state):
+              get_vm_state):
             self._volumeops.attach_volume(connection_info, self._instance,
                                           adapter_type)
 
@@ -451,9 +445,9 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
             self.assertTrue(get_vmdk_info.called)
             attach_disk_to_vm.assert_called_once_with(
                 vm_ref, self._instance, adapter_type,
-                constants.DISK_TYPE_PREALLOCATED, vmdk_path='fake-path')
-            update_volume_details.assert_called_once_with(
-                vm_ref, connection_info['data']['volume_id'], disk_uuid)
+                constants.DISK_TYPE_PREALLOCATED, vmdk_path='fake-path',
+                volume_uuid=connection_info['data']['volume_id'],
+                backing_uuid=disk_uuid)
             if adapter_type == constants.ADAPTER_TYPE_IDE:
                 get_vm_state.assert_called_once_with(self._volumeops._session,
                                                      self._instance)

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -870,18 +870,20 @@ def get_vmdk_detach_config_spec(client_factory, device,
     return config_spec
 
 
-def get_vm_extra_config_spec(client_factory, extra_opts):
-    """Builds extra spec fields from a dictionary."""
-    config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
-    # add the key value pairs
+def create_extra_config(client_factory, extra_opts):
+    """Turn the given dict extra_opts into a list of OptionValue
+
+    The returned list can be used to set the extraConfig attribute of a
+    VirtualMachineConfigSpec.
+    """
     extra_config = []
     for key, value in extra_opts.items():
         opt = client_factory.create('ns0:OptionValue')
         opt.key = key
         opt.value = value
         extra_config.append(opt)
-        config_spec.extraConfig = extra_config
-    return config_spec
+
+    return extra_config
 
 
 def _get_device_capacity(device):

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -42,8 +42,13 @@ class VMwareVolumeOps(object):
     def attach_disk_to_vm(self, vm_ref, instance,
                           adapter_type, disk_type, vmdk_path=None,
                           disk_size=None, linked_clone=False,
-                          device_name=None, disk_io_limits=None):
-        """Attach disk to VM by reconfiguration."""
+                          device_name=None, disk_io_limits=None,
+                          volume_uuid=None, backing_uuid=None):
+        """Attach disk to VM by reconfiguration.
+
+        If volume_uuid and backing_uuid are given, also store the uuid of the
+        volume's device in extraConfig in the same reconfigure request.
+        """
         client_factory = self._session.vim.client.factory
         devices = vm_util.get_hardware_devices(self._session, vm_ref)
         (controller_key, unit_number,
@@ -59,6 +64,12 @@ class VMwareVolumeOps(object):
         if controller_spec:
             vmdk_attach_config_spec.deviceChange.append(controller_spec)
 
+        if volume_uuid and backing_uuid:
+            LOG.debug("Adding volume details for %s to attach config spec.",
+                      volume_uuid, instance=instance)
+            self._add_volume_details_to_config_spec(vmdk_attach_config_spec,
+                                                    volume_uuid, backing_uuid)
+
         LOG.debug("Reconfiguring VM instance %(vm_ref)s to attach "
                   "disk %(vmdk_path)s or device %(device_name)s with type "
                   "%(disk_type)s",
@@ -73,15 +84,15 @@ class VMwareVolumeOps(object):
                    'device_name': device_name, 'disk_type': disk_type},
                   instance=instance)
 
-    def _update_volume_details(self, vm_ref, volume_uuid, device_uuid):
-        # Store the uuid of the volume_device
+    def _add_volume_details_to_config_spec(self, config_spec, volume_uuid,
+                                           device_uuid):
+        """Store the UUID of the volume's device in extraConfig"""
         volume_option = 'volume-%s' % volume_uuid
         extra_opts = {volume_option: device_uuid}
 
         client_factory = self._session.vim.client.factory
-        extra_config_specs = vm_util.get_vm_extra_config_spec(
-                                    client_factory, extra_opts)
-        vm_util.reconfigure_vm(self._session, vm_ref, extra_config_specs)
+        config_spec.extraConfig = vm_util.create_extra_config(client_factory,
+                                                              extra_opts)
 
     def _get_volume_uuid(self, vm_ref, volume_uuid):
         prop = 'config.extraConfig["volume-%s"]' % volume_uuid
@@ -93,11 +104,23 @@ class VMwareVolumeOps(object):
             return opt_val.value
 
     def detach_disk_from_vm(self, vm_ref, instance, device,
-                            destroy_disk=False):
-        """Detach disk from VM by reconfiguration."""
+                            destroy_disk=False, volume_uuid=None):
+        """Detach disk from VM by reconfiguration.
+
+        If volume_uuid is given, also remove the key-value pair <volume_id,
+        vmdk_uuid> from the instance's extraConfig in the same reconfigure
+        request. Setting the value to an empty string will remove the key.
+        """
         client_factory = self._session.vim.client.factory
         vmdk_detach_config_spec = vm_util.get_vmdk_detach_config_spec(
                                     client_factory, device, destroy_disk)
+
+        if volume_uuid is not None:
+            LOG.debug("Adding volume details for %s to detach config spec.",
+                      volume_uuid, instance=instance)
+            self._add_volume_details_to_config_spec(vmdk_detach_config_spec,
+                                                    volume_uuid, '')
+
         disk_key = device.key
         LOG.debug("Reconfiguring VM instance %(vm_ref)s to detach "
                   "disk %(disk_key)s",
@@ -341,11 +364,9 @@ class VMwareVolumeOps(object):
 
         # Attach the disk to virtual machine instance
         self.attach_disk_to_vm(vm_ref, instance, adapter_type, vmdk.disk_type,
-                               vmdk_path=vmdk.path)
-
-        # Store the uuid of the volume_device
-        self._update_volume_details(vm_ref, data['volume_id'],
-                                    vmdk.device.backing.uuid)
+                               vmdk_path=vmdk.path,
+                               volume_uuid=data['volume_id'],
+                               backing_uuid=vmdk.device.backing.uuid)
 
         LOG.debug("Attached VMDK: %s", connection_info, instance=instance)
 
@@ -537,11 +558,8 @@ class VMwareVolumeOps(object):
                                       adapter_type=adapter_type,
                                       disk_type=disk_type)
 
-        self.detach_disk_from_vm(vm_ref, instance, device)
-
-        # Remove key-value pair <volume_id, vmdk_uuid> from instance's
-        # extra config. Setting value to empty string will remove the key.
-        self._update_volume_details(vm_ref, data['volume_id'], "")
+        self.detach_disk_from_vm(vm_ref, instance, device,
+                                 volume_uuid=data['volume_id'])
 
         LOG.debug("Detached VMDK: %s", connection_info, instance=instance)
 


### PR DESCRIPTION
We used to do 2 reconfigure calls for a vmdk attach, which could lead to
inconsistencies if the second - the extraConfig update - did not
succeed. For the VMware driver, the volume looked not attached to the
server then and thus wouldn't get detached later on.

We know change this procedure to attach the vmdk and add the extraConfig
entry at the same time, thus making both fail or none of them - same for
the detach case.

Since we only need this for vmdks, attach_disk_to_vm() and
detach_disk_from_vm() only do it if the right parameters were supplied.
The underlying functions then only update a given config_spec instead of
creating a new one and reconfiguring the cluster.

Besides producing less inconsistencies, this should also make the
volume-attachment/-detachment process minimally faster, because it
requires only a single reconfigure task instead of two.

Change-Id: Icce0c39aaed523ce4e5df97d130a7a14cfabb9c5