### PR TITLE
VMwareapi: Use refs as index for fakedb

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/fake.py
+++ b/nova/tests/unit/virt/vmwareapi/fake.py
@@ -22,8 +22,9 @@ A fake VMware VI API implementation.
 import collections
 import sys
 
+import six
+
 from oslo_log import log as logging
-from oslo_serialization import jsonutils
 from oslo_utils import units
 from oslo_utils import uuidutils
 from oslo_vmware import exceptions as vexc
@@ -76,23 +77,34 @@ def cleanup():
             _db_content[c] = {}
 
 
-def _create_object(table, table_obj):
+def _create_object(table_obj):
     """Create an object in the db."""
-    _db_content.setdefault(table, {})
-    _db_content[table][table_obj.obj] = table_obj
+    _db_content.setdefault(table_obj.obj._type, {})
+    update_object(table_obj)
 
 
-def _get_object(obj_ref):
+def get_object(obj_ref):
     """Get object for the give reference."""
-    return _db_content[obj_ref.type][obj_ref]
+    return _db_content[obj_ref.type][obj_ref.value]
 
 
-def _get_objects(obj_type):
+def get_objects(obj_type):
     """Get objects of the type."""
-    lst_objs = FakeRetrieveResult()
-    for key in _db_content[obj_type]:
-        lst_objs.add_object(_db_content[obj_type][key])
-    return lst_objs
+    return six.itervalues(_db_content[obj_type])
+
+
+def get_first_object(obj_type):
+    """Get the first object of an object type"""
+    return next(six.itervalues(_db_content[obj_type]))
+
+
+def get_first_object_ref(obj_type):
+    """Get the first reference of an object type"""
+    return get_first_object(obj_type).obj
+
+
+def _no_objects_of_type(obj_type):
+    return not _db_content.get(obj_type)
 
 
 def _convert_to_array_of_mor(mors):
@@ -135,21 +147,19 @@ class FakeRetrieveResult(object):
         if token is not None:
             self.token = token
 
-    def add_object(self, object):
-        self.objects.append(object)
+    def add_object(self, obj):
+        self.objects.append(obj)
 
 
-def _get_object_refs(obj_type):
-    """Get object References of the type."""
-    lst_objs = []
-    for key in _db_content[obj_type]:
-        lst_objs.append(key)
-    return lst_objs
+def get_object_refs(obj_type):
+    """Get iterator over object References of the type."""
+    for obj in six.itervalues(_db_content[obj_type]):
+        yield obj.obj
 
 
-def _update_object(table, table_obj):
+def update_object(table_obj):
     """Update objects of the type."""
-    _db_content[table][table_obj.obj] = table_obj
+    _db_content[table_obj.obj._type][table_obj.obj.value] = table_obj
 
 
 class Prop(object):
@@ -175,6 +185,9 @@ class ManagedObjectReference(object):
         # attribute is the identifier for
         self.type = name
         self._type = name
+
+    def __repr__(self):
+        return "{}:{}".format(self._type, self.value)
 
 
 class ObjectContent(object):
@@ -261,8 +274,11 @@ class ManagedObject(object):
         return prefix + "-" + str(self.__class__._counter)
 
     def __repr__(self):
-        return jsonutils.dumps({elem.name: elem.val
-                                for elem in self.propSet})
+        # We can't just dump the managed-object, because it may be circular
+        return "{}:{}({})".format(self.obj._type, self.obj.value,
+            ", ".join(
+                "{}={}".format(p.name, p.val if p.name == "name" else "<>")
+                for p in self.propSet))
 
 
 class DataObject(object):
@@ -592,8 +608,7 @@ class ResourcePool(ManagedObject):
 class DatastoreHostMount(DataObject):
     def __init__(self, value='host-100'):
         super(DatastoreHostMount, self).__init__()
-        host_ref = (_db_content["HostSystem"]
-                    [list(_db_content["HostSystem"].keys())[0]].obj)
+        host_ref = get_first_object_ref("HostSystem")
         host_system = DataObject()
         host_system.ManagedObjectReference = [host_ref]
         host_system.value = value
@@ -630,9 +645,15 @@ class ClusterComputeResource(ManagedObject):
         configuration.dasConfig.admissionControlPolicy = policy
         self.set("configuration.dasConfig.admissionControlPolicy", policy)
 
+        vm_list = DataObject()
+        vm_list.ManagedObjectReference = []
+        self.set("vm", vm_list)
+
     def _add_root_resource_pool(self, r_pool):
         if r_pool:
             self.set("resourcePool", r_pool)
+            pool = get_object(r_pool)
+            self.set("vm", pool.get("vm"))
 
     def _add_host(self, host_sys):
         if host_sys:
@@ -668,7 +689,7 @@ class ClusterComputeResource(ManagedObject):
         # Compute the aggregate stats
         summary.numHosts = len(hosts.ManagedObjectReference)
         for host_ref in hosts.ManagedObjectReference:
-            host_sys = _get_object(host_ref)
+            host_sys = get_object(host_ref)
             connected = host_sys.get("connected")
             host_summary = host_sys.get("summary")
             summary.numCpuCores += host_summary.hardware.numCpuCores
@@ -806,14 +827,18 @@ class HostSystem(ManagedObject):
         if not name:
             name = "ha-{}".format(self.mo_id)
         self.set("name", name)
-        if _db_content.get("HostNetworkSystem", None) is None:
+
+        if _no_objects_of_type("HostNetworkSystem"):
             create_host_network_system()
-        if not _get_object_refs('HostStorageSystem'):
+
+        if _no_objects_of_type("HostStorageSystem"):
             create_host_storage_system()
-        host_net_key = list(_db_content["HostNetworkSystem"].keys())[0]
-        host_net_sys = _db_content["HostNetworkSystem"][host_net_key].obj
-        self.set("configManager.networkSystem", host_net_sys)
-        host_storage_sys_key = _get_object_refs('HostStorageSystem')[0]
+
+        host_net_obj = get_first_object("HostNetworkSystem")
+        host_net_ref = host_net_obj.obj
+        self.set("configManager.networkSystem", host_net_ref)
+
+        host_storage_sys_key = get_first_object_ref('HostStorageSystem')
         self.set("configManager.storageSystem", host_storage_sys_key)
 
         if not ds_ref:
@@ -849,10 +874,9 @@ class HostSystem(ManagedObject):
         self.set("capability.maxHostSupportedVcpus", 600)
         self.set("connected", connected)
 
-        if _db_content.get("Network", None) is None:
+        if _no_objects_of_type("Network"):
             create_network()
-        net_ref = _db_content["Network"][
-            list(_db_content["Network"].keys())[0]].obj
+        net_ref = get_first_object_ref("Network")
         network_do = DataObject()
         network_do.ManagedObjectReference = [net_ref]
         self.set("network", network_do)
@@ -891,7 +915,7 @@ class HostSystem(ManagedObject):
         self.set("config.storageDevice.hostBusAdapter", host_bus_adapter_array)
 
         # Set the same on the storage system managed object
-        host_storage_sys = _get_object(host_storage_sys_key)
+        host_storage_sys = get_object(host_storage_sys_key)
         host_storage_sys.set('storageDeviceInfo.hostBusAdapter',
                              host_bus_adapter_array)
 
@@ -952,17 +976,15 @@ class Datacenter(ManagedObject):
     def __init__(self, name="ha-datacenter", ds_ref=None):
         super(Datacenter, self).__init__("dc")
         self.set("name", name)
-        if _db_content.get("Folder", None) is None:
+        if _no_objects_of_type("Folder"):
             create_folder()
-        folder_ref = _db_content["Folder"][
-            list(_db_content["Folder"].keys())[0]].obj
+        folder_ref = get_first_object_ref("Folder")
         folder_do = DataObject()
         folder_do.ManagedObjectReference = [folder_ref]
         self.set("vmFolder", folder_ref)
-        if _db_content.get("Network", None) is None:
+        if _no_objects_of_type("Network"):
             create_network()
-        net_ref = _db_content["Network"][
-            list(_db_content["Network"].keys())[0]].obj
+        net_ref = get_first_object_ref("Network")
         network_do = DataObject()
         network_do.ManagedObjectReference = [net_ref]
         self.set("network", network_do)
@@ -997,54 +1019,56 @@ class Task(ManagedObject):
 
 def create_host_network_system():
     host_net_system = HostNetworkSystem()
-    _create_object("HostNetworkSystem", host_net_system)
+    _create_object(host_net_system)
 
 
 def create_host_storage_system():
     host_storage_system = HostStorageSystem()
-    _create_object("HostStorageSystem", host_storage_system)
+    _create_object(host_storage_system)
 
 
 def create_host(ds_ref=None):
     host_system = HostSystem(ds_ref=ds_ref)
-    _create_object('HostSystem', host_system)
+    _create_object(host_system)
 
 
 def create_datacenter(name, ds_ref=None):
     data_center = Datacenter(name, ds_ref)
-    _create_object('Datacenter', data_center)
+    _create_object(data_center)
 
 
 def create_datastore(name, capacity, free):
     data_store = Datastore(name, capacity, free)
-    _create_object('Datastore', data_store)
+    _create_object(data_store)
     return data_store.obj
 
 
 def create_res_pool():
     res_pool = ResourcePool()
-    _create_object('ResourcePool', res_pool)
+    _create_object(res_pool)
     return res_pool.obj
 
 
 def create_folder():
     folder = Folder()
-    _create_object('Folder', folder)
+    _create_object(folder)
     return folder.obj
 
 
 def create_network():
     network = Network()
-    _create_object('Network', network)
+    _create_object(network)
 
 
 def create_cluster(name, ds_ref):
     cluster = ClusterComputeResource(name=name)
-    cluster._add_host(_get_object_refs("HostSystem")[0])
-    cluster._add_host(_get_object_refs("HostSystem")[1])
+    for i, host in enumerate(get_object_refs("HostSystem")):
+        cluster._add_host(host)
+        if i >= 1:
+            break
     cluster._add_datastore(ds_ref)
     cluster._add_root_resource_pool(create_res_pool())
-    _create_object('ClusterComputeResource', cluster)
+    _create_object(cluster)
     return cluster
 
 
@@ -1063,16 +1087,15 @@ def create_vm(uuid=None, name=None,
         devices = []
 
     if vmPathName is None:
-        vm_path = ds_obj.DatastorePath(
-            list(_db_content['Datastore'].values())[0])
+        vm_path = ds_obj.DatastorePath(get_first_object("Datastore"))
     else:
         vm_path = ds_obj.DatastorePath.parse(vmPathName)
 
     if res_pool_ref is None:
-        res_pool_ref = list(_db_content['ResourcePool'].keys())[0]
+        res_pool_ref = get_first_object_ref("ResourcePool")
 
     if host_ref is None:
-        host_ref = list(_db_content["HostSystem"].keys())[0]
+        host_ref = get_first_object_ref("HostSystem")
 
     # Fill in the default path to the vmx file if we were only given a
     # datastore. Note that if you create a VM with vmPathName '[foo]', when you
@@ -1081,9 +1104,9 @@ def create_vm(uuid=None, name=None,
     if vm_path.rel_path == '':
         vm_path = vm_path.join(name, name + '.vmx')
 
-    for key, value in _db_content["Datastore"].items():
+    for value in get_objects("Datastore"):
         if value.get('summary.name') == vm_path.datastore:
-            ds = key
+            ds = value.obj
             break
     else:
         ds = create_datastore(vm_path.datastore, 1024, 500)
@@ -1101,9 +1124,9 @@ def create_vm(uuid=None, name=None,
               "resourcePool": res_pool_ref,
               "version": version}
     vm = VirtualMachine(**vm_dict)
-    _create_object("VirtualMachine", vm)
+    _create_object(vm)
 
-    res_pool = _get_object(res_pool_ref)
+    res_pool = get_object(res_pool_ref)
     res_pool.vm.ManagedObjectReference.append(vm.obj)
 
     return vm.obj
@@ -1111,7 +1134,7 @@ def create_vm(uuid=None, name=None,
 
 def create_task(task_name, state="running", result=None, error_fault=None):
     task = Task(task_name, state, result, error_fault)
-    _create_object("Task", task)
+    _create_object(task)
     return task
 
 
@@ -1174,12 +1197,14 @@ def fake_fetch_image(context, instance, host, port, dc_name, ds_name,
 
 def _get_vm_mdo(vm_ref):
     """Gets the Virtual Machine with the ref from the db."""
-    if _db_content.get("VirtualMachine", None) is None:
+    vms = _db_content.get("VirtualMachine")
+    if not vms:
         raise exception.NotFound("There is no VM registered")
-    if vm_ref not in _db_content.get("VirtualMachine"):
+    try:
+        return vms[vm_ref.value]
+    except KeyError:
         raise exception.NotFound("Virtual Machine with ref %s is not "
-                                 "there" % vm_ref)
-    return _db_content.get("VirtualMachine")[vm_ref]
+                                 "there" % vm_ref.value)
 
 
 def _merge_extraconfig(existing, changes):
@@ -1430,11 +1455,10 @@ class FakeVim(object):
     def _find_all_by_uuid(self, *args, **kwargs):
         uuid = kwargs.get('uuid')
         vm_refs = []
-        for vm_ref in _db_content.get("VirtualMachine"):
-            vm = _get_object(vm_ref)
+        for vm in get_objects("VirtualMachine"):
             vm_uuid = vm.get("summary.config.instanceUuid")
             if vm_uuid == uuid:
-                vm_refs.append(vm_ref)
+                vm_refs.append(vm.obj)
         return vm_refs
 
     def _delete_snapshot(self, method, *args, **kwargs):
@@ -1488,7 +1512,7 @@ class FakeVim(object):
                 vm_dict["extra_config"] = extraConfigs
 
         virtual_machine = VirtualMachine(**vm_dict)
-        _create_object("VirtualMachine", virtual_machine)
+        _create_object(virtual_machine)
         task_mdo = create_task(method, "success")
         return task_mdo.obj
 
@@ -1496,7 +1520,7 @@ class FakeVim(object):
         """Unregisters a VM from the Host System."""
         vm_ref = args[0]
         _get_vm_mdo(vm_ref)
-        del _db_content["VirtualMachine"][vm_ref]
+        del _db_content["VirtualMachine"][vm_ref.value]
         task_mdo = create_task(method, "success")
         return task_mdo.obj
 
@@ -1567,13 +1591,7 @@ class FakeVim(object):
 
     def _set_power_state(self, method, vm_ref, pwr_state="poweredOn"):
         """Sets power state for the VM."""
-        if _db_content.get("VirtualMachine", None) is None:
-            raise exception.NotFound("No Virtual Machine has been "
-                                     "registered yet")
-        if vm_ref not in _db_content.get("VirtualMachine"):
-            raise exception.NotFound("Virtual Machine with ref %s is not "
-                                     "there" % vm_ref)
-        vm_mdo = _db_content.get("VirtualMachine").get(vm_ref)
+        vm_mdo = _get_vm_mdo(vm_ref)
         vm_mdo.set("runtime.powerState", pwr_state)
         task_mdo = create_task(method, "success")
         return task_mdo.obj
@@ -1602,7 +1620,7 @@ class FakeVim(object):
                     # This means that we are retrieving props for all managed
                     # data objects of the specified 'type' in the entire
                     # inventory. This gets invoked by vim_util.get_objects.
-                    mdo_refs = _db_content[spec_type]
+                    mdo_refs = list(get_object_refs(spec_type))
                 elif obj_ref.type != spec_type:
                     # This means that we are retrieving props for the managed
                     # data objects in the parent object's 'path' property.
@@ -1612,7 +1630,7 @@ class FakeVim(object):
                     #     path = 'datastore'
                     # the above will retrieve all datastores in the given
                     # cluster.
-                    parent_mdo = _db_content[obj_ref.type][obj_ref]
+                    parent_mdo = get_object(obj_ref)
                     path = obj.selectSet[0].path
                     mdo_refs = parent_mdo.get(path).ManagedObjectReference
                 else:
@@ -1621,12 +1639,13 @@ class FakeVim(object):
                     # vim_util.get_properties_for_a_collection_of_objects.
                     mdo_refs = [obj_ref]
 
+                mdo_list = _db_content[spec_type]
                 for mdo_ref in mdo_refs:
-                    mdo = _db_content[spec_type][mdo_ref]
-                    prop_list = []
-                    for prop_name in properties:
-                        prop = Prop(prop_name, mdo.get(prop_name))
-                        prop_list.append(prop)
+                    mdo = mdo_list[mdo_ref.value]
+                    prop_list = [
+                        Prop(prop_name, mdo.get(prop_name))
+                        for prop_name in properties
+                    ]
                     obj_content = ObjectContent(mdo.obj, prop_list)
                     lst_ret_objs.add_object(obj_content)
             except Exception:
@@ -1636,14 +1655,13 @@ class FakeVim(object):
 
     def _add_port_group(self, method, *args, **kwargs):
         """Adds a port group to the host system."""
-        _host_sk = list(_db_content["HostSystem"].keys())[0]
-        host_mdo = _db_content["HostSystem"][_host_sk]
+        host_mdo = get_first_object("HostSystem")
         host_mdo._add_port_group(kwargs.get("portgrp"))
 
     def _add_iscsi_send_tgt(self, method, *args, **kwargs):
         """Adds a iscsi send target to the hba."""
         send_targets = kwargs.get('targets')
-        host_storage_sys = _get_objects('HostStorageSystem').objects[0]
+        host_storage_sys = get_first_object('HostStorageSystem')
         iscsi_hba_array = host_storage_sys.get('storageDeviceInfo'
                                                '.hostBusAdapter')
         iscsi_hba = iscsi_hba_array.HostHostBusAdapter[0]

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -430,8 +430,8 @@ class VMwareAPIVMTestCase(test.TestCase,
 
     def _get_vm_record(self):
         # Get record for VM
-        vms = vmwareapi_fake._get_objects("VirtualMachine")
-        for vm in vms.objects:
+        vms = vmwareapi_fake.get_objects("VirtualMachine")
+        for vm in vms:
             if vm.get('name') == vm_util._get_vm_name(self._display_name,
                                                       self.uuid):
                 return vm
@@ -1410,7 +1410,7 @@ class VMwareAPIVMTestCase(test.TestCase,
 
     def _snapshot_delete_vm_snapshot_exception(self, exception, call_count=1):
         self._create_vm()
-        fake_vm = vmwareapi_fake._get_objects("VirtualMachine").objects[0].obj
+        fake_vm = vmwareapi_fake.get_first_object_ref("VirtualMachine")
         snapshot_ref = vmwareapi_fake.ManagedObjectReference(
                                value="Snapshot-123",
                                name="VirtualMachineSnapshot")
@@ -1855,7 +1855,7 @@ class VMwareAPIVMTestCase(test.TestCase,
         opt_val = OptionValue(key='', value=5906)
         fake_vm.set(vm_util.VNC_CONFIG_KEY, opt_val)
         vnc_console = self.conn.get_vnc_console(self.context, self.instance)
-        host = vmwareapi_fake._get_objects('HostSystem').objects[0]
+        host = vmwareapi_fake.get_first_object('HostSystem')
         self.assertEqual(host.name, vnc_console.host)
         self.assertEqual(5906, vnc_console.port)
 
@@ -2041,8 +2041,8 @@ class VMwareAPIVMTestCase(test.TestCase,
 
     def test_iscsi_rescan_hba(self):
         fake_target_portal = 'fake_target_host:port'
-        host_storage_sys = vmwareapi_fake._get_objects(
-            "HostStorageSystem").objects[0]
+        host_storage_sys = vmwareapi_fake.get_first_object(
+            "HostStorageSystem")
         iscsi_hba_array = host_storage_sys.get('storageDeviceInfo'
                                                '.hostBusAdapter')
         iscsi_hba = iscsi_hba_array.HostHostBusAdapter[0]
@@ -2062,7 +2062,7 @@ class VMwareAPIVMTestCase(test.TestCase,
     def test_iscsi_get_target(self):
         data = {'target_portal': 'fake_target_host:port',
                 'target_iqn': 'fake_target_iqn'}
-        host = vmwareapi_fake._get_objects('HostSystem').objects[0]
+        host = vmwareapi_fake.get_first_object('HostSystem')
         host._add_iscsi_target(data)
         vops = volumeops.VMwareVolumeOps(self.conn._session)
         result = vops._iscsi_get_target(data)

--- a/nova/tests/unit/virt/vmwareapi/test_vim_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vim_util.py
@@ -28,12 +28,12 @@ class VMwareVIMUtilTestCase(test.NoDBTestCase):
     def test_get_inner_objects(self):
         property = ['summary.name']
         # Get the fake datastores directly from the cluster
-        cluster_refs = fake._get_object_refs('ClusterComputeResource')
-        cluster = fake._get_object(cluster_refs[0])
+        cluster = fake.get_first_object('ClusterComputeResource')
+        cluster_ref = cluster.obj
         expected_ds = cluster.datastore.ManagedObjectReference
         # Get the fake datastores using inner objects utility method
         result = vim_util.get_inner_objects(
-            self.vim, cluster_refs[0], 'datastore', 'Datastore', property)
+            self.vim, cluster_ref, 'datastore', 'Datastore', property)
         datastores = [oc.obj for oc in result.objects]
         self.assertEqual(expected_ds, datastores)
 

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -614,7 +614,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         ide_controller = fake.VirtualIDEController()
         devices.append(scsi_controller)
         devices.append(ide_controller)
-        fake._update_object("VirtualMachine", vm)
+        fake.update_object(vm)
         # return the scsi type, not ide
         hardware_device = vm.get("config.hardware.device").VirtualDevice
         self.assertEqual(constants.DEFAULT_ADAPTER_TYPE,
@@ -627,7 +627,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         ide_controller = fake.VirtualIDEController()
         devices.append(scsi_controller)
         devices.append(ide_controller)
-        fake._update_object("VirtualMachine", vm)
+        fake.update_object(vm)
         # the controller is not suitable since the device under this controller
         # has exceeded SCSI_MAX_CONNECT_NUMBER
         for i in range(0, constants.SCSI_MAX_CONNECT_NUMBER):
@@ -2186,7 +2186,7 @@ class VMwareVMUtilGetHostRefTestCase(test.NoDBTestCase):
         self.session = VMwareAPISession()
 
         # Create a fake VirtualMachine running on a known host
-        self.host_ref = list(fake._db_content['HostSystem'].keys())[0]
+        self.host_ref = fake.get_first_object_ref("HostSystem")
         self.vm_ref = fake.create_vm(host_ref=self.host_ref)
 
     @mock.patch.object(vm_util, 'get_vm_ref')
@@ -2202,7 +2202,7 @@ class VMwareVMUtilGetHostRefTestCase(test.NoDBTestCase):
     def test_get_host_name_for_vm(self, mock_get_vm_ref):
         mock_get_vm_ref.return_value = self.vm_ref
 
-        host = fake._get_object(self.host_ref)
+        host = fake.get_object(self.host_ref)
 
         ret = vm_util.get_host_name_for_vm(self.session, 'fake-instance')
 

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -79,7 +79,8 @@ class VMwareVMOpsTestCase(test.TestCase):
 
         self._virtapi = mock.Mock()
         self._image_id = nova.tests.unit.image.fake.get_valid_image_id()
-        fake_ds_ref = vmwareapi_fake.ManagedObjectReference(value='fake-ds')
+        fake_ds_ref = vmwareapi_fake.ManagedObjectReference(
+            name='Datastore', value='fake-ds')
         self._ds = ds_obj.Datastore(
                 ref=fake_ds_ref, name='fake_ds',
                 capacity=10 * units.Gi,
@@ -87,9 +88,8 @@ class VMwareVMOpsTestCase(test.TestCase):
 
         self._dc_info = ds_util.DcInfo(
                 ref='fake_dc_ref', name='fake_dc',
-                vmFolder=vmwareapi_fake.ManagedObjectReference
-                                                        (name='fake_vm_folder',
-                                                        value='Folder'))
+                vmFolder=vmwareapi_fake.ManagedObjectReference(
+                    name='Folder', value='fake_vm_folder'))
         cluster = vmwareapi_fake.create_cluster('fake_cluster', fake_ds_ref)
         self._uuid = uuidsentinel.foo
         self._instance_values = {
@@ -2497,7 +2497,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                    self._metadata,
                                                    None)
 
-        vm = vmwareapi_fake._get_object(vm_ref)
+        vm = vmwareapi_fake.get_object(vm_ref)
 
         # Test basic VM parameters
         self.assertEqual(self._instance.uuid, vm.name)
@@ -2520,7 +2520,7 @@ class VMwareVMOpsTestCase(test.TestCase):
         datastores = vm.datastore.ManagedObjectReference
         self.assertEqual(1, len(datastores))
 
-        datastore = vmwareapi_fake._get_object(datastores[0])
+        datastore = vmwareapi_fake.get_object(datastores[0])
         self.assertEqual(self._ds.name, datastore.get('summary.name'))
 
         # Test that the VM's network is configured as specified


### PR DESCRIPTION
The code was previously using the object-id to
lookup an object, meaning that you couldn't pass
a newly created Managed-object-reference like you
could over the vmware-api.
Now the lookup happens over the ref-id string,
and in turn some functions were refactored
to take that into account.

Change-Id: I70b87ed5f4fe08076745f9bc389b0f42930395cf