### PR TITLE
Vmware: Sync server-group during migration

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -3124,6 +3124,8 @@ class VMwareVMOps(object):
         self._compute_host = compute_host
 
     def sync_server_group(self, context, sg_uuid):
+        """Sync a server group by its uuid for the current host/cluster
+        """
         # we have to ignore instances currently in a volatitle state, where
         # either VMware cannot support them being in a DRS rule or we expect
         # them to go away during the syncing process, which could lead to
@@ -3131,13 +3133,11 @@ class VMwareVMOps(object):
         # of expected members of a rule, which also removes them in the
         # cluster.
         STATES_EXCLUDING_MEMBERS_FROM_DRS_RULES = [
-            task_states.MIGRATING,
             task_states.DELETING,
             task_states.SHELVING,
             task_states.REBUILDING,
             task_states.REBUILD_BLOCK_DEVICE_MAPPING,
         ]
-
         LOG.debug('Starting sync for server-group %s', sg_uuid)
 
         @utils.synchronized('vmware-server-group-{}'.format(sg_uuid))
@@ -3162,21 +3162,76 @@ class VMwareVMOps(object):
                 LOG.debug('Sync for server-group %s done', sg_uuid)
                 return
 
+            # First we check for all instances, which have ongoing migrations
+            # on the given host, either as source or destination
+
+            # Decision matrix for migrations:
+            # Mig-Status Action/Host
+            #            Source  Dest
+            # Preparing  Remove  N/A
+            # Running    Remove  Add
+            # (Other states are consistent with default behaviour)
+            #
+            # So the Instance.host will always be the source of the migration,
+            # and we want to remove the rules.
+            # We only need to handle specially the case a running migration
+            # on the destination host, and add it
+
+            MigrationList = objects.migration.MigrationList
+            filters = {
+                "host": self._compute_host,
+                "instance_uuid": sg.members,
+                "status": ["preparing", "running"],
+            }
+
+            expected_members = {}
+
+            migrations_by_instance_uuid = {}
+            for migration in MigrationList.get_by_filters(context, filters):
+                instance_uuid = migration.instance_uuid
+                if migration.source_compute == self._compute_host:
+                    # The host is the source of a migration
+                    # That means the instance will be part of the instance list
+                    # So we have to remember that instance to be removed from
+                    # the DRS rule-set
+                    migrations_by_instance_uuid[instance_uuid] = \
+                        migration
+                else:
+                    # We now handle the destination side
+                    if migration.status == "preparing":
+                        # Not even started, we can ignore that one
+                        continue
+
+                    # Polling the cache, as vm_util.get_vm_ref is very slow
+                    # for the negative search.
+                    # We just have to ensure, that the cache holds a value
+                    # before syncing the server group on the destination host
+                    # Race conditions are averted by this functions lock
+                    moref = vm_util.vm_ref_cache_get(instance_uuid)
+                    if moref:
+                        expected_members[instance_uuid] = moref
+
             # retrieve the instances, because sg.members contains all members
             # and we need to filter them for our host
             InstanceList = objects.instance.InstanceList
-            filters = {'host': self._compute_host, 'uuid': sg.members,
-                       'deleted': False}
+            filters = {'host': self._compute_host, 'uuid': sg.members}
             instances = InstanceList.get_by_filters(context, filters,
                                                     expected_attrs=[])
 
-            expected_members = {}
             for instance in instances:
                 task_state = instance.task_state
                 if task_state in STATES_EXCLUDING_MEMBERS_FROM_DRS_RULES:
                     LOG.debug("Excluding member %s of server-group %s, "
                               "because it's in task_state %s.",
                               instance.uuid, sg.uuid, task_state)
+                    continue
+
+                migration = migrations_by_instance_uuid.get(instance.uuid)
+                if migration:
+                    LOG.debug("Excluding member %s of server-group %s, "
+                              "due to being on the source side of "
+                              "ongoing migration %s.",
+                              instance.uuid, sg.uuid, migration.uuid)
                     continue
 
                 try:


### PR DESCRIPTION
During a migration, we have to consider the following situations:

- On the source-host, we have to remove the group constraints
  as soon as the migration has started, in order to avoid that
  the constraints disallow the movement
- On the destination-host, we have to add the rules as soon
  as the vm is in the vcenter, before the instance.host has been
  updated. Otherwise, we might remove rules added by the migration
  itself.

The parameters to specify the cluster and the host are in
preparation for the migration-task, which needs to call
the sync for the source-host on the destination-host

Change-Id: I2b3c626ecf4a33c3baa20489b66bb7e6b69459b6