### PR TITLE
Do not join metadata tables on server get

### DIFF
--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -50,6 +50,7 @@ from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import joinedload_all
 from sqlalchemy.orm import noload
+from sqlalchemy.orm import subqueryload
 from sqlalchemy.orm import undefer
 from sqlalchemy.schema import Table
 from sqlalchemy import sql
@@ -2044,6 +2045,8 @@ def _build_instance_get(context, columns_to_join=None):
             continue
         if 'extra.' in column:
             query = query.options(undefer(column))
+        elif column in ['metadata', 'system_metadata']:
+            query = query.options(subqueryload(column))
         else:
             query = query.options(joinedload(column))
     # NOTE(alaski) Stop lazy loading of columns not needed.


### PR DESCRIPTION
We use SQLAlchemy's "joinedload()" to load "instance_system_metadata"
and "instance_metadata" tables by default. This can become problematic,
if the instance contains user-data, because that can be up to 64 KB in
size. This comes from the fact that the metadata tables contain multiple
rows - in our env more than 20 - and thus the data from the "instances"
table is sent over the wire more than 20 times, leading to very high
output traffic on the DB.

Changing the joinedload() to subqueryload() does incur the penalty of
another query, but reduces the amount of data fetched drastically. In
our tests, this also reduced the time of a "_build_instance_get()" call
to 1/3 for a VM with lots of user-data and is comparable (minimally
faster) for a VM without user-data.

Change-Id: I47aab793979aef7cccb6e9bb0f10143d7ac41e7d