### PR TITLE
vmware: Ignore deleted instances in server-group-sync

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -3320,7 +3320,8 @@ class VMwareVMOps(object):
             # retrieve the instances, because sg.members contains all members
             # and we need to filter them for our host
             InstanceList = objects.instance.InstanceList
-            filters = {'host': self._compute_host, 'uuid': sg.members}
+            filters = {'host': self._compute_host, 'uuid': sg.members,
+                       'deleted': False}
             instances = InstanceList.get_by_filters(context, filters,
                                                     expected_attrs=[])
 


### PR DESCRIPTION
When retrieving the instances being part of a server-group, we retrieved
all instances - even deleted ones. Those ended up not being in the moref
cache and were thus searched in the vCenter - one by one in a very slow
manner, as they didn't exist anymore. This also meant, that spawning a
server in a server-group with lots of deleted members took a very long
time.

We now only query non-deleted members of a server-group and thus should
not run into the same bottleneck in syncing server-groups anymore.

Change-Id: I35cc52449782d4d76b54259a2e28460c01ac7ad6