### PR TITLE
No Flavor notification in Test Fixture setup

### DIFF
--- a/nova/tests/fixtures.py
+++ b/nova/tests/fixtures.py
@@ -689,8 +689,11 @@ class DefaultFlavorsFixture(fixtures.Fixture):
                            root_gb=1, flavorid='6', name='m1.tiny.specs',
                            extra_specs=extra_specs, **defaults),
             ]
-        for flavor in default_flavors:
-            flavor.create()
+        # Sending out notifications results in loading all projects
+        # which is relatively expensive for the setup of each unit test
+        with mock.patch.object(objects.Flavor, '_send_notification'):
+            for flavor in default_flavors:
+                flavor.create()
 
 
 class RPCFixture(fixtures.Fixture):


### PR DESCRIPTION
The notification causes a load of all projects
for each flavor created, times for each test set up.
Patching it out reduces total runtime of the unit
tests by 20%

Change-Id: Ib3b1f2bc401be67d043b723ecff59a0c45d9f81d