### PR TITLE
Vmwareapi: Live-migration changes on conductor level.

### DIFF
--- a/nova/conductor/tasks/live_migrate.py
+++ b/nova/conductor/tasks/live_migrate.py
@@ -151,7 +151,10 @@ class LiveMigrationTask(base.TaskBase):
                                                     self._held_allocations)
 
     def _check_instance_is_active(self):
-        if self.instance.power_state not in (power_state.RUNNING,
+        # NOSTATE, as the VM might be already migrated,
+        # but we missed to update the db and we want to retry
+        if self.instance.power_state not in (power_state.NOSTATE,
+                                             power_state.RUNNING,
                                              power_state.PAUSED):
             raise exception.InstanceInvalidState(
                     instance_uuid=self.instance.uuid,

--- a/nova/objects/migrate_data.py
+++ b/nova/objects/migrate_data.py
@@ -503,3 +503,60 @@ class PowerVMLiveMigrateData(LiveMigrateData):
         for field in self.fields:
             if field in legacy:
                 setattr(self, field, legacy[field])
+
+
+@obj_base.NovaObjectRegistry.register
+class VMWareLiveMigrateData(LiveMigrateData):
+    # Version 1.0: Initial version
+    # Version 1.1: Added dest_cluster_ref, is_same_vcenter,
+    #              instance_already_migrated, relocate_defaults_json,
+    #              vif_infos_json for cross-vcenter migration
+    VERSION = '1.1'
+
+    fields = {
+        'cluster_name': fields.StringField(nullable=False),
+        'datastore_regex': fields.StringField(nullable=False),
+        'dest_cluster_ref': fields.StringField(nullable=False),
+        'is_same_vcenter': fields.BooleanField(default=True),
+        'instance_already_migrated': fields.BooleanField(default=False),
+        'relocate_defaults_json': fields.SensitiveStringField(default="[]"),
+        'vif_infos_json': fields.StringField(default="[]"),
+    }
+
+    @property
+    def relocate_defaults(self):
+        return jsonutils.loads(self.relocate_defaults_json)
+
+    @relocate_defaults.setter
+    def relocate_defaults(self, relocate_defaults_dict):
+        self.relocate_defaults_json = jsonutils.dumps(relocate_defaults_dict)
+
+    @property
+    def vif_infos(self):
+        return jsonutils.loads(self.vif_infos_json)
+
+    @vif_infos.setter
+    def vif_infos(self, vif_infos):
+        self.vif_infos_json = jsonutils.dumps(vif_infos)
+
+    def to_legacy_dict(self, pre_migration_result=False):
+        legacy = super(VMWareLiveMigrateData, self).to_legacy_dict()
+        for field in self.fields:
+            if self.obj_attr_is_set(field):
+                legacy[field] = getattr(self, field)
+        return legacy
+
+    def from_legacy_dict(self, legacy):
+        super(VMWareLiveMigrateData, self).from_legacy_dict(legacy)
+        for field in self.fields:
+            if field in legacy:
+                setattr(self, field, legacy[field])
+
+    def obj_make_compatible(self, primitive, target_version):
+        super(VMWareLiveMigrateData, self).obj_make_compatible(
+            primitive, target_version)
+        target_version = versionutils.convert_version_to_tuple(target_version)
+        if target_version < (1, 1):
+            for k in ('is_same_vcenter', 'instance_already_migrated',
+                      'relocate_defaults_json', 'vif_infos_json'):
+                primitive.pop(k, None)

--- a/nova/tests/unit/notifications/objects/test_notification.py
+++ b/nova/tests/unit/notifications/objects/test_notification.py
@@ -412,6 +412,7 @@ notification_object_data = {
     'ServerGroupPayload': '1.1-4ded2997ea1b07038f7af33ef5c45f7f',
     'ServiceStatusNotification': '1.0-a73147b93b520ff0061865849d3dfa56',
     'ServiceStatusPayload': '1.1-7b6856bd879db7f3ecbcd0ca9f35f92f',
+    'VMWareLiveMigrateData': '1.1-13e17ad269e942ef13a8af7f5e402da7',
 }
 
 

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1166,6 +1166,7 @@ object_data = {
     'VirtCPUTopology': '1.0-fc694de72e20298f7c6bab1083fd4563',
     'VirtualInterface': '1.3-efd3ca8ebcc5ce65fff5a25f31754c54',
     'VirtualInterfaceList': '1.0-9750e2074437b3077e46359102779fc6',
+    'VMWareLiveMigrateData': '1.1-13e17ad269e942ef13a8af7f5e402da7',
     'VolumeUsage': '1.0-6c8190c46ce1469bb3286a1f21c2e475',
     'XenDeviceBus': '1.0-272a4f899b24e31e42b2b9a7ed7e9194',
     'XenapiLiveMigrateData': '1.4-7dc9417e921b2953faa6751f18785f3f',


### PR DESCRIPTION
Split out the changes for live-migration which are affecting the conductor
Basing it on the upstream VMWareLiveMigrateData 1.0 version in the hope
that we have an easier path merging the code with upstream eventually

Change-Id: I5d8417c836d735122e033eeb72f7671b2558afc4