### PR TITLE
Set gobal_request_id and reduce time between volume status checks in migrate-by-connector

### DIFF
--- a/nova/volume/cinder.py
+++ b/nova/volume/cinder.py
@@ -1023,7 +1023,7 @@ class API(object):
             context=admin_context, volume_id=volume_id, state_dict=loop_state)
         try:
             timer.start(initial_delay=5, starting_interval=2,
-                        timeout=migration_timeout, max_interval=300).wait()
+                        timeout=migration_timeout, max_interval=60).wait()
         except Exception:
             with excutils.save_and_reraise_exception():
                 LOG.error("Error migrating volume %s to connector %s",

--- a/nova/volume/cinder.py
+++ b/nova/volume/cinder.py
@@ -993,6 +993,7 @@ class API(object):
                   volume_id, connector)
         info = {'connector': connector, 'lock_volume': True}
         admin_context = nova.context.get_admin_context()
+        admin_context.global_request_id = context.global_id
         client = cinderclient(admin_context, '3.44',
                              skip_version_check=True)
         try:


### PR DESCRIPTION
Please see the 2 commit-messages for details.