### PR TITLE
Add a NetworkInfoAsyncWrapper serializer to raven

### DIFF
--- a/nova/network/model.py
+++ b/nova/network/model.py
@@ -611,3 +611,23 @@ class NetworkInfoAsyncWrapper(NetworkInfo):
                     raise
             finally:
                 self._gt = None
+
+
+# This code makes sure we don't run into deadlocks when using Sentry's raven
+# module to log errors/exceptions. We would otherwise try to serialize the
+# NetworkInfoAsyncWrapper as a list, which would access __iter__(), which would
+# wait for the async process to finish, which can't finish, because it needs to
+# use logging and we hold the lock for logging in raven.
+try:
+    from raven.utils.serializer.base import Serializer
+    from raven.utils.serializer.manager import manager as serialization_manager
+
+    class NetworkInfoAsyncWrapperSerializer(Serializer):
+        types = (NetworkInfoAsyncWrapper, )
+
+        def serialize(self, value, **kwargs):
+            return 'NetworkInfoAsyncWrapper with {}'.format(value._gt)
+
+    serialization_manager.register(NetworkInfoAsyncWrapper)
+except ImportError:
+    pass


### PR DESCRIPTION
When using python-raven to send exceptions to Sentry, the serialization
might run into a deadlock if the exception happens during server build
and the NetworkInfoWrapper object is not done.

We mitigate this by registering our own serializer in raven, which does
not go into the content, but just prints the greenthread.

Change-Id: Ie170e951e4d8d007a48d5878ec957e2e95155628