### PR TITLE
api: Update RequestSpec when updating server-group membership

### DIFF
--- a/nova/api/openstack/compute/server_groups.py
+++ b/nova/api/openstack/compute/server_groups.py
@@ -366,6 +366,16 @@ class ServerGroupController(wsgi.Controller):
         # DB.
         sg.refresh()
 
+        # update the request-specs of the updated members
+        for member_uuid in found_instances_hosts:
+            request_spec = \
+                objects.RequestSpec.get_by_instance_uuid(context, member_uuid)
+            if member_uuid in members_to_add:
+                request_spec.instance_group = sg
+            else:
+                request_spec.instance_group = None
+            request_spec.save()
+
         # tell the compute hosts about the update, so they can sync if
         # necessary
         hosts_to_update = set(h for h in found_instances_hosts.values() if h)


### PR DESCRIPTION
When we add/remove a server to/from a server-group, we have to update
the server's RequestSpec's instance_group attribute, because this is
used during scheduling when resizing a server to record a list of
appropriate hosts for the instance.

	AttributeError: 'NoneType' object has no attribute 'hosts'
	  File "oslo_messaging/rpc/server.py", line 166, in _process_incoming
		res = self.dispatcher.dispatch(message)
	  File "oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
		return self._do_dispatch(endpoint, method, ctxt, args)
	  File "oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
		result = func(ctxt, **new_args)
	  File "oslo_messaging/rpc/server.py", line 229, in inner
		return func(*args, **kwargs)
	  File "nova/conductor/manager.py", line 94, in wrapper
		return fn(self, context, *args, **kwargs)
	  File "nova/compute/utils.py", line 1246, in decorated_function
		return function(self, context, *args, **kwargs)
	  File "nova/conductor/manager.py", line 298, in migrate_server
		host_list)
	  File "nova/conductor/manager.py", line 370, in _cold_migrate
		updates, ex, request_spec)
	  File "oslo_utils/excutils.py", line 220, in __exit__
		self.force_reraise()
	  File "oslo_utils/excutils.py", line 196, in force_reraise
		six.reraise(self.type_, self.value, self.tb)
	  File "nova/conductor/manager.py", line 339, in _cold_migrate
		task.execute()
	  File "nova/conductor/tasks/base.py", line 27, in wrap
		self.rollback()
	  File "oslo_utils/excutils.py", line 220, in __exit__
		self.force_reraise()
	  File "oslo_utils/excutils.py", line 196, in force_reraise
		six.reraise(self.type_, self.value, self.tb)
	  File "nova/conductor/tasks/base.py", line 24, in wrap
		return original(self)
	  File "nova/conductor/tasks/base.py", line 42, in execute
		return self._execute()
	  File "nova/conductor/tasks/migrate.py", line 174, in _execute
		scheduler_utils.setup_instance_group(self.context, self.request_spec)
	  File "nova/scheduler/utils.py", line 893, in setup_instance_group
		request_spec.instance_group.hosts = list(group_info.hosts)

Change-Id: Ic193dd3c59bc717ba5329f63054297f44127d76d