### PR TITLE
Vmware: Refactor update_cluster_placement

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -258,8 +258,9 @@ class VMwareAPIVMTestCase(test.TestCase,
 
         """ Monkey patch for vm_util.vm_needs_special_spawning
         Currently set to return `True` since most of the methods are calling
-        vm_util.update_cluster_placement which calls _get_server_groups. This
-        is done in order to prevent mocking the tests using spawn.
+        VMOps.update_cluster_placement which calls
+        update_admin_vm_group_membership.
+        This is done in order to prevent mocking the tests using spawn.
         """
         self.useFixture(
             fixtures.MonkeyPatch(

--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -19,7 +19,6 @@ from oslo_vmware import vim_util as vutil
 from nova import exception
 from nova.i18n import _
 from nova import utils
-from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import vim_util
 
 LOG = logging.getLogger(__name__)
@@ -33,13 +32,10 @@ def reconfigure_cluster(session, cluster, config_spec):
     session.wait_for_task(reconfig_task)
 
 
-def create_vm_group(client_factory, name, vm_refs, group=None):
+def create_vm_group(client_factory, name, vm_refs):
     """Create a ClusterVmGroup object
-
-    :param:group: if given, update this ClusterVmGroup object instead of
-                  creating a new one
     """
-    group = group or client_factory.create('ns0:ClusterVmGroup')
+    group = client_factory.create('ns0:ClusterVmGroup')
     group.name = name
     group.vm = vm_refs
 
@@ -78,27 +74,13 @@ def create_group_spec(client_factory, group, operation):
     return group_spec
 
 
-def _create_vm_group_spec(client_factory, group_info, vm_refs,
-                          operation="add", group=None):
-    if group:
-        # On vCenter UI, it is not possible to create VM group without
-        # VMs attached to it. But, using APIs, it is possible to create
-        # VM group without VMs attached. Therefore, check for existence
-        # of vm attribute in the group to avoid exceptions
-        if hasattr(group, 'vm'):
-            vm_refs = vm_refs + group.vm
-
-    group = create_vm_group(client_factory, group_info.name, vm_refs, group)
-
-    return create_group_spec(client_factory, group, operation)
-
-
-def _get_vm_group(cluster_config, group_info):
+def _get_vm_group(cluster_config, group_name):
     if not hasattr(cluster_config, 'group'):
-        return
+        return None
     for group in cluster_config.group:
-        if group.name == group_info.name:
+        if group.name == group_name:
             return group
+    return None
 
 
 def fetch_cluster_groups(session, cluster_ref=None, cluster_config=None,
@@ -159,63 +141,44 @@ def delete_vm_group(session, cluster, vm_group):
      vm group
      """
     client_factory = session.vim.client.factory
-    groups = []
 
     group_spec = create_group_spec(client_factory, vm_group, "remove")
-    groups.append(group_spec)
 
     config_spec = client_factory.create('ns0:ClusterConfigSpecEx')
-    config_spec.groupSpec = groups
+    config_spec.groupSpec = [group_spec]
+
     reconfigure_cluster(session, cluster, config_spec)
 
 
 @utils.synchronized('vmware-vm-group-policy')
-def update_placement(session, cluster, vm_ref, group_infos):
-    """Updates cluster for vm placement using DRS"""
+def update_vm_group_membership(session, cluster, vm_group_name, vm_ref):
+    """Updates cluster for vm placement using DRS
+
+    Add a VM to a Vm-group, create it if missing
+    It is up for an administrator to define rules for this group with other
+    means in the VCenter
+    """
     cluster_config = session._call_method(
         vutil, "get_object_property", cluster, "configurationEx")
 
     client_factory = session.vim.client.factory
     config_spec = client_factory.create('ns0:ClusterConfigSpecEx')
-    config_spec.groupSpec = []
-    config_spec.rulesSpec = []
-    for group_info in group_infos:
-        if not group_info.name.startswith(constants.DRS_PREFIX):
-            # We only do this, if this is an admin-defined group, because
-            # VmGroups are not used by the rules created by Nova.
-            group = _get_vm_group(cluster_config, group_info)
 
-            if not group:
-                # Creating group
-                operation = "add"
-            else:
-                # VM group exists on the cluster which is assumed to be
-                # created by VC admin. Add instance to this vm group and let
-                # the placement policy defined by the VC admin take over
-                operation = "edit"
-            group_spec = _create_vm_group_spec(
-                client_factory, group_info, [vm_ref], operation=operation,
-                group=group)
-            config_spec.groupSpec.append(group_spec)
+    operation = None
+    group = _get_vm_group(cluster_config, vm_group_name)
 
-        # If server group policies are defined (by tenants), then
-        # create/edit affinity/anti-affinity rules on cluster.
-        # Note that this might be add-on to the existing vm group
-        # (mentioned above) policy defined by VC admin i.e if VC admin has
-        # restricted placement of VMs to a specific group of hosts, then
-        # the server group policy from nova might further restrict to
-        # individual hosts on a cluster
-        if group_info.policies:
-            # VM group does not exist on cluster
-            policy = group_info.policies[0]
-            if policy != 'soft-affinity':
-                rule_name = "%s-%s" % (group_info.name, policy)
-                rule = _get_rule(cluster_config, rule_name)
-                operation = "edit" if rule else "add"
-                rules_spec = _create_cluster_rules_spec(
-                    client_factory, rule_name, [vm_ref], policy=policy,
-                    operation=operation, rule=rule)
-                config_spec.rulesSpec.append(rules_spec)
+    if not group:
+        operation = "add"
+        group = create_vm_group(client_factory, vm_group_name, [vm_ref])
+    else:
+        operation = "edit"
+        if not hasattr(group, "vm"):
+            group.vm = [vm_ref]
+        else:
+            group.vm.append(vm_ref)
+
+    group_spec = create_group_spec(client_factory, group, operation)
+    config_spec.groupSpec = [group_spec]
 
     reconfigure_cluster(session, cluster, config_spec)
 

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -39,7 +39,6 @@ import nova.conf
 from nova import exception
 from nova.i18n import _
 from nova.network import model as network_model
-from nova.virt.vmwareapi import cluster_util
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import vim_util
 
@@ -1616,13 +1615,6 @@ def get_hosts_and_reservations_for_cluster(session, cluster):
     host_mors = [m for m in host_ret.ManagedObjectReference
                             if m.value not in failover_hosts]
     return host_mors, _get_host_reservations_map(group_ret)
-
-
-def update_cluster_placement(session, instance, cluster, server_group_infos):
-    if not server_group_infos:
-        return
-    vm_ref = get_vm_ref(session, instance)
-    cluster_util.update_placement(session, cluster, vm_ref, server_group_infos)
 
 
 def get_host_ref(session, cluster=None):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -76,9 +76,6 @@ LOG = logging.getLogger(__name__)
 RESIZE_TOTAL_STEPS = 7
 
 
-GroupInfo = collections.namedtuple('GroupInfo', ['name', 'policies'])
-
-
 class VirtualMachineInstanceConfigInfo(object):
     """Parameters needed to create and configure a new instance."""
 
@@ -1134,13 +1131,31 @@ class VMwareVMOps(object):
             reconfig_spec.deviceChange.append(serial_port_spec)
 
     def update_cluster_placement(self, context, instance):
-        server_group_infos = self._get_server_groups(context, instance)
-        for group_info in server_group_infos:
-            self.sync_server_group(context, group_info.name)
+        self.sync_instance_server_group(context, instance)
+        self.update_admin_vm_group_membership(instance)
 
-        provider_group_infos = self._get_provider_server_groups(instance)
-        vm_util.update_cluster_placement(self._session, instance,
-                                         self._cluster, provider_group_infos)
+    def sync_instance_server_group(self, context, instance):
+        try:
+            instance_group_object = objects.instance_group.InstanceGroup
+            server_group = instance_group_object.get_by_instance_uuid(
+                context, instance.uuid)
+            self.sync_server_group(context, server_group.uuid)
+        except nova.exception.InstanceGroupNotFound:
+            pass
+
+    def update_admin_vm_group_membership(self, instance):
+        vm_group_name = CONF.vmware.special_spawning_vm_group
+        if not vm_group_name:
+            return
+
+        needs_empty_host = utils.vm_needs_special_spawning(
+            int(instance.memory_mb), instance.flavor)
+        if needs_empty_host:
+            return
+
+        vm_ref = vm_util.get_vm_ref(self._session, instance)
+        cluster_util.update_vm_group_membership(self._session, self._cluster,
+                                                vm_group_name, vm_ref)
 
     def spawn(self, context, instance, image_meta, injected_files,
               admin_password, network_info, block_device_info=None):
@@ -1187,6 +1202,7 @@ class VMwareVMOps(object):
         # instance uuid.
         vm_util.vm_ref_cache_update(instance.uuid, vm_ref)
 
+        # Update all DRS related rules
         self.update_cluster_placement(context, instance)
 
         # Update the Neutron VNIC index
@@ -1634,32 +1650,6 @@ class VMwareVMOps(object):
                                                     "ResetVM_Task", vm_ref)
             self._session._wait_for_task(reset_task)
             LOG.debug("Did hard reboot of VM", instance=instance)
-
-    def _get_server_groups(self, context, instance):
-        server_group_infos = []
-        try:
-            instance_group_object = objects.instance_group.InstanceGroup
-            server_group = instance_group_object.get_by_instance_uuid(
-                context, instance.uuid)
-            if server_group:
-                name = server_group.uuid
-                server_group_infos.append(GroupInfo(name,
-                                                    server_group.policies))
-        except nova.exception.InstanceGroupNotFound:
-            pass
-
-        return server_group_infos
-
-    def _get_provider_server_groups(self, instance):
-        server_group_infos = []
-
-        needs_empty_host = utils.vm_needs_special_spawning(
-            int(instance.memory_mb), instance.flavor)
-        if CONF.vmware.special_spawning_vm_group and not needs_empty_host:
-            name = CONF.vmware.special_spawning_vm_group
-            server_group_infos.append(GroupInfo(name, None))
-
-        return server_group_infos
 
     def _destroy_instance(self, context, instance, destroy_disks=True):
         # Destroy a VM instance


### PR DESCRIPTION
After the recent changes of syncing server-groups,
the syncing of rules in cluster_util.update_placement has become unused.

The code can be simplified as a preparation for live-migration,
as it will add complexity.

VMops.update_cluster_placement now calls
- sync_instance_server_group, which fetches _the_ server-group
  for the instance and syncs it with the existing VMOps.sync_server_group
- update_admin_vm_group_membership handles the membership to special_spawning_vm_group
  Since that is the only remaining use-case of cluster_util.update_placement,
  the function has been renamed to update_vm_group_membership and reduced to
  that use-case

Change-Id: I94c311790610fc4658f9b06ac052ad46660f1cea