### PR TITLE
Vmware: Add option to remove vm from vm-group

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -151,12 +151,17 @@ def delete_vm_group(session, cluster, vm_group):
 
 
 @utils.synchronized('vmware-vm-group-policy')
-def update_vm_group_membership(session, cluster, vm_group_name, vm_ref):
+def update_vm_group_membership(session, cluster, vm_group_name, vm_ref,
+                               remove=False):
     """Updates cluster for vm placement using DRS
 
-    Add a VM to a Vm-group, create it if missing
-    It is up for an administrator to define rules for this group with other
-    means in the VCenter
+    If remove is set to false (default), add the VM to a Vm-group with
+    the given name and cluster. Create it if missing.
+    Otherwise, remove the vm from the group. The group itself won't get removed
+    even if there are no instances left.
+
+    The assumption is that an administrator defines rules with other means
+    on that group.
     """
     cluster_config = session._call_method(
         vutil, "get_object_property", cluster, "configurationEx")
@@ -164,18 +169,34 @@ def update_vm_group_membership(session, cluster, vm_group_name, vm_ref):
     client_factory = session.vim.client.factory
     config_spec = client_factory.create('ns0:ClusterConfigSpecEx')
 
-    operation = None
     group = _get_vm_group(cluster_config, vm_group_name)
 
     if not group:
-        operation = "add"
+        if remove:
+            return
         group = create_vm_group(client_factory, vm_group_name, [vm_ref])
-    else:
-        operation = "edit"
+        operation = "add"
+    elif not remove:
         if not hasattr(group, "vm"):
             group.vm = [vm_ref]
         else:
             group.vm.append(vm_ref)
+        operation = "edit"
+    else:  # group and remove
+        if not hasattr(group, "vm"):
+            return
+        filtered_vms = []
+        found = False
+        for ref in group.vm:
+            if (vutil.get_moref_value(ref)
+                    == vutil.get_moref_value(vm_ref)):
+                found = True
+            else:
+                filtered_vms.append(ref)
+        if not found:
+            return
+        group.vm = filtered_vms
+        operation = "edit"
 
     group_spec = create_group_spec(client_factory, group, operation)
     config_spec.groupSpec = [group_spec]

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1130,9 +1130,9 @@ class VMwareVMOps(object):
         if serial_port_spec:
             reconfig_spec.deviceChange.append(serial_port_spec)
 
-    def update_cluster_placement(self, context, instance):
+    def update_cluster_placement(self, context, instance, remove=False):
         self.sync_instance_server_group(context, instance)
-        self.update_admin_vm_group_membership(instance)
+        self.update_admin_vm_group_membership(instance, remove=remove)
 
     def sync_instance_server_group(self, context, instance):
         try:
@@ -1143,7 +1143,7 @@ class VMwareVMOps(object):
         except nova.exception.InstanceGroupNotFound:
             pass
 
-    def update_admin_vm_group_membership(self, instance):
+    def update_admin_vm_group_membership(self, instance, remove=False):
         vm_group_name = CONF.vmware.special_spawning_vm_group
         if not vm_group_name:
             return
@@ -1155,7 +1155,8 @@ class VMwareVMOps(object):
 
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         cluster_util.update_vm_group_membership(self._session, self._cluster,
-                                                vm_group_name, vm_ref)
+                                                vm_group_name, vm_ref,
+                                                remove=remove)
 
     def spawn(self, context, instance, image_meta, injected_files,
               admin_password, network_info, block_device_info=None):


### PR DESCRIPTION
In order to migrate a vm (within a vcenter) we need
to be able to remove a vm from a vm-group constraining
it to a set of hosts

Change-Id: I8ef5ebdc54b3c3de0310e461132828aa251ee657