### PR TITLE
vmware: Fix special_spawning using _cluster_ref

### DIFF
--- a/nova/virt/vmwareapi/special_spawning.py
+++ b/nova/virt/vmwareapi/special_spawning.py
@@ -193,7 +193,7 @@ class _SpecialVmSpawningServer(object):
 
             # retrieve all hosts of the cluster
             host_objs = {vutil.get_moref_value(h): h
-                    for h in self._get_hosts_in_cluster(self._cluster_ref)}
+                    for h in self._get_hosts_in_cluster(self._cluster)}
             vms_per_host = {h: [] for h in host_objs}
 
             # get all the vms in a cluster, because we need to find a host


### PR DESCRIPTION
This fixes an AttributeError in _SpecialVmSpawningServer that was
introduced in Ibd576211ac33f38ef0e1b9016381a955916d7c1c, where we access
self._cluster_ref instead of self._cluster.

Change-Id: I43d3d060f7c51841a8561a29d3189e37e4f87fb1