### PR TITLE
Vmware: Handle missing propSet in list_vms

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2678,6 +2678,9 @@ class VMwareVMOps(object):
         with vutil.WithRetrieval(self._session.vim, retrieve_result) \
                 as objects:
             for vm in objects:
+                prop_set = getattr(vm, 'propSet', None)
+                if not prop_set:
+                    continue
                 vm_uuid = None
                 conn_state = None
                 props = {}


### PR DESCRIPTION
If a vm has none of the requested properties,
propSet will not be set. So, we need to skip over that instance

Change-Id: Ia633fecb021bffe1557820e36c33ef53cf90db83