### PR TITLE
Vmware: Handle deleted image graceful

### DIFF
--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -191,14 +191,20 @@ class VMwareImage(object):
 def get_vsphere_location(context, image_id):
     """Get image location in vsphere or None."""
     # image_id can be None if the instance is booted using a volume.
-    if image_id:
+    if not image_id:
+        return None
+
+    try:
         metadata = IMAGE_API.get(context, image_id, include_locations=True)
-        locations = metadata.get('locations')
-        if locations:
-            for loc in locations:
-                loc_url = loc.get('url')
-                if loc_url and loc_url.startswith('vsphere://'):
-                    return loc_url
+    except exception.ImageNotFound:
+        return None
+
+    locations = metadata.get('locations')
+    if locations:
+        for loc in locations:
+            loc_url = loc.get('url')
+            if loc_url and loc_url.startswith('vsphere://'):
+                return loc_url
     return None
 
 


### PR DESCRIPTION
When migrating or resizing an instance, the driver looks
for vsphere locations properties stored with the image
We can't do that though, if the image has been deleted,
so we fall back gracefully

Change-Id: I55c4d1f49e3c6fc0bb89794ac1b44da99ce009ca