### PR TITLE
Use python2 for pre-commit-hook in rocky

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 default_language_version:
   # force all unspecified python hooks to run python3
-  python: python3
+  python: python2
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0


### PR DESCRIPTION
Rocky is not fully python3 compatible
i.e. use of the keyword async

Using python2 in the pre-commit hook fixes
the check tripping over incompatible syntax for python3

Change-Id: I98515842a24fd348934378a842c76ea291ed0006