### PR TITLE
Resource UUID context

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -2454,7 +2454,8 @@ class API(base.Base):
         except exception.InvalidID:
             LOG.debug("Invalid instance id %s", instance_id)
             raise exception.InstanceNotFound(instance_id=instance_id)
-
+        context.resource_id = instance.uuid
+        context.update_store()
         return instance
 
     def get_all(self, context, search_opts=None, limit=None, marker=None,

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -1952,6 +1952,9 @@ class ComputeManager(manager.Manager):
 
         @utils.synchronized(instance.uuid)
         def _locked_do_build_and_run_instance(*args, **kwargs):
+            # NOTE(fwiesel): Spawned in a different thread, store the context
+            context.update_store()
+
             # NOTE(danms): We grab the semaphore with the instance uuid
             # locked because we could wait in line to build this instance
             # for a while and we want to make sure that nothing else tries
@@ -7929,6 +7932,9 @@ class ComputeManager(manager.Manager):
                          'num_vm_instances': num_vm_instances})
 
         def _sync(db_instance):
+            context.resource_uuid = db_instance.uuid
+            context.update_store()
+
             # NOTE(melwitt): This must be synchronized as we query state from
             #                two separate sources, the driver and the database.
             #                They are set (in stop_instance) and read, in sync.

--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -669,6 +669,8 @@ class ComputeTaskManager(base.Base):
 
         elevated = context.elevated()
         for (instance, host_list) in six.moves.zip(instances, host_lists):
+            context.resource_uuid = instance.uuid
+            context.update_store()
             host = host_list.pop(0)
             if is_reschedule:
                 # If this runs in the superconductor, the first instance will
@@ -774,7 +776,7 @@ class ComputeTaskManager(base.Base):
 
             alts = [(alt.service_host, alt.nodename) for alt in host_list]
             LOG.debug("Selected host: %s; Selected node: %s; Alternates: %s",
-                    host.service_host, host.nodename, alts, instance=instance)
+                    host.service_host, host.nodename, alts)
 
             self.compute_rpcapi.build_and_run_instance(context,
                     instance=instance, host=host.service_host, image=image,
@@ -1374,13 +1376,15 @@ class ComputeTaskManager(base.Base):
                 # Skip placeholders that were buried in cell0 or had their
                 # build requests deleted by the user before instance create.
                 continue
+            context.resource_uuid = instance.uuid
+            context.update_store()
             cell = cell_mapping_cache[instance.uuid]
             # host_list is a list of one or more Selection objects, the first
             # of which has been selected and its resources claimed.
             host = host_list.pop(0)
             alts = [(alt.service_host, alt.nodename) for alt in host_list]
             LOG.debug("Selected host: %s; Selected node: %s; Alternates: %s",
-                    host.service_host, host.nodename, alts, instance=instance)
+                    host.service_host, host.nodename, alts)
             filter_props = request_spec.to_legacy_filter_properties_dict()
             scheduler_utils.populate_retry(filter_props, instance.uuid)
             scheduler_utils.populate_filter_properties(filter_props,

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -326,7 +326,7 @@ class VMwareVCDriver(driver.ComputeDriver):
         path = os.path.join(CONF.vmware.serial_log_dir, fname)
         if not os.path.exists(path):
             LOG.warning('The console log is missing. Check your VSPC '
-                        'configuration', instance=instance)
+                        'configuration')
             return b""
         read_log_data, remaining = nova.privsep.path.last_bytes(
             path, MAX_CONSOLE_BYTES)
@@ -528,8 +528,7 @@ class VMwareVCDriver(driver.ComputeDriver):
         """Detach volume storage to VM instance."""
         if not self._vmops.is_instance_in_resource_pool(instance):
             LOG.debug("Not detaching %s, vm is in different cluster",
-                connection_info["volume_id"],
-                instance=instance)
+                connection_info["volume_id"])
             return True
         # NOTE(claudiub): if context parameter is to be used in the future,
         # the _detach_instance_volumes method will have to be updated as well.
@@ -572,15 +571,13 @@ class VMwareVCDriver(driver.ComputeDriver):
                                        disk.get('device_name'))
                 except exception.DiskNotFound:
                     LOG.warning('The volume %s does not exist!',
-                                disk.get('device_name'),
-                                instance=instance)
+                                disk.get('device_name'))
                 except Exception as e:
                     with excutils.save_and_reraise_exception():
                         LOG.error("Failed to detach %(device_name)s. "
                                   "Exception: %(exc)s",
                                   {'device_name': disk.get('device_name'),
-                                   'exc': e},
-                                  instance=instance)
+                                   'exc': e})
 
     def destroy(self, context, instance, network_info, block_device_info=None,
                 destroy_disks=True):
@@ -604,8 +601,7 @@ class VMwareVCDriver(driver.ComputeDriver):
             except (vexc.ManagedObjectNotFoundException,
                     exception.InstanceNotFound):
                 LOG.warning('Instance does not exists. Proceeding to '
-                            'delete instance properties on datastore',
-                            instance=instance)
+                            'delete instance properties on datastore')
         self._vmops.destroy(context, instance, destroy_disks)
 
     def pause(self, instance):
@@ -851,7 +847,7 @@ class VMwareVCDriver(driver.ComputeDriver):
 
         if hasattr(result, 'drsFault'):
             LOG.error("Placement Error: %s", vim_util.serialize_object(
-                result.drsFault), instance=instance)
+                result.drsFault))
 
         if (not hasattr(result, 'recommendations') or
                 not result.recommendations):
@@ -906,12 +902,12 @@ class VMwareVCDriver(driver.ComputeDriver):
         """Live migration of an instance to another host."""
         if not migrate_data:
             LOG.error("live_migration() called without migration_data"
-                      " - cannot continue operations", instance=instance)
+                      " - cannot continue operations")
             recover_method(context, instance, dest, migrate_data)
             raise ValueError("Missing migrate_data")
 
         if migrate_data.instance_already_migrated:
-            LOG.info("Recovering migration", instance=instance)
+            LOG.info("Recovering migration")
             post_method(context, instance, dest, block_migration, migrate_data)
             return
 
@@ -933,16 +929,15 @@ class VMwareVCDriver(driver.ComputeDriver):
                 required_volume_attributes)
             self._set_vif_infos(migrate_data, dest_session)
             self._vmops.live_migration(instance, migrate_data, volumes)
-            LOG.info("Migration operation completed", instance=instance)
+            LOG.info("Migration operation completed")
             post_method(context, instance, dest, block_migration, migrate_data)
         except Exception:
-            LOG.exception("Failed due to an exception", instance=instance)
+            LOG.exception("Failed due to an exception")
             with excutils.save_and_reraise_exception():
                 # We are still in the task-state migrating, so cannot
                 # recover the DRS settings. We rely on the sync to do that
                 LOG.debug("Calling live migration recover_method "
-                          "for instance: %s", instance["name"],
-                          instance=instance)
+                          "for instance: %s", instance["name"])
                 recover_method(context, instance, dest, migrate_data)
 
     def _get_volume_mappings(self, context, instance):
@@ -967,7 +962,7 @@ class VMwareVCDriver(driver.ComputeDriver):
                 message = ("Could not parse connection_info for volume {}."
                     " Reason: {}"
                 ).format(bdm.volume_id, e)
-                LOG.warning(message, instance=instance)
+                LOG.warning(message)
 
             # Normalize the datastore reference
             # As it depends on the caller, if actually need the
@@ -1019,7 +1014,7 @@ class VMwareVCDriver(driver.ComputeDriver):
                                                migrate_data=None):
         """Clean up destination node after a failed live migration."""
         LOG.info("rollback_live_migration_at_destination %s",
-            block_device_info, instance=instance)
+            block_device_info)
         if not migrate_data.is_same_vcenter:
             self._volumeops.delete_shadow_vms(block_device_info, instance)
 
@@ -1067,7 +1062,7 @@ class VMwareVCDriver(driver.ComputeDriver):
         with self._error_out_instance_on_exception(instance,
                 "fixup shadow vms"):
             volumes = self._get_volume_mappings(context, instance)
-            LOG.debug("Fixing shadow vms %s", volumes, instance=instance)
+            LOG.debug("Fixing shadow vms %s", volumes)
             self._volumeops.fixup_shadow_vms(instance, volumes)
 
     def ensure_filtering_rules_for_instance(self, instance, network_info):

--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -227,8 +227,7 @@ def image_transfer(read_handle, write_handle):
 
 
 def upload_iso_to_datastore(iso_path, instance, **kwargs):
-    LOG.debug("Uploading iso %s to datastore", iso_path,
-              instance=instance)
+    LOG.debug("Uploading iso %s to datastore", iso_path)
     with open(iso_path, 'r') as iso_file:
         write_file_handle = rw_handles.FileWriteHandle(
             kwargs.get("host"),
@@ -248,8 +247,7 @@ def upload_iso_to_datastore(iso_path, instance, **kwargs):
             data = iso_file.read(block_size)
         write_file_handle.close()
 
-    LOG.debug("Uploaded iso %s to datastore", iso_path,
-              instance=instance)
+    LOG.debug("Uploaded iso %s to datastore", iso_path)
 
 
 def fetch_image(context, instance, host, port, dc_name, ds_name, file_path,
@@ -259,8 +257,7 @@ def fetch_image(context, instance, host, port, dc_name, ds_name, file_path,
     LOG.debug("Downloading image file data %(image_ref)s to the "
               "data store %(data_store_name)s",
               {'image_ref': image_ref,
-               'data_store_name': ds_name},
-              instance=instance)
+               'data_store_name': ds_name})
 
     metadata = IMAGE_API.get(context, image_ref)
     file_size = int(metadata['size'])
@@ -274,8 +271,7 @@ def fetch_image(context, instance, host, port, dc_name, ds_name, file_path,
               "%(data_store_name)s",
               {'image_ref': image_ref,
                'upload_name': 'n/a' if file_path is None else file_path,
-               'data_store_name': 'n/a' if ds_name is None else ds_name},
-              instance=instance)
+               'data_store_name': 'n/a' if ds_name is None else ds_name})
 
 
 def _build_shadow_vm_config_spec(session, name, size_kb, disk_type, ds_name):
@@ -350,8 +346,7 @@ def fetch_image_stream_optimized(context, instance, session, vm_name,
     image_ref = image_id if image_id else instance.image_ref
     LOG.debug("Downloading image file data %(image_ref)s to the ESX "
               "as VM named '%(vm_name)s'",
-              {'image_ref': image_ref, 'vm_name': vm_name},
-              instance=instance)
+              {'image_ref': image_ref, 'vm_name': vm_name})
 
     metadata = IMAGE_API.get(context, image_ref)
     file_size = int(metadata['size'])
@@ -367,7 +362,7 @@ def fetch_image_stream_optimized(context, instance, session, vm_name,
                                     file_size)
 
     LOG.info("Downloaded image file data %(image_ref)s",
-             {'image_ref': instance.image_ref}, instance=instance)
+             {'image_ref': instance.image_ref})
     vmdk = vm_util.get_vmdk_info(session, imported_vm_ref, vm_name)
     vm_util.mark_vm_as_template(session, instance, imported_vm_ref)
     return vmdk.capacity_in_bytes, vmdk.path
@@ -487,8 +482,7 @@ def fetch_image_ova(context, instance, session, vm_name, ds_name,
     image_ref = instance.image_ref
     LOG.debug("Downloading OVA image file %(image_ref)s to the ESX "
               "as VM named '%(vm_name)s'",
-              {'image_ref': image_ref, 'vm_name': vm_name},
-              instance=instance)
+              {'image_ref': image_ref, 'vm_name': vm_name})
 
     metadata = IMAGE_API.get(context, image_ref)
     file_size = int(metadata['size'])
@@ -515,7 +509,7 @@ def fetch_image_ova(context, instance, session, vm_name, ds_name,
                                                 file_size)
 
                 LOG.info("Downloaded OVA image file %(image_ref)s",
-                         {'image_ref': instance.image_ref}, instance=instance)
+                         {'image_ref': instance.image_ref})
                 vmdk = vm_util.get_vmdk_info(session,
                                              imported_vm_ref,
                                              vm_name)
@@ -529,7 +523,7 @@ def fetch_image_ova(context, instance, session, vm_name, ds_name,
 def upload_image_stream_optimized(context, image_id, instance, session,
                                   vm, vmdk_size):
     """Upload the snapshotted vm disk file to Glance image server."""
-    LOG.debug("Uploading image %s", image_id, instance=instance)
+    LOG.debug("Uploading image %s", image_id)
     metadata = IMAGE_API.get(context, image_id)
 
     read_handle = rw_handles.VmdkReadHandle(session,
@@ -560,5 +554,4 @@ def upload_image_stream_optimized(context, image_id, instance, session,
         updater.stop()
         read_handle.close()
 
-    LOG.debug("Uploaded image %s to the Glance image server", image_id,
-              instance=instance)
+    LOG.debug("Uploaded image %s to the Glance image server", image_id)

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1726,7 +1726,7 @@ def get_vmdk_adapter_type(adapter_type):
 
 def create_vm(session, instance, vm_folder, config_spec, res_pool_ref):
     """Create VM on ESX host."""
-    LOG.debug("Creating VM on the ESX host", instance=instance)
+    LOG.debug("Creating VM on the ESX host")
     vm_create_task = session._call_method(
         session.vim,
         "CreateVM_Task", vm_folder,
@@ -1748,7 +1748,7 @@ def create_vm(session, instance, vm_folder, config_spec, res_pool_ref):
                             '\'%(ostype)s\'. An invalid os type may be '
                             'one cause of this instance creation failure',
                             {'ostype': config_spec.guestId})
-    LOG.debug("Created VM on the ESX host", instance=instance)
+    LOG.debug("Created VM on the ESX host")
     return task_info.result
 
 
@@ -1756,11 +1756,11 @@ def create_vm(session, instance, vm_folder, config_spec, res_pool_ref):
 def _destroy_vm(session, instance, vm_ref=None):
     if not vm_ref:
         vm_ref = get_vm_ref(session, instance)
-    LOG.debug("Destroying the VM", instance=instance)
+    LOG.debug("Destroying the VM")
     destroy_task = session._call_method(session.vim, "Destroy_Task",
                                         vm_ref)
     session._wait_for_task(destroy_task)
-    LOG.info("Destroyed the VM", instance=instance)
+    LOG.info("Destroyed the VM")
 
 
 def destroy_vm(session, instance, vm_ref=None):
@@ -1769,13 +1769,13 @@ def destroy_vm(session, instance, vm_ref=None):
         return _destroy_vm(session, instance, vm_ref=vm_ref)
     except vexc.VimFaultException as e:
         with excutils.save_and_reraise_exception() as ctx:
-            LOG.exception(_('Destroy VM failed'), instance=instance)
+            LOG.exception(_('Destroy VM failed'))
             # we need the `InvalidArgument` fault to bubble out of this
             # function so it can be acted upon on higher levels
             if 'InvalidArgument' not in e.fault_list:
                 ctx.reraise = False
     except Exception:
-        LOG.exception(_('Destroy VM failed'), instance=instance)
+        LOG.exception(_('Destroy VM failed'))
 
 
 def mark_vm_as_template(session, instance, vm_ref=None):
@@ -1783,11 +1783,11 @@ def mark_vm_as_template(session, instance, vm_ref=None):
     try:
         if not vm_ref:
             vm_ref = get_vm_ref(session, instance)
-        LOG.debug("Marking the VM as template", instance=instance)
+        LOG.debug("Marking the VM as template")
         session._call_method(session.vim, "MarkAsTemplate", vm_ref)
-        LOG.info("Marked the VM as template", instance=instance)
+        LOG.info("Marked the VM as template")
     except Exception:
-        LOG.exception(_('Mark VM as template failed'), instance=instance)
+        LOG.exception(_('Mark VM as template failed'))
 
 
 def create_virtual_disk(session, dc_ref, adapter_type, disk_type,
@@ -1866,15 +1866,15 @@ def power_on_instance(session, instance, vm_ref=None):
     if vm_ref is None:
         vm_ref = get_vm_ref(session, instance)
 
-    LOG.debug("Powering on the VM", instance=instance)
+    LOG.debug("Powering on the VM")
     try:
         poweron_task = session._call_method(
                                     session.vim,
                                     "PowerOnVM_Task", vm_ref)
         session._wait_for_task(poweron_task)
-        LOG.debug("Powered on the VM", instance=instance)
+        LOG.debug("Powered on the VM")
     except vexc.InvalidPowerStateException:
-        LOG.debug("VM already powered on", instance=instance)
+        LOG.debug("VM already powered on")
 
 
 def _get_vm_port_indices(session, vm_ref):
@@ -1927,14 +1927,14 @@ def power_off_instance(session, instance, vm_ref=None):
     if vm_ref is None:
         vm_ref = get_vm_ref(session, instance)
 
-    LOG.debug("Powering off the VM", instance=instance)
+    LOG.debug("Powering off the VM")
     try:
         poweroff_task = session._call_method(session.vim,
                                          "PowerOffVM_Task", vm_ref)
         session._wait_for_task(poweroff_task)
-        LOG.debug("Powered off the VM", instance=instance)
+        LOG.debug("Powered off the VM")
     except vexc.InvalidPowerStateException:
-        LOG.debug("VM already powered off", instance=instance)
+        LOG.debug("VM already powered off")
 
 
 def find_rescue_device(hardware_devices, instance):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -49,7 +49,6 @@ import nova.conf
 from nova.console import type as ctype
 from nova import context as nova_context
 from nova import exception
-from nova.i18n import _, _LI
 from nova import network
 from nova import objects
 from nova.objects import fields
@@ -178,8 +177,7 @@ class VMwareVMOps(object):
 
     def _extend_virtual_disk(self, instance, requested_size, name, dc_ref):
         service_content = self._session.vim.service_content
-        LOG.debug("Extending root virtual disk to %s", requested_size,
-                  instance=instance)
+        LOG.debug("Extending root virtual disk to %s", requested_size)
         vmdk_extend_task = self._session._call_method(
                 self._session.vim,
                 "ExtendVirtualDisk_Task",
@@ -193,14 +191,14 @@ class VMwareVMOps(object):
         except Exception as e:
             with excutils.save_and_reraise_exception():
                 LOG.error('Extending virtual disk failed with error: %s',
-                          e, instance=instance)
+                          e)
                 # Clean up files created during the extend operation
                 files = [name.replace(".vmdk", "-flat.vmdk"), name]
                 for file in files:
                     ds_path = ds_obj.DatastorePath.parse(file)
                     self._delete_datastore_file(ds_path, dc_ref)
 
-        LOG.debug("Extended root virtual disk", instance=instance)
+        LOG.debug("Extended root virtual disk")
 
     def _delete_datastore_file(self, datastore_path, dc_ref):
         try:
@@ -312,7 +310,7 @@ class VMwareVMOps(object):
                                            utils.is_neutron(),
                                            image_info.vif_model,
                                            network_info)
-        LOG.debug('Instance VIF info %s', vif_infos, instance=instance)
+        LOG.debug('Instance VIF info %s', vif_infos)
 
         if extra_specs.storage_policy:
             profile_spec = vm_util.get_storage_profile_spec(
@@ -441,8 +439,7 @@ class VMwareVMOps(object):
                   "%(datastore_name)s",
                   {'image_id': vi.ii.image_id,
                    'file_path': image_ds_loc,
-                   'datastore_name': vi.datastore.name},
-                  instance=vi.instance)
+                   'datastore_name': vi.datastore.name})
 
         location_url = ds_obj.DatastoreURL.urlparse(location)
         datacenter_path = location_url.datacenter_path
@@ -460,8 +457,7 @@ class VMwareVMOps(object):
                   "%(datastore_name)s",
                   {'image_id': vi.ii.image_id,
                    'file_path': image_ds_loc,
-                   'datastore_name': vi.datastore.name},
-                  instance=vi.instance)
+                   'datastore_name': vi.datastore.name})
 
     def _fetch_image_as_file(self, context, vi, image_ds_loc):
         """Download image as an individual file to host via HTTP PUT."""
@@ -472,8 +468,7 @@ class VMwareVMOps(object):
                   "%(datastore_name)s",
                   {'image_id': vi.ii.image_id,
                    'file_path': image_ds_loc,
-                   'datastore_name': vi.datastore.name},
-                  instance=vi.instance)
+                   'datastore_name': vi.datastore.name})
 
         # try to get esx cookie to upload
         try:
@@ -481,8 +476,7 @@ class VMwareVMOps(object):
             host, cookies = self._get_esx_host_and_cookies(vi.datastore,
                 dc_path, image_ds_loc.rel_path)
         except Exception as e:
-            LOG.warning("Get esx cookies failed: %s", e,
-                        instance=vi.instance)
+            LOG.warning("Get esx cookies failed: %s", e)
             dc_path = vutil.get_inventory_path(session.vim, vi.dc_info.ref)
 
             host = self._session._host
@@ -513,8 +507,7 @@ class VMwareVMOps(object):
                   "%(datastore_name)s as vApp",
                   {'image_id': vi.ii.image_id,
                    'vm_name': vm_name,
-                   'datastore_name': vi.datastore.name},
-                  instance=vi.instance)
+                   'datastore_name': vi.datastore.name})
 
         image_size, src_folder_ds_path = images.fetch_image_stream_optimized(
             context,
@@ -652,18 +645,17 @@ class VMwareVMOps(object):
         """
         try:
             LOG.debug("Unregistering the template VM %s",
-                      templ_vm_ref.value,
-                      instance=instance)
+                      templ_vm_ref.value)
             self._session._call_method(self._session.vim,
                                        "UnregisterVM", templ_vm_ref)
-            LOG.debug("Unregistered the template VM", instance=instance)
+            LOG.debug("Unregistered the template VM")
         except Exception as excep:
             LOG.warning("got this exception while un-registering a ",
                         "template VM: %s",
-                        excep, instance=instance)
+                        excep)
 
     def _cache_vm_image_from_template(self, vi, templ_vm_ref):
-        LOG.debug("Caching VDMK from template VM", instance=vi.instance)
+        LOG.debug("Caching VDMK from template VM")
         vm_name = self._get_image_template_vm_name(vi.ii.image_id,
                                                    vi.datastore.name)
         vmdk = vm_util.get_vmdk_info(self._session, templ_vm_ref, vm_name)
@@ -675,11 +667,11 @@ class VMwareVMOps(object):
             self._cache_vm_image(vi, vmdk.path)
         except vexc.FileNotFoundException:
             LOG.warning("Could not find files for template VM %s",
-                        templ_vm_ref.value, instance=vi.instance)
+                        templ_vm_ref.value)
             self._unregister_template_vm(templ_vm_ref, vi.instance)
             return False
 
-        LOG.debug("Cached VDMK from template VM", instance=vi.instance)
+        LOG.debug("Cached VDMK from template VM")
         return True
 
     def _cache_stream_optimized_image(self, vi, tmp_image_ds_loc):
@@ -789,7 +781,7 @@ class VMwareVMOps(object):
                         self._session._wait_for_task(templ_vm_clone_task)
                 except vexc.FileNotFoundException:
                     LOG.warning("Could not find files for template VM %s",
-                                other_templ_vm_ref.value, instance=vi.instance)
+                                other_templ_vm_ref.value)
                     continue
                 except vexc.VimFaultException as e:
                     if 'VirtualHardwareVersionNotSupported' in e.fault_list:
@@ -805,7 +797,7 @@ class VMwareVMOps(object):
 
     def _fetch_image_if_missing(self, context, vi):
         image_prepare, image_fetch, image_cache = self._get_image_callbacks(vi)
-        LOG.debug("Processing image %s", vi.ii.image_id, instance=vi.instance)
+        LOG.debug("Processing image %s", vi.ii.image_id)
 
         with lockutils.lock(str(vi.cache_image_path),
                             lock_file_prefix='nova-vmware-fetch_image'):
@@ -824,7 +816,7 @@ class VMwareVMOps(object):
             if not image_available:
                 # no matter if image_as_template is set, we can use the
                 # template_vm in any case
-                LOG.debug("Trying to find template VM", instance=vi.instance)
+                LOG.debug("Trying to find template VM")
                 templ_vm_ref = self._find_image_template_vm(vi)
                 image_available = (templ_vm_ref is not None)
                 if image_available and not CONF.vmware.image_as_template:
@@ -834,8 +826,7 @@ class VMwareVMOps(object):
             if (not image_available and
                     CONF.vmware.fetch_image_from_other_datastores):
                 # fetching from another DS is still faster
-                LOG.debug("Trying to find template VM on other DS",
-                          instance=vi.instance)
+                LOG.debug("Trying to find template VM on other DS")
                 templ_vm_ref = self._fetch_image_from_other_datastores(vi)
                 image_available = (templ_vm_ref is not None)
                 if image_available and not CONF.vmware.image_as_template:
@@ -844,15 +835,13 @@ class VMwareVMOps(object):
 
             if not image_available:
                 # we didn't find it anywhere. upload it
-                LOG.debug("Preparing fetch location", instance=vi.instance)
+                LOG.debug("Preparing fetch location")
                 tmp_dir_loc, tmp_image_ds_loc = image_prepare(vi)
-                LOG.debug("Fetch image to %s", tmp_image_ds_loc,
-                          instance=vi.instance)
+                LOG.debug("Fetch image to %s", tmp_image_ds_loc)
                 image_fetch(context, vi, tmp_image_ds_loc)
-                LOG.debug("Caching image", instance=vi.instance)
+                LOG.debug("Caching image")
                 image_cache(vi, tmp_image_ds_loc)
-                LOG.debug("Cleaning up location %s", str(tmp_dir_loc),
-                          instance=vi.instance)
+                LOG.debug("Cleaning up location %s", str(tmp_dir_loc))
                 if tmp_dir_loc:
                     self._delete_datastore_file(str(tmp_dir_loc),
                                                 vi.dc_info.ref)
@@ -988,13 +977,13 @@ class VMwareVMOps(object):
                         reraise=is_last_attempt):
                     LOG.error('Creating VM template for image failed'
                               ' with error: %s',
-                              create_templ_exc, instance=vi.instance)
+                              create_templ_exc)
                     try:
                         vm_util.destroy_vm(self._session, vi.instance)
                     except Exception as destroy_templ_exc:
                         LOG.error('Cleaning up VM template for'
                                   ' image failed with error: %s',
-                                  destroy_templ_exc, instance=vi.instance)
+                                  destroy_templ_exc)
 
     def _build_template_vm_inventory_path(self, vi):
         vm_folder_name = self._session._call_method(vutil,
@@ -1248,7 +1237,7 @@ class VMwareVMOps(object):
             msg = "Block device information present: %s" % block_device_info
             # NOTE(mriedem): block_device_info can contain an auth_password
             # so we have to scrub the message before logging it.
-            LOG.debug(strutils.mask_password(msg), instance=instance)
+            LOG.debug(strutils.mask_password(msg))
 
             # Before attempting to attach any volume, make sure the
             # block_device_mapping (i.e. disk_bus) is valid
@@ -1297,8 +1286,7 @@ class VMwareVMOps(object):
         if utils.is_big_vm(int(instance.memory_mb), instance.flavor) or \
                 utils.is_large_vm(int(instance.memory_mb), instance.flavor):
             behavior = constants.DRS_BEHAVIOR_PARTIALLY_AUTOMATED
-            LOG.debug("Adding DRS override '%s' for big VM.", behavior,
-                      instance=instance)
+            LOG.debug("Adding DRS override '%s' for big VM.", behavior)
             vm_ref = vm_util.get_vm_ref(self._session, instance)
             cluster_util.update_cluster_drs_vm_override(self._session,
                                                         self._cluster,
@@ -1357,7 +1345,7 @@ class VMwareVMOps(object):
                       CONF.config_drive_format)
             raise exception.InstancePowerOnFailure(reason=reason)
 
-        LOG.info('Using config drive for instance', instance=instance)
+        LOG.info('Using config drive for instance')
         extra_md = {}
         if admin_password:
             extra_md['admin_pass'] = admin_password
@@ -1386,7 +1374,7 @@ class VMwareVMOps(object):
         except Exception as e:
             with excutils.save_and_reraise_exception():
                 LOG.error('Creating config drive failed with error: %s',
-                          e, instance=instance)
+                          e)
 
     def _attach_cdrom_to_vm(self, vm_ref, instance,
                             datastore, file_path):
@@ -1405,13 +1393,13 @@ class VMwareVMOps(object):
             cdrom_attach_config_spec.deviceChange.append(controller_spec)
 
         LOG.debug("Reconfiguring VM instance to attach cdrom %s",
-                  file_path, instance=instance)
+                  file_path)
         vm_util.reconfigure_vm(self._session, vm_ref, cdrom_attach_config_spec)
         LOG.debug("Reconfigured VM instance to attach cdrom %s",
-                  file_path, instance=instance)
+                  file_path)
 
     def _create_vm_snapshot(self, instance, vm_ref, image_id=None):
-        LOG.debug("Creating Snapshot of the VM instance", instance=instance)
+        LOG.debug("Creating Snapshot of the VM instance")
         snapshot_task = self._session._call_method(
                     self._session.vim,
                     "CreateSnapshot_Task", vm_ref,
@@ -1420,7 +1408,7 @@ class VMwareVMOps(object):
                     memory=False,
                     quiesce=True)
         self._session._wait_for_task(snapshot_task)
-        LOG.debug("Created Snapshot of the VM instance", instance=instance)
+        LOG.debug("Created Snapshot of the VM instance")
         task_info = self._session._call_method(vutil,
                                                "get_object_property",
                                                snapshot_task,
@@ -1430,13 +1418,13 @@ class VMwareVMOps(object):
 
     @retry_if_task_in_progress
     def _delete_vm_snapshot(self, instance, vm_ref, snapshot):
-        LOG.debug("Deleting Snapshot of the VM instance", instance=instance)
+        LOG.debug("Deleting Snapshot of the VM instance")
         delete_snapshot_task = self._session._call_method(
                     self._session.vim,
                     "RemoveSnapshot_Task", snapshot,
                     removeChildren=False, consolidate=True)
         self._session._wait_for_task(delete_snapshot_task)
-        LOG.debug("Deleted Snapshot of the VM instance", instance=instance)
+        LOG.debug("Deleted Snapshot of the VM instance")
 
     def _create_linked_clone_from_snapshot(self, instance,
                                            vm_ref, snapshot_ref, dc_info):
@@ -1453,7 +1441,7 @@ class VMwareVMOps(object):
         vm_name = "%s_%s" % (constants.SNAPSHOT_VM_PREFIX,
                              uuidutils.generate_uuid())
 
-        LOG.debug("Creating linked-clone VM from snapshot", instance=instance)
+        LOG.debug("Creating linked-clone VM from snapshot")
         vm_clone_task = self._session._call_method(
                                 self._session.vim,
                                 "CloneVM_Task",
@@ -1462,7 +1450,7 @@ class VMwareVMOps(object):
                                 name=vm_name,
                                 spec=clone_spec)
         self._session._wait_for_task(vm_clone_task)
-        LOG.info("Created linked-clone VM from snapshot", instance=instance)
+        LOG.info("Created linked-clone VM from snapshot")
         task_info = self._session._call_method(vutil,
                                                "get_object_property",
                                                vm_clone_task,
@@ -1545,7 +1533,7 @@ class VMwareVMOps(object):
                                            template=True,
                                            config=config_spec)
 
-        LOG.debug("Cloning VM %s", vm_name, instance=instance)
+        LOG.debug("Cloning VM %s", vm_name)
         vm_clone_task = self._session._call_method(
             self._session.vim,
             "CloneVM_Task",
@@ -1556,8 +1544,7 @@ class VMwareVMOps(object):
             name=vm_name,
             spec=clone_spec)
         self._session._wait_for_task(vm_clone_task)
-        LOG.info(_LI("Cloned VM %s"), vm_name,
-                 instance=instance)
+        LOG.info("Cloned VM %s", vm_name)
         task_info = self._session._call_method(vutil,
                                                "get_object_property",
                                                vm_clone_task,
@@ -1587,8 +1574,7 @@ class VMwareVMOps(object):
             vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
                                               instance.uuid)
             if not vmdk.path:
-                LOG.debug("No root disk defined. Unable to snapshot.",
-                          instance=instance)
+                LOG.debug("No root disk defined. Unable to snapshot.")
                 raise error_util.NoRootDiskDefined()
 
             lst_properties = ["datastore", "summary.config.guestId"]
@@ -1672,16 +1658,16 @@ class VMwareVMOps(object):
         if (tools_status == "toolsOk" and
                 tools_running_status == "guestToolsRunning" and
                 reboot_type == "SOFT"):
-            LOG.debug("Rebooting guest OS of VM", instance=instance)
+            LOG.debug("Rebooting guest OS of VM")
             self._session._call_method(self._session.vim, "RebootGuest",
                                        vm_ref)
-            LOG.debug("Rebooted guest OS of VM", instance=instance)
+            LOG.debug("Rebooted guest OS of VM")
         else:
-            LOG.debug("Doing hard reboot of VM", instance=instance)
+            LOG.debug("Doing hard reboot of VM")
             reset_task = self._session._call_method(self._session.vim,
                                                     "ResetVM_Task", vm_ref)
             self._session._wait_for_task(reset_task)
-            LOG.debug("Did hard reboot of VM", instance=instance)
+            LOG.debug("Did hard reboot of VM")
 
     def _destroy_instance(self, context, instance, destroy_disks=True):
         # Destroy a VM instance
@@ -1707,14 +1693,14 @@ class VMwareVMOps(object):
 
             # Un-register the VM
             try:
-                LOG.debug("Unregistering the VM", instance=instance)
+                LOG.debug("Unregistering the VM")
                 self._session._call_method(self._session.vim,
                                            "UnregisterVM", vm_ref)
-                LOG.debug("Unregistered the VM", instance=instance)
+                LOG.debug("Unregistered the VM")
             except Exception as excep:
                 LOG.warning("In vmwareapi:vmops:_destroy_instance, got "
                             "this exception while un-registering the VM: %s",
-                            excep, instance=instance)
+                            excep)
 
             # Delete the folder holding the VM related content on
             # the datastore.
@@ -1723,8 +1709,7 @@ class VMwareVMOps(object):
                     dir_ds_compliant_path = vm_ds_path.parent
                     LOG.debug("Deleting contents of the VM from "
                               "datastore %(datastore_name)s",
-                              {'datastore_name': vm_ds_path.datastore},
-                              instance=instance)
+                              {'datastore_name': vm_ds_path.datastore})
                     ds_ref_ret = props['datastore']
                     ds_ref = ds_ref_ret.ManagedObjectReference[0]
                     dc_info = self.get_datacenter_ref_and_name(ds_ref)
@@ -1733,18 +1718,16 @@ class VMwareVMOps(object):
                                         dc_info.ref)
                     LOG.debug("Deleted contents of the VM from "
                               "datastore %(datastore_name)s",
-                              {'datastore_name': vm_ds_path.datastore},
-                              instance=instance)
+                              {'datastore_name': vm_ds_path.datastore})
                 except Exception:
                     LOG.warning("In vmwareapi:vmops:_destroy_instance, "
                                 "exception while deleting the VM contents "
                                 "from the disk",
-                                exc_info=True, instance=instance)
+                                exc_info=True)
         except exception.InstanceNotFound:
-            LOG.warning('Instance does not exist on backend',
-                        instance=instance)
+            LOG.warning('Instance does not exist on backend')
         except Exception:
-            LOG.exception(_('Destroy instance failed'), instance=instance)
+            LOG.exception(_('Destroy instance failed'))
         finally:
             vm_util.vm_ref_cache_delete(instance.uuid)
 
@@ -1756,9 +1739,9 @@ class VMwareVMOps(object):
         2. Un-register.
         3. Delete the contents of the folder holding the VM related data.
         """
-        LOG.debug("Destroying instance", instance=instance)
+        LOG.debug("Destroying instance")
         self._destroy_instance(context, instance, destroy_disks=destroy_disks)
-        LOG.debug("Instance destroyed", instance=instance)
+        LOG.debug("Instance destroyed")
 
     def pause(self, instance):
         msg = _("pause not supported for vmwareapi")
@@ -1777,18 +1760,18 @@ class VMwareVMOps(object):
                                                "runtime.powerState")
         # Only PoweredOn VMs can be suspended.
         if pwr_state == "poweredOn":
-            LOG.debug("Suspending the VM", instance=instance)
+            LOG.debug("Suspending the VM")
             suspend_task = self._session._call_method(self._session.vim,
                     "SuspendVM_Task", vm_ref)
             self._session._wait_for_task(suspend_task)
-            LOG.debug("Suspended the VM", instance=instance)
+            LOG.debug("Suspended the VM")
         # Raise Exception if VM is poweredOff
         elif pwr_state == "poweredOff":
             reason = _("instance is powered off and cannot be suspended.")
             raise exception.InstanceSuspendFailure(reason=reason)
         else:
             LOG.debug("VM was already in suspended state. So returning "
-                      "without doing anything", instance=instance)
+                      "without doing anything")
 
     def resume(self, instance):
         """Resume the specified instance."""
@@ -1798,12 +1781,12 @@ class VMwareVMOps(object):
                                                vm_ref,
                                                "runtime.powerState")
         if pwr_state.lower() == "suspended":
-            LOG.debug("Resuming the VM", instance=instance)
+            LOG.debug("Resuming the VM")
             suspend_task = self._session._call_method(
                                         self._session.vim,
                                        "PowerOnVM_Task", vm_ref)
             self._session._wait_for_task(suspend_task)
-            LOG.debug("Resumed the VM", instance=instance)
+            LOG.debug("Resumed the VM")
         else:
             reason = _("instance is not in a suspended state")
             raise exception.InstanceResumeFailure(reason=reason)
@@ -1871,8 +1854,7 @@ class VMwareVMOps(object):
             rescue_device = self._get_rescue_device(instance, vm_ref)
         except exception.NotFound:
             with excutils.save_and_reraise_exception():
-                LOG.error('Unable to access the rescue disk',
-                          instance=instance)
+                LOG.error('Unable to access the rescue disk')
         vm_util.power_off_instance(self._session, instance, vm_ref)
         self._volumeops.detach_disk_from_vm(vm_ref, instance, rescue_device,
                                             destroy_disk=True)
@@ -1906,15 +1888,13 @@ class VMwareVMOps(object):
            :return: True if the instance was shutdown within time limit,
                     False otherwise.
         """
-        LOG.debug("Performing Soft shutdown on instance",
-                 instance=instance)
+        LOG.debug("Performing Soft shutdown on instance")
         vm_ref = vm_util.get_vm_ref(self._session, instance)
 
         props = self._get_instance_props(vm_ref)
 
         if props.get("runtime.powerState") != "poweredOn":
-            LOG.debug("Instance not in poweredOn state.",
-                      instance=instance)
+            LOG.debug("Instance not in poweredOn state.")
             return False
 
         if ((props.get("summary.guest.toolsStatus") == "toolsOk") and
@@ -1922,7 +1902,7 @@ class VMwareVMOps(object):
              "guestToolsRunning")):
 
             LOG.debug("Soft shutdown instance, timeout: %d",
-                     timeout, instance=instance)
+                     timeout)
             self._session._call_method(self._session.vim,
                                        "ShutdownGuest",
                                        vm_ref)
@@ -1932,17 +1912,15 @@ class VMwareVMOps(object):
                 props = self._get_instance_props(vm_ref)
 
                 if props.get("runtime.powerState") == "poweredOff":
-                    LOG.info("Soft shutdown succeeded.",
-                             instance=instance)
+                    LOG.info("Soft shutdown succeeded.")
                     return True
 
                 time.sleep(wait_time)
                 timeout -= retry_interval
 
-            LOG.warning("Timed out while waiting for soft shutdown.",
-                        instance=instance)
+            LOG.warning("Timed out while waiting for soft shutdown.")
         else:
-            LOG.debug("VMware Tools not running", instance=instance)
+            LOG.debug("VMware Tools not running")
 
         return False
 
@@ -1956,7 +1934,7 @@ class VMwareVMOps(object):
                 vutil.get_moref_value(self._root_resource_pool)
         except (exception.InstanceNotFound,
                 vexc.ManagedObjectNotFoundException):
-            LOG.debug("Failed to find instance", instance=instance)
+            LOG.debug("Failed to find instance")
             return False
 
     def _get_instance_props(self, vm_ref):
@@ -1994,8 +1972,7 @@ class VMwareVMOps(object):
         instance_uuid = instance.uuid
         LOG.debug("Updating instance '%(instance_uuid)s' progress to"
                   " %(progress)d",
-                  {'instance_uuid': instance_uuid, 'progress': progress},
-                  instance=instance)
+                  {'instance_uuid': instance_uuid, 'progress': progress})
         instance.progress = progress
         instance.save()
 
@@ -2023,8 +2000,7 @@ class VMwareVMOps(object):
         if not old_needs_override and new_needs_override:
             # Make sure we don't automatically move around "big" VMs
             behavior = constants.DRS_BEHAVIOR_PARTIALLY_AUTOMATED
-            LOG.debug("Adding DRS override '%s' for big VM.", behavior,
-                      instance=instance)
+            LOG.debug("Adding DRS override '%s' for big VM.", behavior)
             cluster_util.update_cluster_drs_vm_override(self._session,
                                                         self._cluster,
                                                         vm_ref,
@@ -2033,16 +2009,14 @@ class VMwareVMOps(object):
         elif old_needs_override and not new_needs_override:
             # remove the old override, if we had one before. make sure we don't
             # error out if it was already deleted another way
-            LOG.debug("Removing DRS override for former big VM.",
-                      instance=instance)
+            LOG.debug("Removing DRS override for former big VM.")
             try:
                 cluster_util.update_cluster_drs_vm_override(self._session,
                                                             self._cluster,
                                                             vm_ref,
                                                             operation='remove')
             except Exception:
-                LOG.exception('Could not remove DRS override.',
-                              instance=instance)
+                LOG.exception('Could not remove DRS override.')
 
         self._clean_up_after_special_spawning(context, flavor.memory_mb,
                                               flavor)
@@ -2086,7 +2060,7 @@ class VMwareVMOps(object):
         vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
                                      uuid=instance.uuid)
         if not vmdk.device:
-            LOG.debug("No root disk attached!", instance=instance)
+            LOG.debug("No root disk attached!")
             return
         ds_ref = vmdk.device.backing.datastore
         datastore = ds_obj.get_datastore_by_ref(self._session, ds_ref)
@@ -2203,16 +2177,13 @@ class VMwareVMOps(object):
             adapter_type = vmdk.adapter_type
 
             self._detach_volumes(instance, block_device_info)
-            LOG.debug("Relocating VM for reverting migration",
-                      instance=instance)
+            LOG.debug("Relocating VM for reverting migration")
             try:
                 self._relocate_vm(vm_ref, context, instance, network_info)
-                LOG.debug("Relocated VM for reverting migration",
-                          instance=instance)
+                LOG.debug("Relocated VM for reverting migration")
             except Exception as e:
                 with excutils.save_and_reraise_exception():
-                    LOG.error("Relocating the VM failed: %s", e,
-                              instance=instance)
+                    LOG.error("Relocating the VM failed: %s", e)
             else:
                 self.update_cluster_placement(context, instance)
             finally:
@@ -2243,16 +2214,14 @@ class VMwareVMOps(object):
             self._detach_volumes(instance, block_device_info)
             reattach_volumes = True
             LOG.debug("Relocating VM for migration to %s",
-                      migration.dest_compute, instance=instance)
+                      migration.dest_compute)
             try:
                 self._relocate_vm(vm_ref, context, instance, network_info,
                                   image_meta)
-                LOG.debug("Relocated VM to %s", migration.dest_compute,
-                          instance=instance)
+                LOG.debug("Relocated VM to %s", migration.dest_compute)
             except Exception as e:
                 with excutils.save_and_reraise_exception():
-                    LOG.error("Relocating the VM failed with error: %s", e,
-                              instance=instance)
+                    LOG.error("Relocating the VM failed with error: %s", e)
                     self._attach_volumes(instance, block_device_info,
                                          adapter_type)
 
@@ -2457,7 +2426,7 @@ class VMwareVMOps(object):
                      "older than %(timeout)d seconds", instances_info)
 
         for instance in instances:
-            LOG.info("Automatically hard rebooting", instance=instance)
+            LOG.info("Automatically hard rebooting")
             self.compute_api.reboot(ctxt, instance, "HARD")
 
     def get_info(self, instance):
@@ -2586,11 +2555,9 @@ class VMwareVMOps(object):
                                  client_factory,
                                  self._get_machine_id_str(network_info))
 
-        LOG.debug("Reconfiguring VM instance to set the machine id",
-                  instance=instance)
+        LOG.debug("Reconfiguring VM instance to set the machine id")
         vm_util.reconfigure_vm(self._session, vm_ref, machine_id_change_spec)
-        LOG.debug("Reconfigured VM instance to set the machine id",
-                  instance=instance)
+        LOG.debug("Reconfigured VM instance to set the machine id")
 
     @utils.synchronized('vmware.get_and_set_vnc_port')
     def _get_and_set_vnc_config(self, client_factory, instance, vm_ref):
@@ -2600,12 +2567,10 @@ class VMwareVMOps(object):
                                       client_factory, port)
 
         LOG.debug("Reconfiguring VM instance to enable vnc on "
-                  "port - %(port)s", {'port': port},
-                  instance=instance)
+                  "port - %(port)s", {'port': port})
         vm_util.reconfigure_vm(self._session, vm_ref, vnc_config_spec)
         LOG.debug("Reconfigured VM instance to enable vnc on "
-                  "port - %(port)s", {'port': port},
-                  instance=instance)
+                  "port - %(port)s", {'port': port})
 
     def _get_ds_browser(self, ds_ref):
         ds_browser = self._datastore_browser_mapping.get(ds_ref.value)
@@ -2865,21 +2830,20 @@ class VMwareVMOps(object):
             attach_config_spec = vm_util.get_network_attach_config_spec(
                                         client_factory, vif_info, port_index,
                                         extra_specs.vif_limits)
-            LOG.debug("Reconfiguring VM to attach interface",
-                      instance=instance)
+            LOG.debug("Reconfiguring VM to attach interface")
             try:
                 vm_util.reconfigure_vm(self._session, vm_ref,
                                        attach_config_spec)
             except Exception as e:
                 LOG.error('Attaching network adapter failed. Exception: %s',
-                          e, instance=instance)
+                          e)
                 raise exception.InterfaceAttachFailed(
                         instance_uuid=instance.uuid)
 
             self._network_api.update_instance_vnic_index(
                 context, instance, vif, port_index)
 
-        LOG.debug("Reconfigured VM to attach interface", instance=instance)
+        LOG.debug("Reconfigured VM to attach interface")
 
     def detach_interface(self, context, instance, vif):
         """Detach an interface from the instance."""
@@ -2910,17 +2874,16 @@ class VMwareVMOps(object):
             client_factory = self._session.vim.client.factory
             detach_config_spec = vm_util.get_network_detach_config_spec(
                                         client_factory, device, port_index)
-            LOG.debug("Reconfiguring VM to detach interface",
-                      instance=instance)
+            LOG.debug("Reconfiguring VM to detach interface")
             try:
                 vm_util.reconfigure_vm(self._session, vm_ref,
                                        detach_config_spec)
             except Exception as e:
                 LOG.error('Detaching network adapter failed. Exception: %s',
-                          e, instance=instance)
+                          e)
                 raise exception.InterfaceDetachFailed(
                         instance_uuid=instance.uuid)
-        LOG.debug("Reconfigured VM to detach interface", instance=instance)
+        LOG.debug("Reconfigured VM to detach interface")
 
     def _use_disk_image_as_full_clone(self, vm_ref, vi):
         """Uses cached image disk by copying it into the VM directory."""
@@ -3105,8 +3068,7 @@ class VMwareVMOps(object):
 
         # NOTE: VM can move hosts in some situations. Debug for admins.
         LOG.debug("VM %(uuid)s is currently on host %(host_name)s",
-                  {'uuid': instance.uuid, 'host_name': host_name},
-                  instance=instance)
+                  {'uuid': instance.uuid, 'host_name': host_name})
         return ctype.ConsoleVNC(**vnc_console)
 
     def get_mks_console(self, instance):

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -67,7 +67,7 @@ class VMwareVolumeOps(object):
 
         if volume_uuid and backing_uuid:
             LOG.debug("Adding volume details for %s to attach config spec.",
-                      volume_uuid, instance=instance)
+                      volume_uuid)
             self._add_volume_details_to_config_spec(vmdk_attach_config_spec,
                                                     volume_uuid, backing_uuid)
 
@@ -75,15 +75,13 @@ class VMwareVolumeOps(object):
                   "disk %(vmdk_path)s or device %(device_name)s with type "
                   "%(disk_type)s",
                   {'vm_ref': vm_ref.value, 'vmdk_path': vmdk_path,
-                   'device_name': device_name, 'disk_type': disk_type},
-                  instance=instance)
+                   'device_name': device_name, 'disk_type': disk_type})
         vm_util.reconfigure_vm(self._session, vm_ref, vmdk_attach_config_spec)
         LOG.debug("Reconfigured VM instance %(vm_ref)s to attach "
                   "disk %(vmdk_path)s or device %(device_name)s with type "
                   "%(disk_type)s",
                   {'vm_ref': vm_ref.value, 'vmdk_path': vmdk_path,
-                   'device_name': device_name, 'disk_type': disk_type},
-                  instance=instance)
+                   'device_name': device_name, 'disk_type': disk_type})
 
     def _add_volume_details_to_config_spec(self, config_spec, volume_uuid,
                                            device_uuid):
@@ -118,20 +116,18 @@ class VMwareVolumeOps(object):
 
         if volume_uuid is not None:
             LOG.debug("Adding volume details for %s to detach config spec.",
-                      volume_uuid, instance=instance)
+                      volume_uuid)
             self._add_volume_details_to_config_spec(vmdk_detach_config_spec,
                                                     volume_uuid, '')
 
         disk_key = device.key
         LOG.debug("Reconfiguring VM instance %(vm_ref)s to detach "
                   "disk %(disk_key)s",
-                  {'vm_ref': vm_ref.value, 'disk_key': disk_key},
-                  instance=instance)
+                  {'vm_ref': vm_ref.value, 'disk_key': disk_key})
         vm_util.reconfigure_vm(self._session, vm_ref, vmdk_detach_config_spec)
         LOG.debug("Reconfigured VM instance %(vm_ref)s to detach "
                   "disk %(disk_key)s",
-                  {'vm_ref': vm_ref.value, 'disk_key': disk_key},
-                  instance=instance)
+                  {'vm_ref': vm_ref.value, 'disk_key': disk_key})
 
     def _iscsi_get_target(self, data):
         """Return the iSCSI Target given a volume info."""
@@ -344,8 +340,7 @@ class VMwareVolumeOps(object):
                             adapter_type=None):
         """Attach vmdk volume storage to VM instance."""
         vm_ref = vm_util.get_vm_ref(self._session, instance)
-        LOG.debug("_attach_volume_vmdk: %s", connection_info,
-                  instance=instance)
+        LOG.debug("_attach_volume_vmdk: %s", connection_info)
         data = connection_info['data']
         volume_ref = self._get_volume_ref(data['volume'])
 
@@ -369,15 +364,14 @@ class VMwareVolumeOps(object):
                                volume_uuid=data['volume_id'],
                                backing_uuid=vmdk.device.backing.uuid)
 
-        LOG.debug("Attached VMDK: %s", connection_info, instance=instance)
+        LOG.debug("Attached VMDK: %s", connection_info)
 
     def _attach_volume_iscsi(self, connection_info, instance,
                              adapter_type=None):
         """Attach iscsi volume storage to VM instance."""
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         # Attach Volume to VM
-        LOG.debug("_attach_volume_iscsi: %s", connection_info,
-                  instance=instance)
+        LOG.debug("_attach_volume_iscsi: %s", connection_info)
 
         data = connection_info['data']
 
@@ -395,13 +389,12 @@ class VMwareVolumeOps(object):
         self.attach_disk_to_vm(vm_ref, instance,
                                adapter_type, 'rdmp',
                                device_name=device_name)
-        LOG.debug("Attached ISCSI: %s", connection_info, instance=instance)
+        LOG.debug("Attached ISCSI: %s", connection_info)
 
     def attach_volume(self, connection_info, instance, adapter_type=None):
         """Attach volume storage to VM instance."""
         driver_type = connection_info['driver_volume_type']
-        LOG.debug("Volume attach. Driver type: %s", driver_type,
-                  instance=instance)
+        LOG.debug("Volume attach. Driver type: %s", driver_type)
         if driver_type == constants.DISK_FORMAT_VMDK:
             self._attach_volume_vmdk(connection_info, instance, adapter_type)
         elif driver_type == constants.DISK_FORMAT_ISCSI:
@@ -531,8 +524,7 @@ class VMwareVolumeOps(object):
         """Detach volume storage to VM instance."""
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         # Detach Volume from VM
-        LOG.debug("_detach_volume_vmdk: %s", connection_info,
-                  instance=instance)
+        LOG.debug("_detach_volume_vmdk: %s", connection_info)
         data = connection_info['data']
         volume_ref = self._get_volume_ref(data['volume'])
 
@@ -562,14 +554,13 @@ class VMwareVolumeOps(object):
         self.detach_disk_from_vm(vm_ref, instance, device,
                                  volume_uuid=data['volume_id'])
 
-        LOG.debug("Detached VMDK: %s", connection_info, instance=instance)
+        LOG.debug("Detached VMDK: %s", connection_info)
 
     def _detach_volume_iscsi(self, connection_info, instance):
         """Detach volume storage to VM instance."""
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         # Detach Volume from VM
-        LOG.debug("_detach_volume_iscsi: %s", connection_info,
-                  instance=instance)
+        LOG.debug("_detach_volume_iscsi: %s", connection_info)
         data = connection_info['data']
 
         # Discover iSCSI Target
@@ -584,13 +575,12 @@ class VMwareVolumeOps(object):
         if device is None:
             raise exception.DiskNotFound(message=_("Unable to find volume"))
         self.detach_disk_from_vm(vm_ref, instance, device, destroy_disk=True)
-        LOG.debug("Detached ISCSI: %s", connection_info, instance=instance)
+        LOG.debug("Detached ISCSI: %s", connection_info)
 
     def detach_volume(self, connection_info, instance):
         """Detach volume storage to VM instance."""
         driver_type = connection_info['driver_volume_type']
-        LOG.debug("Volume detach. Driver type: %s", driver_type,
-                  instance=instance)
+        LOG.debug("Volume detach. Driver type: %s", driver_type)
         if driver_type == constants.DISK_FORMAT_VMDK:
             self._detach_volume_vmdk(connection_info, instance)
         elif driver_type == constants.DISK_FORMAT_ISCSI:
@@ -602,8 +592,7 @@ class VMwareVolumeOps(object):
                            datastore, adapter_type=None):
         """Attach a root volume to the VM instance."""
         driver_type = connection_info['driver_volume_type']
-        LOG.debug("Root volume attach. Driver type: %s", driver_type,
-                  instance=instance)
+        LOG.debug("Root volume attach. Driver type: %s", driver_type)
         # NOTE(jkulik): Upstream moves the volume to the instance DS here. This
         # would violate the differentiation between ephemeral and volume DS, so
         # we don't do that. This comment should help us detect upstream changes
@@ -662,7 +651,6 @@ class VMwareVolumeOps(object):
                     LOG.warning("Shadow-vm %s already has a disk"
                         " attached at %s replacing it with %s",
                         volume, original_device_path, current_device_path,
-                        instance=instance
                         )
                     self.detach_disk_from_vm(self, volume_ref, instance,
                         original_device, destroy_disk=True)
@@ -676,8 +664,7 @@ class VMwareVolumeOps(object):
                     )
             except Exception:
                 LOG.exception("Failed to attach volume {}. Device {}".format(
-                    data["volume_id"],
-                    device.key), instance=instance)
+                    data["volume_id"], device.key))
 
     def delete_shadow_vms(self, block_device_info, instance=None):
         # We need to delete the migrated shadow vms
@@ -702,12 +689,12 @@ class VMwareVolumeOps(object):
                 deleted.append("{volume_id} ({volume})".format(**data))
             except oslo_vmw_exceptions.ManagedObjectNotFoundException:
                 LOG.debug("Volume %s already deleted",
-                        data.get("volume_id"), instance=instance)
+                        data.get("volume_id"))
             except Exception:
                 LOG.exception("Failed to delete volume %s",
-                        data.get("volume_id"), instance=instance)
+                        data.get("volume_id"))
 
-        LOG.info("Deleted %s", deleted, instance=instance)
+        LOG.info("Deleted %s", deleted)
 
     def map_volumes_to_devices(self, instance, disk_infos):
         """Maps a connection_info.data to a device of the instance by its key


### PR DESCRIPTION
These changes store the instance.uuid in the project independent field `resource_uuid` reserved for that purpose.
The second patch removes the now superfluous instance parameter from all logging calls.
