### PR TITLE
Vmware: Handle empty quickStats in host stats

### DIFF
--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1660,7 +1660,7 @@ def _process_host_stats(obj, host_reservations_map):
         "vcpus": threads,
         "vcpus_used": 0,
         "memory_mb": mem_mb,
-        "memory_mb_used": stats_summary.overallMemoryUsage,
+        "memory_mb_used": getattr(stats_summary, "overallMemoryUsage", 0),
         "cpu_info": _host_props_to_cpu_info(host_props),
     }
 


### PR DESCRIPTION
Host in certain states (such as disconnected ones) do not report
quickStats about memory usage, so we have to assume values
here, which is better than failing updating the stats for all hosts.

Since they are not available, both the usage as well as the free
memory will not be added to the total for the cluster.