### PR TITLE
Stable VM References

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1326,6 +1326,7 @@ class VMwareAPIVMTestCase(test.TestCase,
 
     @mock.patch.object(vm_util, 'get_vmdk_info')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cached_instances')
+    @mock.patch.object(vmops.VMwareVMOps, '_fetch_image_if_missing')
     @mock.patch('nova.virt.vmwareapi.vmops.VMwareVMOps._delete_vm_snapshot')
     @mock.patch('nova.virt.vmwareapi.vmops.VMwareVMOps._create_vm_snapshot')
     @mock.patch('nova.virt.vmwareapi.volumeops.VMwareVolumeOps.'
@@ -1334,6 +1335,7 @@ class VMwareAPIVMTestCase(test.TestCase,
                                          mock_create_vm_snapshot,
                                          mock_delete_vm_snapshot,
                                          mock_update_cached_instances,
+                                         mock_fetch_image_if_missing,
                                          mock_get_vmdk):
 
         mock_get_vmdk.return_value = self.get_fake_vmdk()

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -349,13 +349,14 @@ class VMwareVMOpsTestCase(test.TestCase):
             self.assertEqual(hardware.InstanceInfo(state=power_state.SHUTDOWN),
                              info)
 
-    @mock.patch.object(vm_util, 'get_vm_ref')
+    @mock.patch.object(vm_util, 'vm_ref_cache_get')
+    @mock.patch.object(vm_util, 'search_vm_ref_by_identifier')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cached_instances')
     @mock.patch.object(vm_util, '_VM_VALUE_CACHE')
     def test_get_info_instance_deleted(self, mock_value_cache,
                                        mock_update_cached_instances,
-                                       mock_get_vm_ref):
-        vm_util.vm_value_cache_reset()
+                                       mock_search_vm_ref_by_identifier,
+                                       mock_vm_ref_cache_get):
         props = ['summary.config.numCpu', 'summary.config.memorySizeMB',
                  'runtime.powerState']
         prop_cpu = vmwareapi_fake.Prop(props[0], 4)
@@ -365,19 +366,17 @@ class VMwareVMOpsTestCase(test.TestCase):
         obj_content = vmwareapi_fake.ObjectContent(None, prop_list=prop_list)
         result = vmwareapi_fake.FakeRetrieveResult()
         result.add_object(obj_content)
-        mock_get_vm_ref.return_value = vmwareapi_fake.ManagedObjectReference(
-            value='fake_powered_off')
+        mock_vm_ref_cache_get.return_value = (
+            vmwareapi_fake.ManagedObjectReference(value=mock.sentinel.vm_ref))
+        mock_search_vm_ref_by_identifier.return_value = None
 
-        def mock_call_method(module, method, *args, **kwargs):
-            raise vexc.ManagedObjectNotFoundException()
-
-        with mock.patch.object(self._session, '_call_method',
-                               mock_call_method):
+        with mock.patch.object(self._session, 'invoke_api',
+                side_effect=vexc.ManagedObjectNotFoundException(
+                    details=dict(obj=mock.sentinel.vm_ref))):
             self.assertRaises(exception.InstanceNotFound,
                               self._vmops.get_info,
                               self._instance)
-            mock_get_vm_ref.assert_called_once_with(self._session,
-                self._instance)
+            mock_vm_ref_cache_get.assert_called_once_with(self._instance.uuid)
 
     def _test_get_datacenter_ref_and_name(self, ds_ref_exists=False):
         instance_ds_ref = mock.Mock()

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -41,6 +41,7 @@ from nova import exception
 from nova.i18n import _
 from nova.network import model as network_model
 from nova.virt.vmwareapi import constants
+from nova.virt.vmwareapi.session import StableMoRefProxy
 from nova.virt.vmwareapi import vim_util
 
 LOG = logging.getLogger(__name__)
@@ -254,91 +255,16 @@ def vm_refs_cache_reset():
     _VM_REFS_CACHE = {}
 
 
-def vm_ref_cache_delete(id):
-    _VM_REFS_CACHE.pop(id, None)
+def vm_ref_cache_delete(id_):
+    _VM_REFS_CACHE.pop(id_, None)
 
 
-def vm_ref_cache_update(id, vm_ref):
-    _VM_REFS_CACHE[id] = vm_ref
+def vm_ref_cache_update(id_, vm_ref):
+    _VM_REFS_CACHE[id_] = vm_ref
 
 
-def vm_ref_cache_get(id):
-    return _VM_REFS_CACHE.get(id)
-
-
-def _vm_ref_cache(id, func, session, data):
-    vm_ref = vm_ref_cache_get(id)
-    if not vm_ref:
-        vm_ref = func(session, data)
-        vm_ref_cache_update(id, vm_ref)
-    return vm_ref
-
-
-def vm_ref_cache_from_instance(func):
-    @six.wraps(func)
-    def wrapper(session, instance):
-        id_ = instance.uuid
-        return _vm_ref_cache(id_, func, session, instance)
-    return wrapper
-
-
-def vm_ref_cache_heal_from_instance(func):
-    """Decorator for a function working with a cached ManagedObject reference
-    for an instance
-
-    Invalidates the cache in case of matching ManagedObjectNotFoundException
-    Most functions rely on the reference to be stable over the life-time of an
-    instance, and do not handle this exception, they expect InstanceNotFound
-
-    By invalidating the cache, we solve two issues:
-    1. We have a chance to recover from such a rare change
-    2. If not, we now raise InstanceNotFound, which is actually handled
-
-    The main motivator though is the live-vm migration across vcenters,
-    which can make the VM "disappear"
-
-    An operator also can de-register and re-register a vm, or need to recover
-    the vsphere service, resulting in changed mo-refs,
-    requiring a restart to clear the cache.
-
-    WARNING: Care needs to be taken in applying the decorator:
-    It requires, that the function in question is idempotent (up to the point
-    where the vm_ref is being used)
-    """
-    @six.wraps(func)
-    def wrapper(session, instance, *args, **kwargs):
-        try:
-            return func(session, instance, *args, **kwargs)
-        except vexc.ManagedObjectNotFoundException as e:
-            with excutils.save_and_reraise_exception() as ctx:
-                id_ = instance.uuid
-                vm_ref = vm_ref_cache_get(id_)
-                # if there was nothing in the cache, there's nothing to heal
-                if vm_ref is None:
-                    return  # noqa
-
-                # we are missing details about the issue, so raise it
-                if not e.details:
-                    return  # noqa
-
-                obj = e.details.get("obj")
-                # A different moref may be invalid, nothing we can do about it
-                if obj != vm_ref.value:
-                    return  # noqa
-
-                vm_ref_cache_delete(id_)
-                ctx.reraise = False
-
-                # In case the reference has been passed
-                kw_vm_ref = kwargs.get("vm_ref", None)
-                if kw_vm_ref and kw_vm_ref.value == vm_ref.value:
-                    kwargs.pop("vm_ref")
-
-                # Unlikely, but we might run into the same situation again.
-                LOG.info("Trying to recover possible vm-ref incoherence")
-                return wrapper(session, instance, *args, **kwargs)
-
-    return wrapper
+def vm_ref_cache_get(id_):
+    return _VM_REFS_CACHE.get(id_)
 
 
 # the config key which stores the VNC port
@@ -1380,15 +1306,32 @@ def _get_vm_ref_from_extraconfig(session, instance_uuid):
                                      _get_object_for_optionvalue)
 
 
-@vm_ref_cache_from_instance
+class VmMoRefProxy(StableMoRefProxy):
+    def __init__(self, ref, uuid):
+        super(VmMoRefProxy, self).__init__(ref)
+        self._uuid = uuid
+
+    def fetch_moref(self, session):
+        vm_value_cache_delete(self._uuid)
+        self.moref = search_vm_ref_by_identifier(session, self._uuid)
+        if not self.moref:
+            raise exception.InstanceNotFound(instance_id=self._uuid)
+        vm_ref_cache_update(self._uuid, self.moref)
+
+    def __eq__(self, other):
+        try:
+            return self.moref == other.moref
+        except AttributeError:
+            return self.moref == other
+
+
 def get_vm_ref(session, instance):
-    """Get reference to the VM through uuid or vm name."""
-    uuid = instance.uuid
-    vm_ref = (search_vm_ref_by_identifier(session, uuid) or
-              get_vm_ref_from_name(session, instance.name))
-    if vm_ref is None:
-        raise exception.InstanceNotFound(instance_id=uuid)
-    return vm_ref
+    """Get reference to the VM through uuid."""
+    moref = vm_ref_cache_get(instance.uuid)
+    stable_ref = VmMoRefProxy(moref, instance.uuid)
+    if not moref:
+        stable_ref.fetch_moref(session)
+    return stable_ref
 
 
 def search_vm_ref_by_identifier(session, identifier):
@@ -1400,12 +1343,10 @@ def search_vm_ref_by_identifier(session, identifier):
     use get_vm_ref instead.
     """
     vm_ref = (_get_vm_ref_from_vm_uuid(session, identifier) or
-              _get_vm_ref_from_extraconfig(session, identifier) or
-              get_vm_ref_from_name(session, identifier))
+              _get_vm_ref_from_extraconfig(session, identifier))
     return vm_ref
 
 
-@vm_ref_cache_heal_from_instance
 def get_host_ref_for_vm(session, instance):
     """Get a MoRef to the ESXi host currently running an instance."""
 
@@ -1422,7 +1363,6 @@ def get_host_name_for_vm(session, instance):
                                 host_ref, "name")
 
 
-@vm_ref_cache_heal_from_instance
 def get_vm_state(session, instance):
     vm_ref = get_vm_ref(session, instance)
     vm_state = session._call_method(vutil, "get_object_property",
@@ -1836,7 +1776,6 @@ def create_vm(session, instance, vm_folder, config_spec, res_pool_ref):
     return task_info.result
 
 
-@vm_ref_cache_heal_from_instance
 def _destroy_vm(session, instance, vm_ref=None):
     if not vm_ref:
         vm_ref = get_vm_ref(session, instance)
@@ -1943,7 +1882,6 @@ def reconfigure_vm(session, vm_ref, config_spec):
     session._wait_for_task(reconfig_task)
 
 
-@vm_ref_cache_heal_from_instance
 def power_on_instance(session, instance, vm_ref=None):
     """Power on the specified instance."""
 
@@ -2004,7 +1942,6 @@ def get_vm_detach_port_index(session, vm_ref, iface_id):
                 return int(option.key.split('.')[2])
 
 
-@vm_ref_cache_heal_from_instance
 def power_off_instance(session, instance, vm_ref=None):
     """Power off the specified instance."""
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2455,24 +2455,15 @@ class VMwareVMOps(object):
         if not vm_util._VM_VALUE_CACHE:
             self.update_cached_instances()
 
-        @vm_util.vm_ref_cache_heal_from_instance
-        def _get_vm_props(session, instance):
-            vm_ref = vm_util.get_vm_ref(self._session, instance)
-            vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
-            if vm_props and powerstate_property in vm_props:
-                return vm_props
-
+        vm_ref = vm_util.get_vm_ref(self._session, instance)
+        vm_props = vm_util._VM_VALUE_CACHE.get(vm_ref.value, {})
+        if not vm_props or powerstate_property not in vm_props:
             if CONF.vmware.use_property_collector:
                 LOG.debug("VM instance data was not found on the cache.")
 
-            return session._call_method(
+            vm_props = self._session._call_method(
                 vutil, "get_object_properties_dict",
                 vm_ref, [powerstate_property])
-
-        try:
-            vm_props = _get_vm_props(self._session, instance)
-        except vexc.ManagedObjectNotFoundException:
-            raise exception.InstanceNotFound(instance_id=instance.uuid)
 
         return hardware.InstanceInfo(
             state=constants.POWER_STATES[vm_props[powerstate_property]])


### PR DESCRIPTION
Based on the stable managed object reference "infrastructure" from #288 (and changes to the tests #290),
instead of retrying the whole code block with a decorator, wrap the moref in a proxy-object, and search for the new moref in case we get a ManagedObjectNotFoundException.

Similar to the stable volume managed-object references #289, 