### PR TITLE
Vmwareapi: Handle missing details in ManagedObjectNotFoundException

### DIFF
--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -324,6 +324,10 @@ def vm_ref_cache_heal_from_instance(func):
                 if vm_ref is None:
                     return  # noqa
 
+                # we are missing details about the issue, so raise it
+                if not e.details:
+                    return  # noqa
+
                 obj = e.details.get("obj")
                 # A different moref may be invalid, nothing we can do about it
                 if obj != vm_ref.value:


### PR DESCRIPTION
The attribute 'details' isn't always set,
so we have to raise the exception without
recovering the missing vm_ref

Change-Id: Ib1fbd90e03a0f36fb5833c71ae6cdde454e74958