### PR TITLE
Remove tenant filter for Security group search in  VM creation to be able to use shared Security Groups.

### DIFF
--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -790,16 +790,14 @@ class API(base_api.NetworkAPI):
         :raises nova.exception.NoUniqueMatch: If multiple security groups
             are requested with the same name.
         :raises nova.exception.SecurityGroupNotFound: If a requested security
-            group is not in the tenant-filtered list of available security
-            groups in Neutron.
+            group is not in the list of available security groups in Neutron.
         """
         security_group_ids = []
         # TODO(arosen) Should optimize more to do direct query for security
         # group if len(security_groups) == 1
         if len(security_groups):
-            search_opts = {'tenant_id': instance.project_id}
-            user_security_groups = neutron.list_security_groups(
-                **search_opts).get('security_groups')
+            user_security_groups = neutron.list_security_groups().get(
+                'security_groups')
 
             for security_group in security_groups:
                 name_match = None

--- a/nova/network/security_group/neutron_driver.py
+++ b/nova/network/security_group/neutron_driver.py
@@ -135,12 +135,8 @@ class SecurityGroupAPI(security_group_base.SecurityGroupBase):
         neutron = neutronapi.get_client(context)
         try:
             if not id and name:
-                # NOTE(flwang): The project id should be honoured so as to get
-                # the correct security group id when user(with admin role but
-                # non-admin project) try to query by name, so as to avoid
-                # getting more than duplicated records with the same name.
                 id = neutronv20.find_resourceid_by_name_or_id(
-                    neutron, 'security_group', name, context.project_id)
+                    neutron, 'security_group', name)
             group = neutron.show_security_group(id).get('security_group')
             return self._convert_to_nova_security_group_format(group)
         except n_exc.NeutronClientNoUniqueMatch as e:


### PR DESCRIPTION
This commit removes tenant (project) filter for security group list in two places `nova-api` and `nova-compute`. Nova will not be able to get the wrong security groups (that are not allowed) because in these places user's context is used.

### Security
By adding additional debug logs I printed the list of security groups that Nova got from Neutron API and compare it with the available security group list. Both lists match 100%.

Debug logging:
```
nova-compute-bb90-c648d8b9c-5n9lg nova-compute 2021-09-20 14:02:01,324.324 6 DEBUG nova.network.neutronv2.api [-] SECURITY GROUPS: [u'06d74a24-d305-423b-a0cc-f4c6ea69e6f1', u'1a5b0497-010e-469d-8b3a-7aa9e19df07b', u'2c56e6ad-ec2a-4380-b414-4eae771e9e8c', u'2c8a1686-4ebb-4b66-9582-8cb1c2206f1b', u'2ffa46b2-d21b-4373-9b20-37907b74d8ef', u'3b7161c7-66dd-4641-9113-b709ad2201da', u'3ce4feed-551a-49ce-b57d-06b483b3e056', u'520f5224-b941-4fbd-a2ff-5f86bc206985', u'5fd2a794-e6a6-4086-8d62-5e4271d65c22', u'6dcd4cab-56ef-415a-a383-fb2fbe0fea3c', u'79ead086-fad2-47d4-84b8-add3c69c30eb', u'7dc80cce-1e87-44e6-b92e-29b6fd8bdf98', u'848e8ac6-9f2a-4286-9bab-6a61d7f0c1d7', u'8a7de7f9-5599-45fa-bf1e-012d0f320126', u'9b5d160a-0e46-46f7-800d-cc4ade23a888', u'a8f73353-b9bb-46cd-906f-80a350c204b5', u'b5c53c61-8bc5-43e3-9832-3d019f1cd004', u'bbc712be-872a-4f2a-b0f8-a17b825f575e', u'c2312844-b03c-422c-ae99-4ff09143aa91', u'c731d8cb-b4e2-47a5-aa70-f595b5570a42', u'cea2c3e7-02aa-4f6d-9948-ad31e827c7f2', u'd0488817-2428-409d-826d-767fe9d69c11', u'd5862b57-3d22-4e64-a23b-f239d4c3b0db', u'da11924f-2aad-44b6-897f-4c5f93f8ec3e', u'e1ae29d0-c6eb-42e7-a9a1-1317a2fd88b1', u'efed9b5e-21c1-4c2e-8513-e8e0ce8dd37a', u'feca28f3-b7ac-4f78-b188-9d0b3c4bdfd1'] _process_security_groups /nova-base-source/nova-base-archive-stable-rocky-m3/nova/network/neutronv2/api.py:801
```

Available security groups:

```
$ openstack security group list -c ID -f value
06d74a24-d305-423b-a0cc-f4c6ea69e6f1
1a5b0497-010e-469d-8b3a-7aa9e19df07b
2c56e6ad-ec2a-4380-b414-4eae771e9e8c
2c8a1686-4ebb-4b66-9582-8cb1c2206f1b
2ffa46b2-d21b-4373-9b20-37907b74d8ef
3b7161c7-66dd-4641-9113-b709ad2201da
3ce4feed-551a-49ce-b57d-06b483b3e056
520f5224-b941-4fbd-a2ff-5f86bc206985
5fd2a794-e6a6-4086-8d62-5e4271d65c22
6dcd4cab-56ef-415a-a383-fb2fbe0fea3c
79ead086-fad2-47d4-84b8-add3c69c30eb
7dc80cce-1e87-44e6-b92e-29b6fd8bdf98
848e8ac6-9f2a-4286-9bab-6a61d7f0c1d7
8a7de7f9-5599-45fa-bf1e-012d0f320126
9b5d160a-0e46-46f7-800d-cc4ade23a888
a8f73353-b9bb-46cd-906f-80a350c204b5
b5c53c61-8bc5-43e3-9832-3d019f1cd004
bbc712be-872a-4f2a-b0f8-a17b825f575e
c2312844-b03c-422c-ae99-4ff09143aa91
c731d8cb-b4e2-47a5-aa70-f595b5570a42
cea2c3e7-02aa-4f6d-9948-ad31e827c7f2
d0488817-2428-409d-826d-767fe9d69c11
d5862b57-3d22-4e64-a23b-f239d4c3b0db
da11924f-2aad-44b6-897f-4c5f93f8ec3e
e1ae29d0-c6eb-42e7-a9a1-1317a2fd88b1
efed9b5e-21c1-4c2e-8513-e8e0ce8dd37a
feca28f3-b7ac-4f78-b188-9d0b3c4bdfd1
```

### Non-unique name problems
If the user will have non-unique names for security groups: one in the project and the second one shared Nova API will return the error `More than one SecurityGroup exists with the name '...'`. Example:

```
$ openstack security group list | grep test-sg-rbac

| b5c53c61-8bc5-43e3-9832-3d019f1cd004 | test-sg-rbac                        |                                     | 7243f3f80a99434292d6766069d3961a | []       |
| cdba42fa-6f00-44eb-9927-678faab21807 | test-sg-rbac                        | test-sg-rbac                        | e9141fb24eee4b3e9f25ae69cda31132 | []       |

$ openstack server create --network=03655309-a525-4dac-a551-6e269ff73465 --flavor=24 --image=ubuntu-20.04-amd64-vmware --security-group=test-sg-rbac test
More than one SecurityGroup exists with the name 'test-sg-rbac'.
```

### Performance
As a result of these changes, Nova gets all security groups without filtering from Neutron API and it will be slower. Performance comparison:

```
 $ curl -s -X GET "https://$NEUTRON_URL/v2.0/security-groups?project_id=e9141fb24eee4b3e9f25ae69cda31132" -H "Accept: application/json" -H "User-Agent: openstacksdk/0.57.0 keystoneauth1/4.3.1 python-requests/2.25.1 CPython/3.9.5" -H "X-Auth-Token: $TOKEN" -o /dev/null -w "@curl-format.txt"
     time_namelookup:  0.004326s
        time_connect:  0.041808s
     time_appconnect:  0.137256s
    time_pretransfer:  0.137411s
       time_redirect:  0.000000s
  time_starttransfer:  0.611862s
                     ----------
          time_total:  0.778839s

 $ curl -s -X GET "https://$NEUTRON_URL/v2.0/security-groups" -H "Accept: application/json" -H "User-Agent: openstacksdk/0.57.0 keystoneauth1/4.3.1 python-requests/2.25.1 CPython/3.9.5" -H "X-Auth-Token: $TOKEN" -o /dev/null -w "@curl-format.txt"
     time_namelookup:  0.006605s
        time_connect:  0.046886s
     time_appconnect:  0.145570s
    time_pretransfer:  0.145793s
       time_redirect:  0.000000s
  time_starttransfer:  0.773550s
                     ----------
          time_total:  0.938802s
```