### PR TITLE
VMware: Refactor tests wrt moref equality

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vim_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vim_util.py
@@ -28,12 +28,12 @@ class VMwareVIMUtilTestCase(test.NoDBTestCase):
     def test_get_inner_objects(self):
         property = ['summary.name']
         # Get the fake datastores directly from the cluster
-        cluster_refs = fake._get_object_refs('ClusterComputeResource')
-        cluster = fake._get_object(cluster_refs[0])
+        cluster = fake.get_first_object('ClusterComputeResource')
+        cluster_ref = cluster.obj
         expected_ds = cluster.datastore.ManagedObjectReference
         # Get the fake datastores using inner objects utility method
         result = vim_util.get_inner_objects(
-            self.vim, cluster_refs[0], 'datastore', 'Datastore', property)
+            self.vim, cluster_ref, 'datastore', 'Datastore', property)
         datastores = [oc.obj for oc in result.objects]
         self.assertEqual(expected_ds, datastores)
 

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -2109,7 +2109,7 @@ class VMwareVMUtilGetHostRefTestCase(test.NoDBTestCase):
         self.session = driver.VMwareAPISession()
 
         # Create a fake VirtualMachine running on a known host
-        self.host_ref = list(fake._db_content['HostSystem'].keys())[0]
+        self.host_ref = fake.get_first_object_ref("HostSystem")
         self.vm_ref = fake.create_vm(host_ref=self.host_ref)
 
     @mock.patch.object(vm_util, 'get_vm_ref')
@@ -2125,7 +2125,7 @@ class VMwareVMUtilGetHostRefTestCase(test.NoDBTestCase):
     def test_get_host_name_for_vm(self, mock_get_vm_ref):
         mock_get_vm_ref.return_value = self.vm_ref
 
-        host = fake._get_object(self.host_ref)
+        host = fake.get_object(self.host_ref)
 
         ret = vm_util.get_host_name_for_vm(self.session, 'fake-instance')
 

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -79,7 +79,8 @@ class VMwareVMOpsTestCase(test.TestCase):
 
         self._virtapi = mock.Mock()
         self._image_id = nova.tests.unit.image.fake.get_valid_image_id()
-        fake_ds_ref = vmwareapi_fake.ManagedObjectReference(value='fake-ds')
+        fake_ds_ref = vmwareapi_fake.ManagedObjectReference(name='fake-ds',
+                                                            value='Datastore')
         self._ds = ds_obj.Datastore(
                 ref=fake_ds_ref, name='fake_ds',
                 capacity=10 * units.Gi,
@@ -87,9 +88,9 @@ class VMwareVMOpsTestCase(test.TestCase):
 
         self._dc_info = ds_util.DcInfo(
                 ref='fake_dc_ref', name='fake_dc',
-                vmFolder=vmwareapi_fake.ManagedObjectReference
-                                                        (name='fake_vm_folder',
-                                                        value='Folder'))
+                vmFolder=vmwareapi_fake.ManagedObjectReference(
+                    name='fake_vm_folder',
+                    value='Folder'))
         cluster = vmwareapi_fake.create_cluster('fake_cluster', fake_ds_ref)
         self._uuid = uuidsentinel.foo
         self._instance_values = {
@@ -109,7 +110,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                       root_gb=10, ephemeral_gb=0, swap=0,
                                       extra_specs={})
         self._instance.flavor = self._flavor
-        self._volumeops = volumeops.VMwareVolumeOps(self._session)
+        self._volumeops = volumeops.VMwareVolumeOps(self._session, cluster.obj)
         self._vmops = vmops.VMwareVMOps(self._session, self._virtapi,
                                         self._volumeops,
                                         cluster=cluster.obj)
@@ -330,7 +331,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                return_value=result):
             info = self._vmops.get_info(self._instance)
             mock_get_vm_ref.assert_called_once_with(self._session,
-                self._instance)
+                                                    self._instance)
             expected = hardware.InstanceInfo(state=power_state.RUNNING)
             self.assertEqual(expected, info)
 
@@ -345,17 +346,18 @@ class VMwareVMOpsTestCase(test.TestCase):
                                return_value=result):
             info = self._vmops.get_info(self._instance)
             mock_get_vm_ref.assert_called_once_with(self._session,
-                self._instance)
+                                                    self._instance)
             self.assertEqual(hardware.InstanceInfo(state=power_state.SHUTDOWN),
                              info)
 
-    @mock.patch.object(vm_util, 'get_vm_ref')
+    @mock.patch.object(vm_util, 'search_vm_ref_by_identifier')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cached_instances')
     @mock.patch.object(vm_util, '_VM_VALUE_CACHE')
     def test_get_info_instance_deleted(self, mock_value_cache,
                                        mock_update_cached_instances,
-                                       mock_get_vm_ref):
+                                       mock_search_vm_ref):
         vm_util.vm_value_cache_reset()
+        vm_ref_value = mock.sentinel.missing_ref
         props = ['summary.config.numCpu', 'summary.config.memorySizeMB',
                  'runtime.powerState']
         prop_cpu = vmwareapi_fake.Prop(props[0], 4)
@@ -365,19 +367,24 @@ class VMwareVMOpsTestCase(test.TestCase):
         obj_content = vmwareapi_fake.ObjectContent(None, prop_list=prop_list)
         result = vmwareapi_fake.FakeRetrieveResult()
         result.add_object(obj_content)
-        mock_get_vm_ref.return_value = vmwareapi_fake.ManagedObjectReference(
-            value='fake_powered_off')
+        mock_search_vm_ref.side_effect = [
+            vmwareapi_fake.ManagedObjectReference(value=vm_ref_value),
+            None
+        ]
 
         def mock_call_method(module, method, *args, **kwargs):
-            raise vexc.ManagedObjectNotFoundException()
+            raise vexc.ManagedObjectNotFoundException(
+                details={'obj': vm_ref_value}
+            )
 
-        with mock.patch.object(self._session, '_call_method',
+        with mock.patch.object(vutil, 'get_object_properties_dict',
                                mock_call_method):
             self.assertRaises(exception.InstanceNotFound,
                               self._vmops.get_info,
                               self._instance)
-            mock_get_vm_ref.assert_called_once_with(self._session,
-                self._instance)
+            mock_search_vm_ref.assert_has_calls(2 * [
+                mock.call(self._session,
+                          self._instance.uuid)])
 
     def _test_get_datacenter_ref_and_name(self, ds_ref_exists=False):
         instance_ds_ref = mock.Mock()
@@ -515,6 +522,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                         self._instance, vm_ref=vm_ref)
             else:
                 self.assertFalse(_power_on_instance.called)
+
             _get_vm_ref.assert_called_once_with(self._session,
                                                 self._instance)
             _power_off.assert_called_once_with(self._session, self._instance,
@@ -872,7 +880,8 @@ class VMwareVMOpsTestCase(test.TestCase):
             except test.TestingException:
                 pass
 
-            vm_ref_calls = [mock.call(self._session, self._instance)]
+            vm_ref_calls = [mock.call(self._session,
+                                      self._instance)]
             fake_power_off.assert_called_once_with(self._session,
                                                    self._instance,
                                                    'fake-ref')
@@ -2497,7 +2506,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                    self._metadata,
                                                    None)
 
-        vm = vmwareapi_fake._get_object(vm_ref)
+        vm = vmwareapi_fake.get_object(vm_ref)
 
         # Test basic VM parameters
         self.assertEqual(self._instance.uuid, vm.name)
@@ -2520,7 +2529,7 @@ class VMwareVMOpsTestCase(test.TestCase):
         datastores = vm.datastore.ManagedObjectReference
         self.assertEqual(1, len(datastores))
 
-        datastore = vmwareapi_fake._get_object(datastores[0])
+        datastore = vmwareapi_fake.get_object(datastores[0])
         self.assertEqual(self._ds.name, datastore.get('summary.name'))
 
         # Test that the VM's network is configured as specified
@@ -3242,7 +3251,8 @@ class VMwareVMOpsTestCase(test.TestCase):
         mock_extra_specs.return_value = extra_specs
         self._vmops.attach_interface(self._context, self._instance,
                                      self._image_meta, self._network_values)
-        mock_get_vm_ref.assert_called_once_with(self._session, self._instance)
+        mock_get_vm_ref.assert_called_once_with(self._session,
+                                                self._instance)
         mock_get_attach_port_index.assert_called_once_with(self._session,
                                                            'fake-ref')
         mock_get_network_attach_config_spec.assert_called_once_with(
@@ -3272,7 +3282,8 @@ class VMwareVMOpsTestCase(test.TestCase):
                                return_value='hardware-devices'):
             self._vmops.detach_interface(self._context, self._instance,
                                          self._network_values)
-        mock_get_vm_ref.assert_called_once_with(self._session, self._instance)
+        mock_get_vm_ref.assert_called_once_with(self._session,
+                                                self._instance)
         mock_get_detach_port_index.assert_called_once_with(self._session,
                                                            'fake-ref', None)
         mock_get_network_detach_config_spec.assert_called_once_with(
@@ -3351,7 +3362,8 @@ class VMwareVMOpsTestCase(test.TestCase):
         self._vmops.attach_interface(self._context, self._instance,
                                      self._image_meta,
                                      self._network_values)
-        mock_get_vm_ref.assert_called_once_with(self._session, self._instance)
+        mock_get_vm_ref.assert_called_once_with(self._session,
+                                                self._instance)
         mock_get_attach_port_index.assert_called_once_with(self._session,
                                                            'fake-ref')
         mock_get_network_attach_config_spec.assert_called_once_with(


### PR DESCRIPTION
The tests mostly looking up the objects by identity of
the managed object reference instead of the value.
Refactored the tests so they also work with equal values.

And while we are at it, pass a cluster ref to volumeops,
as it can't work without it

Change-Id: Ica95550d2f5d9eb9f2d9d07bc60e21310802da1f