### PR TITLE
Stable Volume References

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1925,8 +1925,7 @@ class VMwareAPIVMTestCase(test.TestCase,
 
             get_vm_ref.assert_called_once_with(self.conn._session,
                                                self.instance)
-            get_volume_ref.assert_called_once_with(
-                connection_info['data']['volume'])
+            get_volume_ref.assert_called_once_with(connection_info['data'])
             self.assertTrue(get_vmdk_info.called)
             attach_disk_to_vm.assert_called_once_with(mock.sentinel.vm_ref,
                 self.instance, adapter_type, disk_type, vmdk_path='fake-path',

--- a/nova/tests/unit/virt/vmwareapi/test_volumeops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_volumeops.py
@@ -143,8 +143,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
 
             get_vm_ref.assert_called_once_with(self._volumeops._session,
                                                instance)
-            get_volume_ref.assert_called_once_with(
-                connection_info['data']['volume'])
+            get_volume_ref.assert_called_once_with(connection_info['data'])
             self.assertTrue(get_vmdk_info.called)
             get_vm_state.assert_called_once_with(self._volumeops._session,
                                                  instance)
@@ -264,8 +263,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
 
             get_vm_ref.assert_called_once_with(self._volumeops._session,
                                                instance)
-            get_volume_ref.assert_called_once_with(
-                connection_info['data']['volume'])
+            get_volume_ref.assert_called_once_with(connection_info['data'])
             get_vmdk_backed_disk_device.assert_called_once_with(
                 mock.sentinel.vm_ref, connection_info['data'])
             adapter_type = vm_util.CONTROLLER_TO_ADAPTER_TYPE.get(
@@ -312,8 +310,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
 
             get_vm_ref.assert_called_once_with(self._volumeops._session,
                                                instance)
-            get_volume_ref.assert_called_once_with(
-                connection_info['data']['volume'])
+            get_volume_ref.assert_called_once_with(connection_info['data'])
             get_vmdk_backed_disk_device.assert_called_once_with(
                 mock.sentinel.vm_ref, connection_info['data'])
             get_vm_state.assert_called_once_with(self._volumeops._session,
@@ -440,8 +437,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
 
             get_vm_ref.assert_called_once_with(self._volumeops._session,
                                                self._instance)
-            get_volume_ref.assert_called_once_with(
-                connection_info['data']['volume'])
+            get_volume_ref.assert_called_once_with(connection_info['data'])
             self.assertTrue(get_vmdk_info.called)
             attach_disk_to_vm.assert_called_once_with(
                 vm_ref, self._instance, adapter_type,


### PR DESCRIPTION
Based on top of #288.

We wrap the "volume_ref" in a proxy-object, which will search of a shadow-vm with the stored id in case of a ManagedObjectNotFoundException. That way, we can detach volumes also when a shadow-vm has been un- and re-registered.
