### PR TITLE
Vmware: Find unique VNC port in cluster

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -715,7 +715,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         self.flags(vnc_port=5900, group='vmware')
         self.flags(vnc_port_total=10000, group='vmware')
         actual = vm_util.get_vnc_port(
-            fake.FakeObjectRetrievalSession(fake_vms))
+            fake.FakeObjectRetrievalSession(fake_vms), 'fake_cluster')
         self.assertEqual(actual, 5910)
 
     def test_get_vnc_port_exhausted(self):
@@ -724,7 +724,8 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         self.flags(vnc_port_total=10, group='vmware')
         self.assertRaises(exception.ConsolePortRangeExhausted,
                           vm_util.get_vnc_port,
-                          fake.FakeObjectRetrievalSession(fake_vms))
+                          fake.FakeObjectRetrievalSession(fake_vms),
+                          'fake_cluster')
 
     def test_get_cluster_ref_by_name_none(self):
         fake_objects = fake.FakeRetrieveResult()

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -643,12 +643,14 @@ class VMwareVMOpsTestCase(test.TestCase):
                 mock.patch.object(vmops.VMwareVMOps, "_attach_volumes"),
                 mock.patch.object(vmops.VMwareVMOps,
                                   "update_cluster_placement"),
+                mock.patch.object(vmops.VMwareVMOps,
+                                  "_get_and_set_vnc_config"),
         ) as (fake_resize_create_ephemerals_and_swap,
               fake_update_instance_progress, fake_power_on, fake_get_vm_ref,
               fake_remove_ephemerals_and_swap, fake_get_vmdk_info,
               fake_resize_vm, fake_resize_disk, fake_relocate_vm,
               fake_detach_volumes, fake_attach_volumes,
-              fake_update_cluster_placement):
+              fake_update_cluster_placement, fake_get_and_set_vnc_config):
             migration = migration or objects.Migration(dest_compute="nova",
                                                        source_compute="nova")
             if relocate_fails:
@@ -688,6 +690,12 @@ class VMwareVMOpsTestCase(test.TestCase):
                 else:
                     fake_update_cluster_placement.assert_not_called()
                     relocate_failed = True
+
+                fake_get_and_set_vnc_config.assert_called_once_with(
+                    self._session.vim.client.factory,
+                    self._instance,
+                    'fake-ref'
+                )
 
             if not relocate_failed:
                 fake_resize_create_ephemerals_and_swap.assert_called_once_with(

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2224,6 +2224,10 @@ class VMwareVMOps(object):
             self.update_cluster_placement(context, instance)
             self.disable_drs_if_needed(instance)
 
+            if CONF.vnc.enabled:
+                client_factory = self._session.vim.client.factory
+                self._get_and_set_vnc_config(client_factory, instance, vm_ref)
+
         self._update_instance_progress(context, instance,
                                        step=2,
                                        total_steps=RESIZE_TOTAL_STEPS)
@@ -2472,9 +2476,8 @@ class VMwareVMOps(object):
     @utils.synchronized('vmware.get_and_set_vnc_port')
     def _get_and_set_vnc_config(self, client_factory, instance, vm_ref):
         """Set the vnc configuration of the VM."""
-        port = vm_util.get_vnc_port(self._session)
-        vnc_config_spec = vm_util.get_vnc_config_spec(
-                                      client_factory, port)
+        port = vm_util.get_vnc_port(self._session, self._root_resource_pool)
+        vnc_config_spec = vm_util.get_vnc_config_spec(client_factory, port)
 
         LOG.debug("Reconfiguring VM instance to enable vnc on "
                   "port - %(port)s", {'port': port},


### PR DESCRIPTION
Currently, a list of all vnc-ports in the whole vcenter
is fetched to determine a new vnc-port for a VM.

The vnc port needs to be unique only per host,
but since we do not control the host,
we better chose one unique per cluster.
This reduces the worst-case in vsphere 7
from 45000 vms in the vcenter to 8000 vms in the cluster.

Change-Id: Ifc24a188b325416235ea245037ae22740d80a5bb