### PR TITLE
vmware: Refactor get_info() for healing vmref cache

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2438,26 +2438,32 @@ class VMwareVMOps(object):
 
     def get_info(self, instance):
         """Return data about the VM instance."""
-        lst_properties = ["runtime.powerState"]
+        powerstate_property = 'runtime.powerState'
 
         if not vm_util._VM_VALUE_CACHE:
             self.update_cached_instances()
 
-        vm_ref = vm_util.get_vm_ref(self._session, instance)
-        vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
-        if not vm_props or "runtime.powerState" not in vm_props:
-            try:
-                if CONF.vmware.use_property_collector:
-                    LOG.debug("VM instance data was not found on the cache.")
+        @vm_util.vm_ref_cache_heal_from_instance
+        def _get_vm_props(session, instance):
+            vm_ref = vm_util.get_vm_ref(self._session, instance)
+            vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
+            if vm_props and powerstate_property in vm_props:
+                return vm_props
 
-                vm_props = self._session._call_method(
-                    vutil, "get_object_properties_dict",
-                    vm_ref, lst_properties)
-            except vexc.ManagedObjectNotFoundException:
-                raise exception.InstanceNotFound(instance_id=instance.uuid)
+            if CONF.vmware.use_property_collector:
+                LOG.debug("VM instance data was not found on the cache.")
+
+            return session._call_method(
+                vutil, "get_object_properties_dict",
+                vm_ref, [powerstate_property])
+
+        try:
+            vm_props = _get_vm_props(self._session, instance)
+        except vexc.ManagedObjectNotFoundException:
+            raise exception.InstanceNotFound(instance_id=instance.uuid)
 
         return hardware.InstanceInfo(
-            state=constants.POWER_STATES[vm_props['runtime.powerState']])
+            state=constants.POWER_STATES[vm_props[powerstate_property]])
 
     def _get_diagnostics(self, instance):
         """Return data about VM diagnostics."""


### PR DESCRIPTION
When a VM gets reregistered in the vCenter, it changes its moref id. To
catch this case, we previously introduced a decorator, that would react
to ManagedObjectNotFoundException and retries the function without
cached moref.

We want the same to happen in VMwareVMOps.get_info(), as this function
is called regularly to check the VM's state. To achieve this, we
refactor get_info() a little to contain a local function matching the
decorator's expected parameters.

Change-Id: If798a3af4430a82dce9ef03a5ef097a215271b40