### PR TITLE
Vmware: No update_admin_vm_group_membership in post_live_migration

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2752,14 +2752,15 @@ class VMwareAPIVMTestCase(test.TestCase,
         block_device_info = self._create_block_device_info()
         with test.nested(
                 mock.patch.object(self.conn._volumeops, 'delete_shadow_vms'),
-                mock.patch.object(self.conn._vmops, 'update_cluster_placement')
-            ) as (mock_delete_shadow_vms, mock_update_cluster_placement):
+                mock.patch.object(self.conn._vmops,
+                                  'sync_instance_server_group')
+            ) as (mock_delete_shadow_vms, mock_sync_instance_server_group):
 
             self.conn.post_live_migration(
                           self.context, self.instance, block_device_info,
                           migrate_data)
             mock_delete_shadow_vms.assert_called_once()
-            mock_update_cluster_placement.assert_called_once()
+            mock_sync_instance_server_group.assert_called_once()
 
     def test_get_instance_disk_info_is_implemented(self):
         # Ensure that the method has been implemented in the driver

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -1027,7 +1027,7 @@ class VMwareVCDriver(driver.ComputeDriver):
         """Post operation of live migration at source host."""
         if not migrate_data.is_same_vcenter:
             self._volumeops.delete_shadow_vms(block_device_info, instance)
-        self._vmops.update_cluster_placement(context, instance)
+        self._vmops.sync_instance_server_group(context, instance)
 
     def post_live_migration_at_source(self, context, instance, network_info):
         # This is mostly for network related cleanup tasks at the source


### PR DESCRIPTION
Since the VM is gone after a migration,
it won't be possible to update the vm-group membership

Change-Id: I04c62f400a522bf9fe5828199c0dff80a1004f42