### PR TITLE
vmware: Fix AttributeError in find_rescue_device()

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -34,6 +34,7 @@ from nova.tests.unit.virt.vmwareapi import fake
 from nova.tests.unit.virt.vmwareapi import stubs
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import driver
+from nova.virt.vmwareapi import vim_util
 from nova.virt.vmwareapi import vm_util
 
 CONF = nova.conf.CONF
@@ -1819,7 +1820,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         devices = fake._create_array_of_type('VirtualDevice')
         devices.VirtualDevice = self._vmdk_path_and_adapter_type_devices(
             filename)
-        return devices
+        return vim_util.get_array_items(devices)
 
     def test_find_rescue_device(self):
         filename = '[test_datastore] uuid/uuid-rescue.vmdk'

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1942,7 +1942,7 @@ def find_rescue_device(hardware_devices, instance):
     :param instance: nova.objects.instance.Instance object
     :return: the rescue disk device object
     """
-    for device in hardware_devices.VirtualDevice:
+    for device in hardware_devices:
         if (device.__class__.__name__ == "VirtualDisk" and
                 device.backing.__class__.__name__ ==
                 'VirtualDiskFlatVer2BackingInfo' and


### PR DESCRIPTION
With switching to vm_util.get_hardware_devices(), we automatically use
vim_util.get_array_items(), which already takes care of accessing the
VirtualDevice attribute automatically. Thus, we get a list instead of an
object and cannot access a VirtualDevice attribute anymore.

The fix is to just iterate over the list of objects.

Change-Id: I3e031d3954c6361d96d26c13e47ae161056b0b78