### PR TITLE
Fix NetworkInfoAsyncWrapper serializer registration

### DIFF
--- a/nova/network/model.py
+++ b/nova/network/model.py
@@ -628,6 +628,6 @@ try:
         def serialize(self, value, **kwargs):
             return 'NetworkInfoAsyncWrapper with {}'.format(value._gt)
 
-    serialization_manager.register(NetworkInfoAsyncWrapper)
+    serialization_manager.register(NetworkInfoAsyncWrapperSerializer)
 except ImportError:
     pass


### PR DESCRIPTION
We unintentionally registered the NetworkInfoAsyncWrapper instead of the
NetworkInfoAsyncWrapperSerializer which could not work and broke sentry
reporting.

Change-Id: Ib6f436ded2481d99dc1b32c54974c37b94281b81