### PR TITLE
Let Nova migrate volumes between shards

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4813,7 +4813,8 @@ class ComputeManager(manager.Manager):
                     if connector is None:
                         connector = self.driver.get_volume_connector(instance)
                     self.volume_api.attachment_update(
-                        context, bdm.attachment_id, connector, bdm.device_name)
+                        context, bdm.attachment_id, connector, bdm.volume_id,
+                        bdm.device_name)
 
     def _complete_volume_attachments(self, context, bdms):
         """Completes volume attachments for the instance
@@ -6035,7 +6036,7 @@ class ComputeManager(manager.Manager):
             # the host connector, which will give us back the new attachment
             # connection_info.
             new_cinfo = self.volume_api.attachment_update(
-                context, new_attachment_id, connector,
+                context, new_attachment_id, connector, new_volume_id,
                 mountpoint)['connection_info']
 
             if vol_multiattach:

--- a/nova/conf/cinder.py
+++ b/nova/conf/cinder.py
@@ -94,6 +94,18 @@ cinder.conf), the volume create request will fail and the instance will fail
 the build request.
 By default there is no availability zone restriction on volume attach.
 """),
+    cfg.FloatOpt('min_migration_speed_mib_per_second',
+               default=24,
+               help="""
+Assumed mininum speed for a volume migration
+
+We compute a timeout how long Nova will wait for a volume to migrate based on
+this speed in MiB/s and the size of the volume.
+
+Possible values:
+
+  * Positive floating point value
+"""),
 ]
 
 

--- a/nova/exception.py
+++ b/nova/exception.py
@@ -2385,3 +2385,7 @@ class ZVMConnectorError(ZVMDriverException):
         self.rc = results.get('rc')
         self.rs = results.get('rs')
         self.errmsg = results.get('errmsg')
+
+
+class VolumeMigrationError(NovaException):
+    msg_fmt = 'Migration of volume %(volume_id)s failed: %(reason)s'

--- a/nova/tests/fixtures.py
+++ b/nova/tests/fixtures.py
@@ -1728,7 +1728,7 @@ class CinderFixtureNewAttachFlow(fixtures.Fixture):
             attachments.remove(attachment)
 
         def fake_attachment_update(_self, context, attachment_id, connector,
-                                   mountpoint=None):
+                                   volume_id, mountpoint=None):
             # Ensure the attachment exists
             _find_attachment(attachment_id)
             attachment_ref = {'driver_volume_type': 'fake_type',

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -4909,6 +4909,7 @@ class ComputeTestCase(BaseTestCase,
         fake_bdms = objects.BlockDeviceMappingList(objects=[
             objects.BlockDeviceMapping(destination_type='volume',
                                        attachment_id=uuids.attachment_id,
+                                       volume_id=uuids.volume_id,
                                        device_name='/dev/vdb'),
             objects.BlockDeviceMapping(destination_type='volume',
                                        attachment_id=None),
@@ -5016,7 +5017,8 @@ class ComputeTestCase(BaseTestCase,
             # volume BDM that had an attachment.
             mock_attachment_update.assert_called_once_with(
                 self.context, uuids.attachment_id,
-                mock_get_vol_connector.return_value, '/dev/vdb')
+                mock_get_vol_connector.return_value, uuids.volume_id,
+                '/dev/vdb')
             mock_attachment_complete.assert_called_once_with(
                 self.context, uuids.attachment_id)
 

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -2589,7 +2589,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             # We updated the new attachment with the host connector.
             attachment_update.assert_called_once_with(
                 self.context, uuids.new_attachment_id, mock.sentinel.connector,
-                bdm.device_name)
+                new_volume['id'], bdm.device_name)
             # We tell Cinder that the new volume is connected
             attachment_complete.assert_called_once_with(
                 self.context, uuids.new_attachment_id)
@@ -2662,7 +2662,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             # We updated the new attachment with the host connector.
             attachment_update.assert_called_once_with(
                 self.context, uuids.new_attachment_id, mock.sentinel.connector,
-                bdm.device_name)
+                new_volume['id'], bdm.device_name)
             # We tell Cinder that the new volume is connected
             attachment_complete.assert_called_once_with(
                 self.context, uuids.new_attachment_id)
@@ -2735,7 +2735,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             # We tried to update the new attachment with the host connector.
             attachment_update.assert_called_once_with(
                 self.context, uuids.new_attachment_id, mock.sentinel.connector,
-                bdm.device_name)
+                new_volume['id'], bdm.device_name)
             # After a failure, we rollback the detaching status of the old
             # volume.
             roll_detaching.assert_called_once_with(
@@ -2807,7 +2807,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             # We updated the new attachment with the host connector.
             attachment_update.assert_called_once_with(
                 self.context, uuids.new_attachment_id, mock.sentinel.connector,
-                bdm.device_name)
+                new_volume['id'], bdm.device_name)
             # After a failure, we rollback the detaching status of the old
             # volume.
             roll_detaching.assert_called_once_with(
@@ -2846,7 +2846,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             self.assertTrue(new_cinfo['multiattach'])
             attachment_update.assert_called_once_with(
                 self.context, uuids.new_attachment_id, connector,
-                bdm.device_name)
+                new_volume['id'], bdm.device_name)
 
     def test_swap_volume_with_multiattach_no_driver_support(self):
         """Tests a swap volume scenario where the new volume being swapped-to
@@ -7423,6 +7423,7 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase):
         fake_bdms = objects.BlockDeviceMappingList(objects=[
             objects.BlockDeviceMapping(destination_type='volume',
                                        attachment_id=uuids.attachment_id,
+                                       volume_id=uuids.volume_id,
                                        device_name='/dev/vdb'),
             objects.BlockDeviceMapping(destination_type='volume',
                                        attachment_id=None),
@@ -7476,7 +7477,8 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase):
             # volume BDM that had an attachment.
             mock_attachment_update.assert_called_once_with(
                 self.context, uuids.attachment_id,
-                mock_get_vol_connector.return_value, '/dev/vdb')
+                mock_get_vol_connector.return_value, uuids.volume_id,
+                '/dev/vdb')
             mock_attachment_complete.assert_called_once_with(
                 self.context, uuids.attachment_id)
 

--- a/nova/tests/unit/virt/test_block_device.py
+++ b/nova/tests/unit/virt/test_block_device.py
@@ -670,7 +670,7 @@ class TestDriverBlockDevice(test.NoDBTestCase):
             else:
                 self.volume_api.attachment_update.assert_called_once_with(
                     elevated_context, self.attachment_id, connector,
-                    bdm_dict['device_name'])
+                    fake_volume['id'], bdm_dict['device_name'])
 
             if driver_attach:
                 mock_get_encry.assert_called_once_with(

--- a/nova/tests/unit/volume/test_cinder.py
+++ b/nova/tests/unit/volume/test_cinder.py
@@ -423,7 +423,8 @@ class CinderApiTestCase(test.NoDBTestCase):
         mock_cinderclient.return_value.attachments.update.return_value = (
             fake_attachment)
         result = self.api.attachment_update(
-            self.ctx, uuids.attachment_id, connector=connector)
+            self.ctx, uuids.attachment_id, connector=connector,
+            volume_id=uuids.volume_id)
         self.assertEqual(expected_attachment_ref, result)
         # Make sure the connector wasn't modified.
         self.assertNotIn('mountpoint', connector)
@@ -454,7 +455,7 @@ class CinderApiTestCase(test.NoDBTestCase):
             fake_attachment)
         result = self.api.attachment_update(
             self.ctx, uuids.attachment_id, connector=original_connector,
-            mountpoint='/dev/vdb')
+            volume_id=uuids.volume_id, mountpoint='/dev/vdb')
         self.assertEqual(expected_attachment_ref, result)
         # Make sure the original connector wasn't modified.
         self.assertNotIn('mountpoint', original_connector)
@@ -471,7 +472,8 @@ class CinderApiTestCase(test.NoDBTestCase):
         self.assertRaises(exception.VolumeAttachmentNotFound,
                           self.api.attachment_update,
                           self.ctx, uuids.attachment_id,
-                          connector={'host': 'fake-host'})
+                          connector={'host': 'fake-host'},
+                          volume_id=uuids.volume_id)
 
     @mock.patch('nova.volume.cinder.cinderclient')
     def test_attachment_update_attachment_no_connector(self,
@@ -482,7 +484,8 @@ class CinderApiTestCase(test.NoDBTestCase):
             cinder_exception.BadRequest(400))
         self.assertRaises(exception.InvalidInput,
                           self.api.attachment_update,
-                          self.ctx, uuids.attachment_id, connector=None)
+                          self.ctx, uuids.attachment_id, connector=None,
+                          volume_id=uuids.volume_id)
 
     @mock.patch('nova.volume.cinder.cinderclient',
                 side_effect=exception.CinderAPIVersionNotAvailable(
@@ -494,7 +497,8 @@ class CinderApiTestCase(test.NoDBTestCase):
         """
         self.assertRaises(exception.CinderAPIVersionNotAvailable,
                           self.api.attachment_update,
-                          self.ctx, uuids.attachment_id, connector={})
+                          self.ctx, uuids.attachment_id, connector={},
+                          volume_id=uuids.volume_id)
         mock_cinderclient.assert_called_once_with(self.ctx, '3.44',
                                                   skip_version_check=True)
 

--- a/nova/virt/block_device.py
+++ b/nova/virt/block_device.py
@@ -574,7 +574,7 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
         LOG.debug("Updating existing volume attachment record: %s",
                   attachment_id, instance=instance)
         connection_info = volume_api.attachment_update(
-            context, attachment_id, connector,
+            context, attachment_id, connector, volume_id,
             self['mount_device'])['connection_info']
         if 'serial' not in connection_info:
             connection_info['serial'] = self.volume_id

--- a/nova/volume/cinder.py
+++ b/nova/volume/cinder.py
@@ -1006,8 +1006,14 @@ class API(object):
                         'code': getattr(ex, 'code', None)})
             return False
 
-        # NOTE(jkulik): A day would be 24 MIB/s on average for a 2 TiB volume.
-        MIGRATION_TIMEOUT = 24 * 3600
+        assumed_speed_mib = CONF.cinder.min_migration_speed_mib_per_second
+        try:
+            volume = client.volumes.get(volume_id)
+            # volume.size is GiB
+            migration_timeout = int(volume.size * 1024 // assumed_speed_mib)
+        except cinder_exception.ClientException:
+            # assume a big volume for computing the default timeout
+            migration_timeout = int(2 * 1024 * 1024 // assumed_speed_mib)
         # an external dictionary so the looping function can keep state between
         # runs
         loop_state = {}
@@ -1016,7 +1022,7 @@ class API(object):
             context=admin_context, volume_id=volume_id, state_dict=loop_state)
         try:
             timer.start(initial_delay=5, starting_interval=2,
-                        timeout=MIGRATION_TIMEOUT, max_interval=300).wait()
+                        timeout=migration_timeout, max_interval=300).wait()
         except Exception:
             with excutils.save_and_reraise_exception():
                 LOG.error("Error migrating volume %s to connector %s",

--- a/nova/volume/cinder.py
+++ b/nova/volume/cinder.py
@@ -31,6 +31,7 @@ from keystoneauth1 import exceptions as keystone_exception
 from keystoneauth1 import loading as ks_loading
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
+from oslo_service import loopingcall
 from oslo_utils import encodeutils
 from oslo_utils import excutils
 from oslo_utils import strutils
@@ -40,6 +41,7 @@ from six.moves import urllib
 
 from nova import availability_zones as az
 import nova.conf
+import nova.context
 from nova import exception
 from nova.i18n import _
 from nova.i18n import _LE
@@ -816,7 +818,7 @@ class API(object):
                            'code': getattr(ex, 'code', None)})
 
     @translate_attachment_exception
-    def attachment_update(self, context, attachment_id, connector,
+    def attachment_update(self, context, attachment_id, connector, volume_id,
                           mountpoint=None):
         """Updates the connector on the volume attachment. An attachment
         without a connector is considered reserved but not fully attached.
@@ -826,6 +828,9 @@ class API(object):
         :param connector: host connector dict. This is required when updating
             a volume attachment. To terminate a connection, the volume
             attachment for that connection must be deleted.
+        :param volume_id: UUID of the volume, so we can migrate it
+            transparently, if the volume does not support the current
+            connector.
         :param mountpoint: Optional mount device name for the attachment,
             e.g. "/dev/vdb". Theoretically this is optional per volume backend,
             but in practice it's normally required so it's best to always
@@ -847,20 +852,179 @@ class API(object):
             _connector = copy.deepcopy(connector)
             _connector['mountpoint'] = mountpoint
 
-        try:
+        def _do_update():
             attachment_ref = cinderclient(
                 context, '3.44', skip_version_check=True).attachments.update(
                     attachment_id, _connector)
             translated_attach_ref = _translate_attachment_ref(
                 attachment_ref.to_dict())
             return translated_attach_ref
+
+        try:
+            return _do_update()
         except cinder_exception.ClientException as ex:
+            with excutils.save_and_reraise_exception() as ctxt:
+                code = getattr(ex, 'code', None)
+                if code != 400:
+                    LOG.error(('Update attachment failed for attachment '
+                               '%(id)s. Error: %(msg)s Code: %(code)s'),
+                              {'id': attachment_id,
+                               'msg': six.text_type(ex),
+                               'code': getattr(ex, 'code', None)})
+                # NOTE(jkulik): We can handle a volume being in a different
+                # shard (i.e. Connector not supported, code 416), but all other
+                # exceptions need to go further up.
+                if code != 406:
+                    return
+
+                # try to migrate. if this fails, we raise the original
+                # exception further up
+                if not self.migrate_by_connector(context, volume_id,
+                                                 connector):
+                    return
+
+                # if we migrated, we're basically in a new situation and thus
+                # don't need the old error to show anymore.
+                ctxt.reraise = False
+
+                LOG.info('Retrying attachment_update call for volume %s and '
+                         'attachment %s after migration to %s',
+                         volume_id, attachment_id, connector)
+                # NOTE(jkulik): This probably needs send_service_user_token
+                # enabled, because the migration can take a long time and the
+                # user-supplied token might have run out.
+                try:
+                    return _do_update()
+                except cinder_exception.ClientException as ex:
+                    with excutils.save_and_reraise_exception():
+                        LOG.error(('Update attachment failed for attachment '
+                                   '%(id)s. Error: %(msg)s Code: %(code)s'),
+                                  {'id': attachment_id,
+                                   'msg': six.text_type(ex),
+                                   'code': getattr(ex, 'code', None)})
+
+    def _wait_for_migration_end(self, context, volume_id, state_dict):
+        """Retrieve the volume state and check if the migration finished.
+
+        This method should be used in a LoopingCall.
+
+        `context` needs to be an admin context as returned by
+        nova.context.get_admin_context(), because the migration-status is not
+        necessarily visible to the normal user - it depends on the policy.
+
+        From the api-ref documenation:
+        On success, the volume status will return to its original status of
+        available or in-use and the migration_status will be success. On
+        failure, the migration_status will be error. In the case of failure, if
+        lock_volume was true and the volume was originally available when it
+        was migrated, the status will go back to available.
+
+        `state_dict` should be a dictionary so we can keep some state between
+        runs. This is necessary to e.g. see if we ran into errors before.
+        """
+        client = cinderclient(context, '3.44',
+                              skip_version_check=True)
+
+        try:
+            volume = client.volumes.get(volume_id)
+        except cinder_exception.ClientException:
+            with excutils.save_and_reraise_exception() as ctxt:
+                # This should make it resistent against temporary failures in
+                # talking to Cinder: we only raise if we encountered enough
+                # failures in a row.
+                state_dict['failures'] = state_dict.get('failures', 0) + 1
+                if state_dict['failures'] < 5:
+                    ctxt.reraise = False
+                    return
+
+        state_dict['failures'] = 0
+
+        # from Cinder's source code:
+        # The migration status 'none' means no migration has ever been done
+        # before. The migration status 'error' means the previous migration
+        # failed. The migration status 'success' means the previous migration
+        # succeeded. The migration status 'deleting' means the source volume
+        # fails to delete after a migration.
+        # All of the statuses above means the volume is not in the process
+        # of a migration.
+
+        # "starting" is set during the synchronous part of the migration action
+        # call.
+        # "migrating" is set by the volume manager in the asynchronous part
+        # right before calling the driver to migrate the volume.
+        # "completing" is only used for os-migrate_volume_completion call, not
+        # for os-migrate_volume
+
+        migration_status = getattr(volume, 'os-vol-mig-status-attr:migstat',
+                                   None)
+        if not migration_status:
+            # The status should have changed to "starting" during the
+            # synchronous part of the call, so we error out here.
+            msg = 'migration_status is unset - migration did not start'
+            raise exception.VolumeMigrationError(volume_id=volume_id,
+                                                 reason=msg)
+        if migration_status in ('starting', 'migrating'):
+            # expected status while things are ongoing. we return to check
+            # again on next loop
+            return
+        if migration_status == 'success':
+            # the volume migrated successfully, so we can stop the looping
+            raise loopingcall.LoopingCallDone()
+        if migration_status == 'error':
+            # the migration failed for one reason or another
+            msg = 'migrations_status went to "error". ' \
+                  'Check Cinder logs for details.'
+            raise exception.VolumeMigrationError(volume_id=volume_id,
+                                                 reason=msg)
+        # unknown migration_status -> raise exception
+        msg = 'unhandled migration_status "{}"'.format(migration_status)
+        raise exception.VolumeMigrationError(volume_id=volume_id,
+                                             reason=msg)
+
+    def migrate_by_connector(self, context, volume_id, connector):
+        """Call os-migrate_volume_by_connector and wait for migration
+
+        We're using a generic, token-less admin token here, because this is an
+        admin-only call and the user-token doesn't have the necessary rights.
+        This also means, this function requires the [cinder] section of
+        nova.conf to contain valid admin authentication.
+        """
+        LOG.info('Trying to migrate volume %s to connector %s',
+                  volume_id, connector)
+        info = {'connector': connector, 'lock_volume': True}
+        admin_context = nova.context.get_admin_context()
+        client = cinderclient(admin_context, '3.44',
+                             skip_version_check=True)
+        try:
+            client.volumes._action('os-migrate_volume_by_connector',
+                                   volume_id, info)
+        except cinder_exception.ClientException as ex:
+            LOG.error(('Migrate by connector failed for volume '
+                       '%(id)s. Error: %(msg)s Code: %(code)s'),
+                       {'id': volume_id,
+                        'msg': six.text_type(ex),
+                        'code': getattr(ex, 'code', None)})
+            return False
+
+        # NOTE(jkulik): A day would be 24 MIB/s on average for a 2 TiB volume.
+        MIGRATION_TIMEOUT = 24 * 3600
+        # an external dictionary so the looping function can keep state between
+        # runs
+        loop_state = {}
+        timer = loopingcall.BackOffLoopingCall(
+            self._wait_for_migration_end,
+            context=admin_context, volume_id=volume_id, state_dict=loop_state)
+        try:
+            timer.start(initial_delay=5, starting_interval=2,
+                        timeout=MIGRATION_TIMEOUT, max_interval=300).wait()
+        except Exception:
             with excutils.save_and_reraise_exception():
-                LOG.error(('Update attachment failed for attachment '
-                           '%(id)s. Error: %(msg)s Code: %(code)s'),
-                          {'id': attachment_id,
-                           'msg': six.text_type(ex),
-                           'code': getattr(ex, 'code', None)})
+                LOG.error("Error migrating volume %s to connector %s",
+                          volume_id, connector)
+
+        LOG.info('Migrated volume %s to connector %s',
+                  volume_id, connector)
+        return True
 
     @translate_attachment_exception
     @retrying.retry(stop_max_attempt_number=5,


### PR DESCRIPTION
Until now, we handled shard-migration transparently in Cinder. This did
not work well, if the migration took longer than Cinder's RPC-timeout -
which is a given for volumes over a certain size.

To address this, Nova will now initialize the migration and wait for it
to finish. To help with that, Cinder gained a new endpoint to migrate
volumes by connector - because we pass the vCenter UUID inside the
connection_capabilities of it - and by returning a new error-message on
attachment_update, so Nova knows that the update failed because the
volume is in another shard  - or rather assigned to another backend.

Since we now have to migrate a volume, callers of attachment_update now
have to provide a volume_id in addition to the previous parameters.

Change-Id: I9f89f2887be6f5e2f2184cd771542007393af0dd