### PR TITLE
Skip recomputing baremetal quota usage

### DIFF
--- a/nova/quota.py
+++ b/nova/quota.py
@@ -197,12 +197,18 @@ class DbQuotaDriver(object):
             # such as AbsoluteResources.
             if not isinstance(resource, CountableResource):
                 continue
-            if resource.name in usages:
+            if resource.name in usages or 'instances' in usages and \
+                    resource.name.startswith('instances_'):
                 # This is needed because for any of the resources:
                 # ('instances', 'cores', 'ram'), they are counted at the same
                 # time for efficiency (query the instances table once instead
                 # of multiple times). So, a count of any one of them contains
                 # counts for the others and we can avoid re-counting things.
+                # NOTE(jkulik): If 'instances' is in there, our resources for
+                # baremetal flavors, which all start with `instances_` also
+                # have to be in there. If they are not in there, the
+                # user/project has no instance with that resource and we don't
+                # list it. Still, we don't have to re-compute the usages.
                 continue
             if resource.name in ('key_pairs', 'server_group_members',
                                  'security_group_rules'):


### PR DESCRIPTION
We're using a single function to compute the usage of multiple quota
reources. There's already a check in place that prohibits recomputing
that data, if the resource's name is already in the data. When computing
usage data, we use the instances belonging to a user/project. If that
user/project does not have any baremetal instances of a flavor, we don't
add the flavor's resource to the usage data. This means, the check is
unable to skip recomputing the data.

If "instances" is already in the usage data, our shared function must
have been called already. Therefore, if we encounter a resource having a
name starting with "instances_" - which should be only true for
resources we created for baremetal flavors - we can skip the
recomputation even if the resource's name is not in the usage data.