### PR TITLE
vmware: Specify volume profiles while snapshotting

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -544,7 +544,9 @@ class VMwareVCDriver(driver.ComputeDriver):
 
     def snapshot(self, context, instance, image_id, update_task_state):
         """Create snapshot from a running VM instance."""
-        self._vmops.snapshot(context, instance, image_id, update_task_state)
+        volumes = self._get_volume_mappings(context, instance)
+        self._vmops.snapshot(context, instance, image_id, update_task_state,
+                             volume_mapping=volumes)
 
     def reboot(self, context, instance, network_info, reboot_type,
                block_device_info=None, bad_volumes_callback=None):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1470,9 +1470,12 @@ class VMwareVMOps(object):
         return task_info.result
 
     def _create_vm_clone(self, instance, vm_ref, snapshot_ref, dc_info,
-                         disk_move_type=None, image_id=None, disks=None):
+                         disk_move_type=None, image_id=None, disks=None,
+                         volume_mapping=None):
         """Clone VM to be deployed to same ds as source VM
         """
+        volume_mapping = volume_mapping or {}
+
         image_id = image_id or uuidutils.generate_uuid()
 
         if disks:
@@ -1504,17 +1507,36 @@ class VMwareVMOps(object):
         if disks:
             disk_devices = [vmdk_info.device.key for vmdk_info in disks]
             device_change = []
+            disk_locators = []
             for device in vm_util.get_hardware_devices(self._session, vm_ref):
+                device_is_disk = device.__class__.__name__ == "VirtualDisk"
                 if getattr(device, 'macAddress', None) or \
-                                        device.__class__.__name__ == "VirtualDisk"\
-                        and device.key not in disk_devices:
+                        device_is_disk and device.key not in disk_devices:
                     removal = client_factory.create(
                                     'ns0:VirtualDeviceConfigSpec')
                     removal.device = device
                     removal.operation = 'remove'
+                    if device_is_disk:
+                        # specify a profile on the disk as one of the disks
+                        # could be associated with a storage IO control enabled
+                        # profile and clone then fails without profile even if
+                        # we remove the disk
+                        data = volume_mapping.get(device.key)
+                        if data and data.get('profile_id'):
+                            profile_spec = client_factory.create(
+                                "ns0:VirtualMachineDefinedProfileSpec")
+                            profile_spec.profileId = data.get('profile_id')
+
+                            locator = client_factory.create(
+                                "ns0:VirtualMachineRelocateSpecDiskLocator")
+                            locator.diskId = device.key
+                            locator.datastore = device.backing.datastore
+                            locator.profile = [profile_spec]
+                            disk_locators.append(locator)
                     device_change.append(removal)
 
             config_spec.deviceChange = device_change
+            rel_spec.disk = disk_locators
 
         clone_spec = vm_util.clone_vm_spec(client_factory,
                                            rel_spec,
@@ -1542,7 +1564,8 @@ class VMwareVMOps(object):
                                                "info")
         return task_info.result
 
-    def snapshot(self, context, instance, image_id, update_task_state):
+    def snapshot(self, context, instance, image_id, update_task_state,
+                 volume_mapping):
         """Create snapshot from a running VM instance.
 
         Steps followed are:
@@ -1608,7 +1631,8 @@ class VMwareVMOps(object):
                                                 dc_info,
                                                 disk_move_type=disk_move_type,
                                                 image_id=image_id,
-                                                disks=[vmdk])
+                                                disks=[vmdk],
+                                                volume_mapping=volume_mapping)
 
             update_task_state(task_state=task_states.IMAGE_UPLOADING,
                               expected_state=task_states.IMAGE_PENDING_UPLOAD)


### PR DESCRIPTION
When at least one of the disks attached to the VM during snapshotting is
associated with a profile containing storage IO control, the clone
operation done during snapshotting fails with `VmConfigFault` and the
more detailed "IO Filters are configured for the Source Disk
vm-174314:2002, but no storage-policy selected for the destination.
Select an appropriate storage-policy for destination disk.".

We can mitigate this by specifying the profile in the RelocateSpec part
of the CloneSpec, i.e. add an VirtualMachineRelocateSpecDiskLocator for
each disk to be detached into the "location.disk" attribute. Setting
the "profile" attribute on the VirtualDeviceConfigSpec we create for
specifying the removal does not help.

This will not add a profile for volumes attached before Cinder's queens
release, as the "profile_id" was not part of connection_info before
that.

Change-Id: I2b71ef4a0b2ce79c287946dd15b7dc6af22439e9

---

Since we didn't have our storage IO control enabled volume-type before Cinder was on queens, this should fix all VMs for us.