### PR TITLE
vmware: Fix getting rules/groups in cluster_util

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -124,7 +124,7 @@ def fetch_cluster_groups(session, cluster_ref=None, cluster_config=None,
             vutil, "get_object_property", cluster_ref, "configurationEx")
 
     groups = {}
-    for group in cluster_config.group:
+    for group in getattr(cluster_config, 'group', []):
         if group_type == 'vm':
             if not vim_util.is_vim_instance(group, 'ClusterVmGroup'):
                 continue
@@ -151,7 +151,7 @@ def fetch_cluster_rules(session, cluster_ref=None, cluster_config=None):
         cluster_config = session._call_method(
             vutil, "get_object_property", cluster_ref, "configurationEx")
 
-    return {r.name: r for r in cluster_config.rule}
+    return {r.name: r for r in getattr(cluster_config, 'rule', [])}
 
 
 def delete_vm_group(session, cluster, vm_group):


### PR DESCRIPTION
The attribute group/rule gets removed by the underlying SOAP library if
it's empty. Therefore, we have to check for it to exist instead of
trying to iterate over it unconditionally.

Change-Id: I443338bf97dcf83478e0a9971179480ecb01c009