### PR TITLE
[SAP] Shard as volume creation scheduling-hint

### DIFF
--- a/nova/tests/unit/volume/test_cinder.py
+++ b/nova/tests/unit/volume/test_cinder.py
@@ -193,6 +193,7 @@ class CinderApiTestCase(test.NoDBTestCase):
                                                     description='',
                                                     imageRef=None,
                                                     metadata=None, name='',
+                                                    scheduler_hints=None,
                                                     snapshot_id=None,
                                                     volume_type=None)
 
@@ -222,7 +223,7 @@ class CinderApiTestCase(test.NoDBTestCase):
         mock_cinderclient.return_value.volumes.create.assert_called_once_with(
             1, imageRef=None, availability_zone=None,
             volume_type=None, description='', snapshot_id=None, name='',
-            metadata=None)
+            scheduler_hints=None, metadata=None)
 
     @mock.patch('nova.volume.cinder.cinderclient')
     def test_get_all(self, mock_cinderclient):

--- a/nova/virt/block_device.py
+++ b/nova/virt/block_device.py
@@ -24,6 +24,7 @@ from oslo_utils import excutils
 from nova import block_device
 import nova.conf
 from nova import exception
+from nova.objects.aggregate import AggregateList
 from nova import utils
 
 CONF = nova.conf.CONF
@@ -76,6 +77,17 @@ def _get_volume_create_az_value(instance):
     # fail to build the instance on the compute node which results in a
     # NoValidHost error.
     return instance.availability_zone
+
+
+def _get_volume_create_scheduler_hints(context, instance):
+    try:
+        shard = next(aggr.name
+                     for aggr in AggregateList.get_by_host(
+                         context, instance.host)
+                     if aggr.name.startswith('vc-'))
+        return {'vcenter-shard': shard}
+    except StopIteration:
+        return None
 
 
 class DriverBlockDevice(dict):
@@ -370,11 +382,13 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
         :return: A two-item tuple of volume ID and attachment ID.
         """
         av_zone = _get_volume_create_az_value(instance)
+        scheduler_hints = _get_volume_create_scheduler_hints(context, instance)
         name = create_kwargs.pop('name', '')
         description = create_kwargs.pop('description', '')
         vol = volume_api.create(
             context, size, name, description,
-            availability_zone=av_zone, **create_kwargs)
+            availability_zone=av_zone, scheduler_hints=scheduler_hints,
+            **create_kwargs)
 
         if wait_func:
             self._call_wait_func(context, wait_func, volume_api, vol['id'])

--- a/nova/volume/cinder.py
+++ b/nova/volume/cinder.py
@@ -640,7 +640,7 @@ class API(object):
     @translate_create_exception
     def create(self, context, size, name, description, snapshot=None,
                image_id=None, volume_type=None, metadata=None,
-               availability_zone=None):
+               availability_zone=None, scheduler_hints=None):
         client = cinderclient(context)
 
         if snapshot is not None:
@@ -651,6 +651,7 @@ class API(object):
         kwargs = dict(snapshot_id=snapshot_id,
                       volume_type=volume_type,
                       availability_zone=availability_zone,
+                      scheduler_hints=scheduler_hints,
                       metadata=metadata,
                       imageRef=image_id,
                       name=name,


### PR DESCRIPTION
From the instance we can derive the shard and pass the value
as a scheduling hint to cinder

Change-Id: I81faa098634916b64af147d20427796036dd2cbb