### PR TITLE
[vmware] refactor resize/migration to follow nova principles

### DIFF
--- a/nova/scheduler/filters/shard_filter.py
+++ b/nova/scheduler/filters/shard_filter.py
@@ -131,21 +131,6 @@ class ShardFilter(filters.BaseHostFilter):
                         'shard_prefix': self._SHARD_PREFIX})
             return False
 
-        # forbid changing the shard of an instance
-        instance_host = spec_obj.get_scheduler_hint('source_host')
-        resize_or_rebuild = (spec_obj.get_scheduler_hint('_nova_check_type')
-                             in ('resize', 'rebuild'))
-        host_shard_hosts = set(host
-                               for aggr in host_shard_aggrs
-                               for host in aggr.hosts)
-        if (resize_or_rebuild and instance_host
-                and instance_host not in host_shard_hosts):
-            LOG.debug('%(host_state)s is in another shard than the '
-                      'instance\'s %(instance_host)s',
-                      {'host_state': host_state,
-                       'instance_host': instance_host})
-            return False
-
         project_id = spec_obj.project_id
 
         shards = self._get_shards(project_id)

--- a/nova/tests/unit/scheduler/filters/test_shard_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_shard_filter.py
@@ -178,7 +178,7 @@ class TestShardFilter(test.NoDBTestCase):
 
         self.filt_cls._PROJECT_SHARD_CACHE['foo'] = ['vc-a-0', 'vc-a-1',
                                                      'vc-b-0']
-        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
     def test_shard_project_has_sharding_enabled_any_host_passes(self):
         self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled']

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -240,7 +240,8 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.assertFalse(self.conn.need_legacy_block_device_info)
 
     def test_get_host_ip_addr(self):
-        self.assertEqual(HOST, self.conn.get_host_ip_addr())
+        host = '1.0|{}'.format(self.conn._vcenter_uuid)
+        self.assertEqual(host, self.conn.get_host_ip_addr())
 
     def test_init_host_with_no_session(self):
         self.conn._session = mock.Mock()
@@ -656,7 +657,7 @@ class VMwareAPIVMTestCase(test.TestCase,
             self.assertTrue(self.cd_attach_called)
 
     @mock.patch.object(vmops.VMwareVMOps, 'power_off')
-    @mock.patch.object(driver.VMwareVCDriver, 'detach_volume')
+    @mock.patch.object(volumeops.VMwareVolumeOps, 'detach_volume')
     @mock.patch.object(vmops.VMwareVMOps, 'destroy')
     def test_destroy_with_attached_volumes(self,
                                            mock_destroy,
@@ -674,7 +675,7 @@ class VMwareAPIVMTestCase(test.TestCase,
                           block_device_info=bdi)
         mock_power_off.assert_called_once_with(self.instance)
         mock_detach_volume.assert_called_once_with(
-            None, connection_info, self.instance, 'fake-name')
+            connection_info, self.instance)
         mock_destroy.assert_called_once_with(self.context, self.instance, True)
 
     @mock.patch.object(vmops.VMwareVMOps, 'power_off',
@@ -696,7 +697,7 @@ class VMwareAPIVMTestCase(test.TestCase,
         mock_power_off.assert_called_once_with(self.instance)
         mock_destroy.assert_called_once_with(self.context, self.instance, True)
 
-    @mock.patch.object(driver.VMwareVCDriver, 'detach_volume',
+    @mock.patch.object(volumeops.VMwareVolumeOps, 'detach_volume',
                        side_effect=exception.NovaException())
     @mock.patch.object(vmops.VMwareVMOps, 'destroy')
     def test_destroy_with_attached_volumes_with_exception(
@@ -711,11 +712,11 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.assertRaises(exception.NovaException,
                           self.conn.destroy, self.context, self.instance,
                           self.network_info, block_device_info=bdi)
-        mock_detach_volume.assert_called_once_with(
-            None, connection_info, self.instance, 'fake-name')
+        mock_detach_volume.assert_called_once_with(connection_info,
+                                                   self.instance)
         self.assertFalse(mock_destroy.called)
 
-    @mock.patch.object(driver.VMwareVCDriver, 'detach_volume',
+    @mock.patch.object(volumeops.VMwareVolumeOps, 'detach_volume',
                        side_effect=exception.DiskNotFound(message='oh man'))
     @mock.patch.object(vmops.VMwareVMOps, 'destroy')
     def test_destroy_with_attached_volumes_with_disk_not_found(
@@ -730,7 +731,7 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.conn.destroy(self.context, self.instance, self.network_info,
                           block_device_info=bdi)
         mock_detach_volume.assert_called_once_with(
-            None, connection_info, self.instance, 'fake-name')
+            connection_info, self.instance)
         self.assertTrue(mock_destroy.called)
         mock_destroy.assert_called_once_with(self.context, self.instance, True)
 
@@ -1591,7 +1592,7 @@ class VMwareAPIVMTestCase(test.TestCase,
                 self.assertFalse(mock_reboot.called)
 
     @mock.patch('nova.virt.driver.block_device_info_get_mapping')
-    @mock.patch('nova.virt.vmwareapi.driver.VMwareVCDriver.detach_volume')
+    @mock.patch.object(volumeops.VMwareVolumeOps, 'detach_volume')
     def test_detach_instance_volumes(
             self, detach_volume, block_device_info_get_mapping):
         self._create_vm()
@@ -1615,10 +1616,8 @@ class VMwareAPIVMTestCase(test.TestCase,
                 block_device_info)
             vmops.power_off.assert_called_once_with(self.instance)
             exp_detach_calls = [
-                mock.call(None, mock.sentinel.connection_info_1,
-                          self.instance, 'dev1'),
-                mock.call(None, mock.sentinel.connection_info_2,
-                          self.instance, 'dev2')]
+                mock.call(mock.sentinel.connection_info_1, self.instance),
+                mock.call(mock.sentinel.connection_info_2, self.instance)]
             self.assertEqual(exp_detach_calls, detach_volume.call_args_list)
 
     def test_destroy(self):
@@ -1668,30 +1667,50 @@ class VMwareAPIVMTestCase(test.TestCase,
                               None, self.destroy_disks)
             self.assertFalse(mock_destroy.called)
 
-    def _destroy_instance_without_vm_ref(self,
-                                         task_state=None):
-
-        def fake_vm_ref_from_name(session, vm_name):
-            return 'fake-ref'
+    def _destroy_instance_without_vm_ref(self, task_state=None,
+                                         reverting_in_place_migration=False):
 
         self._create_instance()
         with test.nested(
-             mock.patch.object(vm_util, 'get_vm_ref_from_name',
-                               fake_vm_ref_from_name),
+             mock.patch.object(vm_util, 'get_vm_ref',
+                               return_value='fake-ref'),
+             mock.patch.object(vm_util, 'get_vm_name'),
              mock.patch.object(self.conn._session,
                                '_call_method'),
-             mock.patch.object(self.conn._vmops,
-                               '_destroy_instance')
-        ) as (mock_get, mock_call, mock_destroy):
+             mock.patch.object(self.conn._vmops, '_destroy_instance'),
+             mock.patch.object(self.conn, '_detach_instance_volumes'),
+        ) as (mock_get_vm_ref, mock_get_vm_name, mock_call, mock_destroy,
+                mock_detach):
+            if reverting_in_place_migration:
+                mock_get_vm_name.return_value = 'fake-vm-name'
+            else:
+                mock_get_vm_name.return_value = self.instance.uuid
+
+            block_device_info = mock.sentinel.block_device_info
+
             self.instance.task_state = task_state
             self.conn.destroy(self.context, self.instance,
                               self.network_info,
-                              None, True)
+                              block_device_info, True)
+
             if task_state == task_states.RESIZE_REVERTING:
-                expected = 0
+                mock_get_vm_ref.assert_called_once_with(self.conn._session,
+                                                        self.instance)
+                mock_get_vm_name.assert_called_once_with(self.conn._session,
+                    mock_get_vm_ref.return_value)
+                if reverting_in_place_migration:
+                    mock_destroy.assert_not_called()
+                else:
+                    mock_destroy.assert_called_once_with(self.context,
+                        self.instance, destroy_disks=True)
+                    mock_detach.assert_called_once_with(self.instance,
+                                                        block_device_info)
             else:
-                expected = 1
-            self.assertEqual(expected, mock_destroy.call_count)
+                mock_destroy.assert_called_once_with(self.context,
+                                                     self.instance,
+                                                     destroy_disks=True)
+                mock_detach.assert_called_once_with(self.instance,
+                                                    block_device_info)
             self.assertFalse(mock_call.called)
 
     def test_destroy_instance_without_vm_ref(self):
@@ -1700,6 +1719,11 @@ class VMwareAPIVMTestCase(test.TestCase,
     def test_destroy_instance_without_vm_ref_with_resize_revert(self):
         self._destroy_instance_without_vm_ref(
             task_state=task_states.RESIZE_REVERTING)
+
+    def test_destroy_instance_reverting_in_place_migration(self):
+        self._destroy_instance_without_vm_ref(
+            task_state=task_states.RESIZE_REVERTING,
+            reverting_in_place_migration=True)
 
     def test_destroy_instance_with_vm_ref_but_with_volumes(self):
         self.destroy_disks = True
@@ -2548,9 +2572,10 @@ class VMwareAPIVMTestCase(test.TestCase,
     def test_resize_to_smaller_disk(self, mock_update_cached_instances):
         self._create_vm(instance_type='m1.large')
         flavor = self._get_instance_type_by_name('m1.small')
+        fake_dest = '1.0|vcenter-uuid'
         self.assertRaises(exception.InstanceFaultRollback,
                           self.conn.migrate_disk_and_power_off, self.context,
-                          self.instance, 'fake_dest', flavor, None)
+                          self.instance, fake_dest, flavor, None)
 
     def test_spawn_attach_volume_vmdk(self):
         self._spawn_attach_volume_vmdk()

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -13,10 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import mock
 import re
 import time
 
-import mock
 from oslo_serialization import jsonutils
 from oslo_utils import units
 from oslo_utils import uuidutils
@@ -112,7 +112,8 @@ class VMwareVMOpsTestCase(test.TestCase):
         self._volumeops = volumeops.VMwareVolumeOps(self._session)
         self._vmops = vmops.VMwareVMOps(self._session, self._virtapi,
                                         self._volumeops,
-                                        cluster=cluster.obj)
+                                        cluster=cluster.obj,
+                                        vcenter_uuid=uuidsentinel.vcenter)
         self._cluster = cluster
         self._image_meta = objects.ImageMeta.from_dict({'id': self._image_id,
                                                         'owner': ''})
@@ -626,8 +627,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                   succeeds=False)
 
     def _test_finish_migration(self, power_on=True,
-                               resize_instance=False, migration=None,
-                               relocate_fails=False):
+                               resize_instance=False, migration=None):
         with test.nested(
                 mock.patch.object(self._vmops,
                                   '_resize_create_ephemerals_and_swap'),
@@ -635,6 +635,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                 mock.patch.object(vm_util, "power_on_instance"),
                 mock.patch.object(vm_util, "get_vm_ref",
                                   return_value='fake-ref'),
+                mock.patch.object(vm_util, "reconfigure_vm"),
                 mock.patch.object(vmops.VMwareVMOps,
                                   "_remove_ephemerals_and_swap"),
                 mock.patch.object(vm_util, 'get_vmdk_info'),
@@ -645,88 +646,81 @@ class VMwareVMOpsTestCase(test.TestCase):
                 mock.patch.object(vmops.VMwareVMOps, "_attach_volumes"),
                 mock.patch.object(vmops.VMwareVMOps,
                                   "update_cluster_placement"),
+                mock.patch.object(vmops.VMwareVMOps,
+                                  "_get_vm_networking_spec"),
+                mock.patch.object(images,
+                                  "get_vsphere_location"),
+                mock.patch.object(ds_util,
+                                  "get_datastore",
+                                  return_value=self._ds),
         ) as (fake_resize_create_ephemerals_and_swap,
               fake_update_instance_progress, fake_power_on, fake_get_vm_ref,
-              fake_remove_ephemerals_and_swap, fake_get_vmdk_info,
-              fake_resize_vm, fake_resize_disk, fake_relocate_vm,
-              fake_detach_volumes, fake_attach_volumes,
-              fake_update_cluster_placement):
+              fake_reconfigure_vm, fake_remove_ephemerals_and_swap,
+              fake_get_vmdk_info, fake_resize_vm, fake_resize_disk,
+              fake_relocate_vm, fake_detach_volumes, fake_attach_volumes,
+              fake_update_cluster_placement, fake_get_vm_networking_spec,
+              fake_get_vsphere_location, fake_get_datastore):
+            vm_ref = fake_get_vm_ref.return_value
             migration = migration or objects.Migration(dest_compute="nova",
-                                                       source_compute="nova")
-            if relocate_fails:
-                fake_relocate_vm.side_effect = test.TestingException
+                source_compute="nova", uuid=uuidsentinel.migration)
+            block_device_info = mock.sentinel.block_device_info
+
             vmdk = vm_util.VmdkInfo('[fake] uuid/root.vmdk',
                                     'fake-adapter',
                                     'fake-disk',
                                     self._instance.flavor.root_gb * units.Gi,
                                     'fake-device')
             fake_get_vmdk_info.return_value = vmdk
-            vm_ref_calls = [mock.call(self._session, self._instance)]
-            try:
-                self._vmops.finish_migration(context=self._context,
-                                             migration=migration,
-                                             instance=self._instance,
-                                             disk_info=None,
-                                             network_info=None,
-                                             block_device_info=None,
-                                             resize_instance=resize_instance,
-                                             image_meta=None,
-                                             power_on=power_on)
-            except test.TestingException:
-                pass
-            relocate_failed = False
-            if migration.dest_compute != migration.source_compute:
-                fake_relocate_vm.\
-                    assert_called_once_with('fake-ref', self._context,
-                                            self._instance, None, None)
-                fake_detach_volumes.assert_called_once_with(self._instance,
-                                                            None)
-                fake_attach_volumes.assert_called_once_with(self._instance,
-                                                            None,
-                                                            vmdk.adapter_type)
-                if not relocate_fails:
-                    fake_update_cluster_placement.assert_called_once_with(
-                        self._context, self._instance)
-                else:
-                    fake_update_cluster_placement.assert_not_called()
-                    relocate_failed = True
 
-            if not relocate_failed:
-                fake_resize_create_ephemerals_and_swap.assert_called_once_with(
-                    'fake-ref', self._instance, None)
-                fake_remove_ephemerals_and_swap.assert_called_once_with(
-                    'fake-ref')
-                if power_on:
-                    fake_power_on.assert_called_once_with(self._session,
-                                                          self._instance,
-                                                          vm_ref='fake-ref')
-                else:
-                    self.assertFalse(fake_power_on.called)
+            self._vmops.finish_migration(context=self._context,
+                                         migration=migration,
+                                         instance=self._instance,
+                                         disk_info=None,
+                                         network_info=None,
+                                         block_device_info=block_device_info,
+                                         resize_instance=resize_instance,
+                                         image_meta=None,
+                                         power_on=power_on)
+            fake_attach_volumes.assert_called_once_with(self._instance,
+                block_device_info,
+                constants.DEFAULT_ADAPTER_TYPE)
 
-                fake_resize_vm.assert_called_once_with(self._context,
-                                                       self._instance,
-                                                       'fake-ref',
-                                                       self._instance.flavor,
-                                                       mock.ANY)
-                if resize_instance:
-                    fake_resize_disk.\
-                        assert_called_once_with(self._instance,
-                                                'fake-ref',
-                                                vmdk,
-                                                self._instance.flavor)
-
-                calls = [mock.call(self._context, self._instance, step=i,
-                                   total_steps=vmops.RESIZE_TOTAL_STEPS)
-                         for i in range(2, 7)]
-                fake_update_instance_progress.assert_has_calls(calls)
+            fake_resize_create_ephemerals_and_swap.assert_called_once_with(
+                'fake-ref', self._instance, block_device_info)
+            fake_remove_ephemerals_and_swap.assert_called_once_with(
+                'fake-ref')
+            if power_on:
+                fake_power_on.assert_called_once_with(self._session,
+                                                        self._instance)
             else:
-                fake_resize_create_ephemerals_and_swap.assert_not_called()
-                fake_remove_ephemerals_and_swap.assert_not_called()
-                fake_power_on.assert_not_called()
-                fake_resize_vm.assert_not_called()
+                self.assertFalse(fake_power_on.called)
+
+            fake_resize_vm.assert_called_once_with(self._context,
+                                                    self._instance,
+                                                    vm_ref,
+                                                    self._instance.flavor,
+                                                    mock.ANY)
+            if resize_instance:
+                fake_resize_disk.\
+                    assert_called_once_with(self._instance,
+                                            vm_ref,
+                                            vmdk,
+                                            self._instance.flavor)
+            else:
                 fake_resize_disk.assert_not_called()
-                fake_update_instance_progress.assert_not_called()
-            fake_get_vm_ref.assert_has_calls(vm_ref_calls)
+
+            calls = [mock.call(self._context, self._instance, step=i,
+                                total_steps=vmops.RESIZE_TOTAL_STEPS)
+                        for i in range(5, vmops.RESIZE_TOTAL_STEPS)]
+            fake_update_instance_progress.assert_has_calls(calls)
+            fake_update_cluster_placement.assert_called_once_with(
+                    self._context, self._instance)
+
+            if power_on:
+                fake_power_on.assert_called_once_with(self._session,
+                                                      self._instance)
+            else:
+                self.assertFalse(fake_power_on.called)
 
     def test_finish_migration_power_on(self):
         self._test_finish_migration(power_on=True, resize_instance=False)
@@ -736,17 +730,6 @@ class VMwareVMOpsTestCase(test.TestCase):
 
     def test_finish_migration_power_on_resize(self):
         self._test_finish_migration(power_on=True, resize_instance=True)
-
-    def test_finish_migration_another_cluster(self, relocate_fails=False):
-        self._test_finish_migration(power_on=True,
-                                    resize_instance=False,
-                                    relocate_fails=relocate_fails,
-                                    migration=objects.Migration(
-                                        dest_compute="dest",
-                                        source_compute="source"))
-
-    def test_finish_migration_relocate_fails(self):
-        self.test_finish_migration_another_cluster(relocate_fails=True)
 
     @mock.patch.object(vmops.VMwareVMOps, '_create_swap')
     @mock.patch.object(vmops.VMwareVMOps, '_create_ephemeral')
@@ -799,6 +782,81 @@ class VMwareVMOpsTestCase(test.TestCase):
         vmdk = vm_util.VmdkInfo(None, None, None, 0, None)
         self._test_resize_create_ephemerals(vmdk, None)
 
+    @mock.patch.object(ds_util, 'get_datastore')
+    @mock.patch.object(images, 'get_vsphere_location')
+    @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
+    @mock.patch.object(vm_util, 'rename_vm')
+    @mock.patch.object(vm_util, '_get_vm_ref_from_vm_uuid',
+                       return_value=mock.sentinel.migrated_vm)
+    @mock.patch.object(vm_util, 'power_on_instance')
+    @mock.patch.object(vm_util, 'reconfigure_vm')
+    @mock.patch.object(vmops.VMwareVMOps, '_attach_volumes')
+    @mock.patch.object(vmops.VMwareVMOps, "_get_vm_networking_spec",
+                       return_value=mock.sentinel.networking_spec)
+    @mock.patch.object(vmops.VMwareVMOps, "_update_vnic_index")
+    @mock.patch.object(vm_util, 'get_vmdk_info')
+    @mock.patch.object(objects.MigrationContext, 'get_by_instance_uuid')
+    @mock.patch.object(objects.Migration, 'get_by_id_and_instance')
+    def test_finish_revert_migration(self, fake_migration_get,
+                                     fake_migration_context_get,
+                                     fake_get_vmdk_info,
+                                     fake_update_vnic_index,
+                                     fake_get_vm_networking_spec,
+                                     fake_attach_volumes,
+                                     fake_reconfigure_vm, fake_power_on,
+                                     fake_get_vm_ref_by_uuid,
+                                     fake_rename_vm,
+                                     fake_update_cluster_placement,
+                                     fake_get_vsphere_location,
+                                     fake_get_datastore,
+                                     legacy_migration=False):
+        vm_ref = fake_get_vm_ref_by_uuid.return_value
+        fake_get_datastore.return_value = self._ds
+        if not legacy_migration:
+            dest = self._vmops.get_host_ip_addr()
+        else:
+            dest = "127.0.0.1"
+        migration = objects.Migration(
+            dest_host=dest, uuid=uuidutils.generate_uuid())
+        fake_migration_get.return_value = migration
+        fake_migration_context_get.return_value = \
+            objects.MigrationContext(migration_id=101)
+        vmdk = vm_util.VmdkInfo('[fake] uuid/root.vmdk',
+                                'fake-adapter',
+                                'fake-disk',
+                                self._instance.flavor.root_gb * units.Gi,
+                                'fake-device')
+        fake_get_vmdk_info.return_value = vmdk
+        self._vmops.finish_revert_migration(self._context, self._instance,
+                                            mock.sentinel.network_info,
+                                            mock.sentinel.block_device_info,
+                                            power_on=True)
+        fake_migration_get.assert_called_once_with(self._context, 101,
+                                                   self._instance.uuid)
+        fake_get_vm_ref_by_uuid.assert_called_once_with(self._session,
+                                                        migration.uuid)
+        if legacy_migration:
+            fake_get_vmdk_info.assert_called_once_with(
+                self._session, vm_ref, uuid=self._instance.uuid)
+        else:
+            fake_reconfigure_vm.assert_called_once_with(
+                self._session, vm_ref, mock.sentinel.networking_spec
+            )
+            fake_attach_volumes.assert_called_once_with(
+                self._instance, mock.sentinel.block_device_info,
+                constants.DEFAULT_ADAPTER_TYPE,
+                existing_disks={})
+            fake_get_vm_networking_spec.assert_called_once_with(
+                self._instance, mock.sentinel.network_info)
+            fake_update_vnic_index.assert_called_once_with(
+                self._context, self._instance, mock.sentinel.network_info
+            )
+            fake_rename_vm.assert_called_once_with(self._session, vm_ref,
+                                                   self._instance)
+        fake_power_on.assert_called_once_with(self._session, self._instance)
+
+    @mock.patch.object(objects.MigrationContext, 'get_by_instance_uuid')
+    @mock.patch.object(objects.Migration, 'get_by_id_and_instance')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
     @mock.patch.object(vmops.VMwareVMOps, '_resize_create_ephemerals_and_swap')
@@ -819,20 +877,16 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vmops.VMwareVMOps, '_attach_volumes')
     @mock.patch.object(vmops.VMwareVMOps, '_relocate_vm')
     @mock.patch.object(vmops.VMwareVMOps, 'list_instances')
-    def _test_finish_revert_migration(self, fake_list_instances,
-                                      fake_relocate_vm, fake_attach_volumes,
-                                      fake_detach_volumes, fake_power_on,
-                                      fake_get_vm_ref, fake_power_off,
-                                      fake_resize_spec, fake_reconfigure_vm,
-                                      fake_get_browser,
-                                      fake_original_exists, fake_disk_move,
-                                      fake_disk_delete,
-                                      fake_remove_ephemerals_and_swap,
-                                      fake_resize_create_ephemerals_and_swap,
-                                      fake_get_extra_specs,
-                                      fake_update_cluster_placement,
-                                      power_on, instances_list=None,
-                                      relocate_fails=False):
+    def _test_finish_revert_in_place_migration(
+            self, fake_list_instances, fake_relocate_vm, fake_attach_volumes,
+            fake_detach_volumes, fake_power_on, fake_get_vm_ref,
+            fake_power_off, fake_resize_spec, fake_reconfigure_vm,
+            fake_get_browser, fake_original_exists, fake_disk_move,
+            fake_disk_delete, fake_remove_ephemerals_and_swap,
+            fake_resize_create_ephemerals_and_swap, fake_get_extra_specs,
+            fake_update_cluster_placement,
+            fake_migration_get_by_id_and_instance, fake_get_by_instance_uuid,
+            power_on, instances_list=None, relocate_fails=False):
         """Tests the finish_revert_migration method on vmops."""
         datastore = ds_obj.Datastore(ref='fake-ref', name='fake')
         device = vmwareapi_fake.DataObject()
@@ -848,6 +902,11 @@ class VMwareVMOpsTestCase(test.TestCase):
                                  vmFolder='fake_folder')
         extra_specs = vm_util.ExtraSpecs()
         fake_get_extra_specs.return_value = extra_specs
+        fake_migration_get_by_id_and_instance.return_value = \
+            objects.Migration(dest_host='fake-host',
+                              uuid=uuidutils.generate_uuid())
+        fake_get_by_instance_uuid.return_value = \
+            objects.MigrationContext(migration_id=101)
         with test.nested(
             mock.patch.object(self._vmops, 'get_datacenter_ref_and_name',
                               return_value=dc_info),
@@ -943,37 +1002,38 @@ class VMwareVMOpsTestCase(test.TestCase):
         else:
             self.assertFalse(fake_power_on.called)
 
-    def test_finish_revert_migration_power_on(self):
-        self._test_finish_revert_migration(power_on=True)
+    def test_finish_revert_in_place_migration_power_on(self):
+        self._test_finish_revert_in_place_migration(power_on=True)
 
-    def test_finish_revert_migration_power_off(self):
-        self._test_finish_revert_migration(power_on=False)
+    def test_finish_revert_in_place_migration_power_off(self):
+        self._test_finish_revert_in_place_migration(power_on=False)
 
-    def test_finish_revert_migration_another_cluster(self,
-                                                     relocate_fails=False):
+    def test_finish_revert_in_place_migration_another_cluster(
+            self, relocate_fails=False):
         instances_list = ["fake_uuid_foo_bar"]
-        self._test_finish_revert_migration(power_on=True,
-                                           instances_list=instances_list,
-                                           relocate_fails=relocate_fails)
+        self._test_finish_revert_in_place_migration(
+            power_on=True, instances_list=instances_list,
+            relocate_fails=relocate_fails)
 
-    def test_finish_revert_migration_relocate_fails(self):
-        self.test_finish_revert_migration_another_cluster(relocate_fails=True)
+    def test_finish_revert_in_place_migration_relocate_fails(self):
+        self.test_finish_revert_in_place_migration_another_cluster(
+            relocate_fails=True)
 
     @mock.patch.object(volumeops.VMwareVolumeOps, 'attach_volume')
     def test_attach_volumes(self, fake_attach_volume):
         block_device_info = {
             'block_device_mapping': [
-                {'boot_index': -1, 'connection_info': {'id': 'c'}},
-                {'boot_index': 1, 'connection_info': {'id': 'b'}},
-                {'boot_index': 0, 'connection_info': {'id': 'a'}},
+                {'mount_device': '/dev/sda', 'connection_info': {'id': 'c'}},
+                {'mount_device': '/dev/sdb', 'connection_info': {'id': 'b'}},
+                {'mount_device': '/dev/sdc', 'connection_info': {'id': 'a'}},
             ]
         }
         self._vmops._attach_volumes(self._instance, block_device_info,
                                     mock.sentinel.adapter_type)
         fake_attach_volume.assert_has_calls([
-            mock.call({'id': 'a'}, self._instance, mock.sentinel.adapter_type),
-            mock.call({'id': 'b'}, self._instance, mock.sentinel.adapter_type),
             mock.call({'id': 'c'}, self._instance, mock.sentinel.adapter_type),
+            mock.call({'id': 'b'}, self._instance, mock.sentinel.adapter_type),
+            mock.call({'id': 'a'}, self._instance, mock.sentinel.adapter_type),
         ])
 
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata')
@@ -981,8 +1041,11 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
                        return_value='fake-spec')
-    def test_resize_vm(self, fake_resize_spec, fake_reconfigure,
+    @mock.patch.object(vm_util, 'get_vm_ref', return_value='vm-ref')
+    def test_resize_vm(self, fake_get_vm_ref,
+                       fake_resize_spec, fake_reconfigure,
                        fake_get_extra_specs, fake_get_metadata):
+        vm_ref = mock.sentinel.vm_ref
         extra_specs = vm_util.ExtraSpecs()
         fake_get_extra_specs.return_value = extra_specs
         fake_get_metadata.return_value = self._metadata
@@ -992,15 +1055,14 @@ class VMwareVMOpsTestCase(test.TestCase):
                                 extra_specs={})
         instance = self._instance.obj_clone()
         instance.old_flavor = instance.flavor.obj_clone()
-        self._vmops._resize_vm(self._context, instance, 'vm-ref', flavor,
-                               None)
+        self._vmops._resize_vm(self._context, instance, vm_ref, flavor, None)
         fake_get_metadata.assert_called_once_with(self._context,
                                                   instance, flavor)
         fake_resize_spec.assert_called_once_with(
             self._session.vim.client.factory, 2, 1024, extra_specs,
             metadata=self._metadata)
         fake_reconfigure.assert_called_once_with(self._session,
-                                                 'vm-ref', 'fake-spec')
+                                                 vm_ref, 'fake-spec')
 
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
@@ -1008,11 +1070,14 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
                        return_value='fake-spec')
+    @mock.patch.object(vm_util, 'get_vm_ref',
+                       return_value=mock.sentinel.vm_ref)
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
-    def test_resize_vm_bigvm_upsize(self, fake_drs_override, fake_resize_spec,
-                                    fake_reconfigure,
+    def test_resize_vm_bigvm_upsize(self, fake_drs_override, fake_get_vm_ref,
+                                    fake_resize_spec, fake_reconfigure,
                                     fake_cleanup_after_special_spawning,
                                     fake_get_extra_specs, fake_get_metadata):
+        vm_ref = fake_get_vm_ref.return_value
         extra_specs = vm_util.ExtraSpecs()
         fake_get_extra_specs.return_value = extra_specs
         fake_get_metadata.return_value = self._metadata
@@ -1022,12 +1087,11 @@ class VMwareVMOpsTestCase(test.TestCase):
                                 extra_specs={})
         instance = self._instance.obj_clone()
         instance.old_flavor = instance.flavor.obj_clone()
-        self._vmops._resize_vm(self._context, instance, 'vm-ref', flavor,
-                               None)
+        self._vmops._resize_vm(self._context, instance, vm_ref, flavor, None)
         behavior = constants.DRS_BEHAVIOR_PARTIALLY_AUTOMATED
         fake_drs_override.assert_called_once_with(self._session,
                                                   self._cluster.obj,
-                                                  'vm-ref',
+                                                  vm_ref,
                                                   operation='add',
                                                   behavior=behavior)
         expected = (self._context, int(flavor.memory_mb), flavor)
@@ -1039,11 +1103,14 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
                        return_value='fake-spec')
+    @mock.patch.object(vm_util, 'get_vm_ref',
+                       return_value=mock.sentinel.vm_ref)
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
-    def test_resize_vm_bigvm_downsize(self, fake_drs_override,
+    def test_resize_vm_bigvm_downsize(self, fake_drs_override, fake_get_vm_ref,
                                       fake_resize_spec, fake_reconfigure,
                                       fake_cleanup_after_special_spawning,
                                       fake_get_extra_specs, fake_get_metadata):
+        vm_ref = fake_get_vm_ref.return_value
         extra_specs = vm_util.ExtraSpecs()
         fake_get_extra_specs.return_value = extra_specs
         fake_get_metadata.return_value = self._metadata
@@ -1054,11 +1121,10 @@ class VMwareVMOpsTestCase(test.TestCase):
         instance = self._instance.obj_clone()
         instance.old_flavor = instance.flavor.obj_clone()
         instance.old_flavor.memory_mb = CONF.bigvm_mb
-        self._vmops._resize_vm(self._context, instance, 'vm-ref', flavor,
-                               None)
+        self._vmops._resize_vm(self._context, instance, vm_ref, flavor, None)
         fake_drs_override.assert_called_once_with(self._session,
                                                   self._cluster.obj,
-                                                  'vm-ref',
+                                                  vm_ref,
                                                   operation='remove')
         expected = (self._context, int(flavor.memory_mb), flavor)
         fake_cleanup_after_special_spawning.assert_called_once_with(*expected)
@@ -1104,8 +1170,11 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vmops.VMwareVMOps, '_extend_virtual_disk')
     @mock.patch.object(ds_util, 'disk_move')
     @mock.patch.object(ds_util, 'disk_copy')
-    def test_resize_disk(self, fake_disk_copy, fake_disk_move,
+    @mock.patch.object(vm_util, 'get_vm_ref',
+                       return_value=mock.sentinel.vm_ref)
+    def test_resize_disk(self, fake_get_vm_ref, fake_disk_copy, fake_disk_move,
                          fake_extend):
+        vm_ref = fake_get_vm_ref.return_value
         datastore = ds_obj.Datastore(ref='fake-ref', name='fake')
         device = vmwareapi_fake.DataObject()
         backing = vmwareapi_fake.DataObject()
@@ -1127,12 +1196,12 @@ class VMwareVMOpsTestCase(test.TestCase):
             instance.old_flavor = instance.flavor.obj_clone()
             flavor = fake_flavor.fake_flavor_obj(self._context,
                          root_gb=self._instance.flavor.root_gb + 1)
-            self._vmops._resize_disk(instance, 'fake-ref', vmdk, flavor)
+            self._vmops._resize_disk(instance, vm_ref, vmdk, flavor)
             fake_get_dc_ref_and_name.assert_called_once_with(datastore.ref)
             fake_disk_copy.assert_called_once_with(
                 self._session, dc_info.ref, '[fake] uuid/root.vmdk',
                 '[fake] uuid/resized.vmdk')
-            mock_detach_disk.assert_called_once_with('fake-ref',
+            mock_detach_disk.assert_called_once_with(vm_ref,
                                                      instance,
                                                      device)
             fake_extend.assert_called_once_with(
@@ -1148,7 +1217,7 @@ class VMwareVMOpsTestCase(test.TestCase):
             fake_disk_move.assert_has_calls(calls)
 
             mock_attach_disk.assert_called_once_with(
-                    'fake-ref', instance, 'fake-adapter', 'fake-disk',
+                    vm_ref, instance, 'fake-adapter', 'fake-disk',
                     '[fake] uuid/root.vmdk')
 
     @mock.patch.object(vm_util, 'detach_devices_from_vm')
@@ -1166,15 +1235,48 @@ class VMwareVMOpsTestCase(test.TestCase):
         detach_devices.assert_called_once_with(self._vmops._session,
                                                mock.sentinel.vm_ref, devices)
 
+    @mock.patch.object(vm_util, '_get_vm_ref_from_vm_uuid',
+                       return_value=mock.sentinel.migrated_vm)
+    @mock.patch.object(vm_util, 'destroy_vm')
+    @mock.patch.object(vmops.VMwareVMOps, 'api_for_migration')
+    @mock.patch.object(vmops.VMwareVMOps, '_is_in_place_migration',
+                       return_value=False)
+    def test_confirm_migration(self, fake_legacy_test, mock_api,
+                              fake_destroy, fake_get_vm_ref_from_uuid):
+        migration = objects.Migration(uuid=uuidsentinel.migration)
+        self._vmops.confirm_migration(self._context, migration, self._instance,
+                                        network_info=None)
+
+        fake_get_vm_ref_from_uuid.assert_called_once_with(self._session,
+                                                          migration.uuid)
+        fake_destroy.assert_called_once_with(self._session, self._instance,
+                                             mock.sentinel.migrated_vm)
+        op = mock_api.return_value.confirm_migration_destination
+        op.called_once_with(self._context, self._instance)
+
+    @mock.patch.object(vm_util, 'rename_vm')
+    @mock.patch.object(vm_util, 'get_vm_ref',
+                       return_value=mock.sentinel.vm_ref)
+    def test_confirm_migration_destination(self, fake_get_vm_ref,
+                                           fake_rename_vm):
+        self._vmops.confirm_migration_destination(self._context,
+                                                  self._instance)
+
+        fake_get_vm_ref.assert_called_once_with(self._session,
+                                                self._instance)
+        fake_rename_vm.assert_called_once_with(self._session,
+                                               fake_get_vm_ref.return_value,
+                                               self._instance)
+
     @mock.patch.object(ds_util, 'disk_delete')
     @mock.patch.object(ds_util, 'file_exists',
                        return_value=True)
     @mock.patch.object(vmops.VMwareVMOps, '_get_ds_browser',
                        return_value='fake-browser')
     @mock.patch.object(vm_util, 'get_vm_ref', return_value='fake-ref')
-    def test_confirm_migration(self, fake_get_vm_ref, fake_get_browser,
-                               fake_original_exists,
-                               fake_disk_delete):
+    def test_confirm_in_place_migration(
+            self, fake_get_vm_ref, fake_get_browser, fake_original_exists,
+            fake_disk_delete):
         """Tests the confirm_migration method on vmops."""
         datastore = ds_obj.Datastore(ref='fake-ref', name='fake')
         device = vmwareapi_fake.DataObject()
@@ -1188,13 +1290,16 @@ class VMwareVMOpsTestCase(test.TestCase):
                                 device)
         dc_info = ds_util.DcInfo(ref='fake_ref', name='fake',
                                  vmFolder='fake_folder')
+        migration = objects.Migration(dest_host='fake-host',
+                                      uuid=uuidutils.generate_uuid())
         with test.nested(
             mock.patch.object(self._vmops, 'get_datacenter_ref_and_name',
                               return_value=dc_info),
             mock.patch.object(vm_util, 'get_vmdk_info',
                               return_value=vmdk)
         ) as (fake_get_dc_ref_and_name, fake_get_vmdk_info):
-            self._vmops.confirm_migration(None,
+            self._vmops.confirm_migration(self._context,
+                                          migration,
                                           self._instance,
                                           None)
             fake_get_vm_ref.assert_called_once_with(self._session,
@@ -1213,6 +1318,11 @@ class VMwareVMOpsTestCase(test.TestCase):
         self._test_migrate_disk_and_power_off(
             flavor_root_gb=self._instance.flavor.root_gb + 1)
 
+    def test_migrate_disk_and_power_off_rolls_back_on_failure(self):
+        self._test_migrate_disk_and_power_off(
+            flavor_root_gb=self._instance.flavor.root_gb + 1,
+            migrate_fails=True)
+
     def test_migrate_disk_and_power_off_zero_disk_flavor(self):
         self._instance.flavor.root_gb = 0
         self._test_migrate_disk_and_power_off(flavor_root_gb=0)
@@ -1222,54 +1332,305 @@ class VMwareVMOpsTestCase(test.TestCase):
                           self._test_migrate_disk_and_power_off,
                           flavor_root_gb=self._instance.flavor.root_gb - 1)
 
+    @mock.patch.object(vmops.VMwareVMOps, '_do_finish_revert_migration')
+    @mock.patch.object(objects.ImageMeta, 'from_instance')
+    @mock.patch.object(vm_util, 'reconfigure_vm_device_change')
+    @mock.patch.object(vm_util, 'rename_vm')
     @mock.patch.object(vm_util, 'get_vmdk_info')
+    @mock.patch.object(vm_util, 'power_on_instance')
     @mock.patch.object(vm_util, 'power_off_instance')
+    @mock.patch.object(vm_util, 'get_hardware_devices_by_type',
+                       return_value={})
+    @mock.patch.object(vm_util, 'get_vm_ref', return_value='source-ref')
+    @mock.patch.object(vmops.VMwareVMOps, "_do_migrate_disk")
+    @mock.patch.object(vmops.VMwareVMOps, "_get_remove_network_device_change")
+    @mock.patch.object(vmops.VMwareVMOps, "_detach_volumes")
     @mock.patch.object(vmops.VMwareVMOps, "_update_instance_progress")
-    @mock.patch.object(vm_util, 'get_vm_ref', return_value='fake-ref')
-    def _test_migrate_disk_and_power_off(self, fake_get_vm_ref, fake_progress,
-                                         fake_power_off, fake_get_vmdk_info,
-                                         flavor_root_gb):
+    def _test_migrate_disk_and_power_off(self,
+                                         fake_progress, fake_detach_volumes,
+                                         fake_get_remove_network_device_change,
+                                         fake_do_migrate_disk,
+                                         fake_get_vm_ref,
+                                         fake_get_hardware_devices_by_type,
+                                         fake_power_off,
+                                         fake_power_on, fake_get_vmdk_info,
+                                         fake_rename_vm, fake_vm_device_change,
+                                         fake_image_meta, fake_finish_revert,
+                                         flavor_root_gb,
+                                         migrate_fails=False):
+        block_device_info = mock.sentinel.block_device_info
+
         vmdk = vm_util.VmdkInfo('[fake] uuid/root.vmdk',
                                 'fake-adapter',
                                 'fake-disk',
                                 self._instance.flavor.root_gb * units.Gi,
                                 'fake-device')
+        image_meta = {'properties': {'fake-meta': 'fake-meta'}}
+        fake_image_meta.return_value = image_meta
+        dest = self._vmops.get_host_ip_addr()
         fake_get_vmdk_info.return_value = vmdk
+        fake_get_remove_network_device_change.return_value = ['fake-device']
         flavor = fake_flavor.fake_flavor_obj(self._context,
                                              root_gb=flavor_root_gb)
-        self._vmops.migrate_disk_and_power_off(self._context,
-                                               self._instance,
-                                               None,
-                                               flavor)
+        if migrate_fails:
+            fake_do_migrate_disk.side_effect = test.TestingException
+            self.assertRaises(exception.InstanceFaultRollback,
+                              self._vmops.migrate_disk_and_power_off,
+                              self._context, self._instance, dest, flavor,
+                              network_info=None,
+                              block_device_info=block_device_info)
+        else:
+            self._vmops.migrate_disk_and_power_off(
+                self._context, self._instance, dest, flavor, network_info=None,
+                block_device_info=block_device_info)
 
-        fake_get_vm_ref.assert_called_once_with(self._session,
-                                                self._instance)
-
-        fake_power_off.assert_called_once_with(self._session,
-                                               self._instance,
-                                               'fake-ref')
         calls = [mock.call(self._context, self._instance, step=i,
                            total_steps=vmops.RESIZE_TOTAL_STEPS)
-                 for i in range(2)]
+                 for i in range(4)]
         fake_progress.assert_has_calls(calls)
 
+        fake_get_vm_ref.assert_called_with(self._session, self._instance)
+        fake_get_vmdk_info.assert_called_once_with(self._session, 'source-ref')
+
+        fake_rename_vm.assert_called_once_with(self._session, 'source-ref',
+                                               self._instance)
+        fake_power_off.assert_called_once_with(self._session, self._instance,
+                                               'source-ref')
+        fake_detach_volumes.assert_called_once_with(
+            self._instance, block_device_info)
+        fake_get_remove_network_device_change.assert_called_once_with(
+            'source-ref')
+        fake_vm_device_change.assert_called_once_with(self._session,
+                                                      'source-ref',
+                                                      ['fake-device'])
+        dest_data = self._vmops._decode_host_addr(dest)
+        fake_do_migrate_disk.assert_called_once_with(self._context,
+            'source-ref', self._instance, dest_data, flavor)
+        if migrate_fails:
+            fake_finish_revert.assert_called_once_with(self._context,
+                self._instance, block_device_info, None, 'source-ref',
+                fake_get_hardware_devices_by_type.return_value)
+            fake_power_on.assert_called_once_with(
+                self._session, self._instance)
+
+    def test_migrate_disk_and_power_off_rejects_version(self):
+        """Rejects a different migration_version"""
+        dest = 'fake-v1|cluster|.*|localhost|443|None|None'
+
+        self.assertRaises(exception.NovaException,
+                          self._vmops.migrate_disk_and_power_off,
+                          self._context, self._instance_values, dest,
+                          self._flavor, None, None)
+
+    @mock.patch.object(vm_util, 'rename_vm')
+    @mock.patch.object(objects.MigrationContext, 'get_by_instance_uuid')
+    @mock.patch.object(vmops.VMwareVMOps, '_get_project_folder')
+    @mock.patch.object(vmops.VMwareVMOps, 'get_datacenter_ref_and_name')
+    @mock.patch.object(vmops.VMwareVMOps, 'change_vm_instance_uuid')
+    @mock.patch.object(vm_util, 'get_res_pool_ref')
+    @mock.patch.object(ds_util, 'get_datastore')
+    @mock.patch.object(ds_util, 'get_allowed_datastore_types')
+    @mock.patch.object(vmops.VMwareVMOps, '_get_storage_policy')
+    @mock.patch.object(objects.ImageMeta, 'from_instance')
+    @mock.patch.object(VMwareAPISession, '_wait_for_task')
+    @mock.patch.object(VMwareAPISession, '_call_method')
+    @mock.patch.object(objects.Migration, 'get_by_id_and_instance')
+    def _test_do_migrate_disk(self, fake_migration_get, fake_call_method,
+                              fake_wait_for_task, fake_image_meta,
+                              fake_get_storage_policy, fake_allowed_ds_types,
+                              fake_get_datastore, fake_get_res_pool_ref,
+                              fake_change_uuid, fake_get_dc_ref_name,
+                              fake_get_project_folder,
+                              fake_migration_context_get,
+                              fake_rename_vm, dest, change_uuid_fails=False):
+
+        vm_ref = mock.sentinel.vm_ref
+        folder_ref = mock.sentinel.folder
+        datastore_ref = mock.sentinel.datastore
+        disk_move_type = mock.sentinel.disk_move_type
+        service = mock.sentinel.service
+
+        # {'migration_version': parts[0], 'vcenter_uuid': parts[1]}
+        remote = dest['vcenter_uuid'] != uuidsentinel.vcenter
+        fake_get_project_folder.return_value = folder_ref
+        fake_get_dc_ref_name.return_value = 'fake-dc-info'
+        fake_get_res_pool_ref.return_value = 'fake-respool'
+        fake_get_datastore.return_value = mock.Mock(ref=datastore_ref)
+
+        migration_context = objects.MigrationContext()
+        migration_context.instance_uuid = self._instance.uuid
+        migration_context.migration_id = 101
+        fake_migration_context_get.return_value = migration_context
+
+        migration = objects.Migration()
+        migration.uuid = uuidsentinel.migration_uuid
+        migration.dest_compute = dest['vcenter_uuid']
+        migration.source_compute = uuidsentinel.vcenter
+        fake_migration_get.return_value = migration
+
+        fake_wait_for_task.side_effect = [mock.Mock(result='fake-cloned-ref'),
+                                          None]
+
+        if remote:
+            rpc_api = mock.Mock()
+            remote_relocate_spec = rpc_api.get_relocate_spec.return_value
+            remote_relocate_spec.folder = folder_ref
+            remote_relocate_spec.datastore = datastore_ref
+            remote_relocate_spec.diskMoveType = disk_move_type
+            remote_relocate_spec.service = service
+            with mock.patch.object(self._vmops, 'api_for_migration',
+                    return_value=rpc_api):
+                self._vmops._do_migrate_disk(self._context, vm_ref,
+                                             self._instance,
+                                             dest, self._flavor)
+
+        else:
+            self._vmops._do_migrate_disk(self._context, vm_ref, self._instance,
+                                         dest, mock.sentinel.flavor)
+        # Migration is fetched from the DB
+        fake_migration_get.assert_called_once_with(self._context,
+            migration_context.migration_id, self._instance.uuid)
+
+        # VM is cloned with CloneVM_Task
+        _, args, kwargs = fake_call_method.mock_calls[0]
+        self.assertEqual('CloneVM_Task', args[1])
+        self.assertEqual(vm_ref, args[2])
+        self.assertEqual(folder_ref, kwargs['folder'])
+        self.assertEqual(self._instance.uuid, kwargs['name'])
+        spec = kwargs['spec']
+        self.assertFalse(spec.powerOn)
+        # Relocate spec
+        self.assertEqual(datastore_ref, spec.location.datastore)
+        if remote:
+            self.assertEqual(disk_move_type, spec.location.diskMoveType)
+            self.assertEqual(service, spec.location.service)
+            fake_change_uuid.assert_called_once_with(self._context,
+                                                     self._instance,
+                                                     vm_ref,
+                                                     uuid=migration.uuid),
+
+            rpc_api.change_vm_instance_uuid.assert_called_once_with(
+                self._context, self._instance, 'fake-cloned-ref')
+        else:
+            self.assertEqual('moveAllDiskBackingsAndAllowSharing',
+                            spec.location.diskMoveType)
+            self.assertIsNone(spec.location.service)
+            fake_change_uuid.assert_has_calls([
+                mock.call(self._context, self._instance, vm_ref,
+                          uuid=migration.uuid),
+                mock.call(self._context, self._instance, 'fake-cloned-ref')
+            ])
+
+    def test_do_migrate_disk_local_session(self):
+        decoded = {'vcenter_uuid': uuidsentinel.vcenter}
+        self._test_do_migrate_disk(dest=decoded)
+
+    def test_do_migrate_disk_remote_session(self):
+        decoded = {'vcenter_uuid': uuidsentinel.other_vcenter}
+        self._test_do_migrate_disk(dest=decoded)
+
+    @mock.patch.object(vif, 'get_vif_info')
+    @mock.patch.object(vif, 'get_network_device')
+    @mock.patch.object(vm_util, 'get_hardware_devices')
+    @mock.patch.object(vm_util, 'set_net_device_backing')
+    def test_get_network_device_change(self, fake_set_net_device_backing,
+                                       fake_get_hardware_devices,
+                                       fake_get_network_device,
+                                       fake_get_vif_info):
+        vm_ref = 'fake-ref'
+        network_info = ['fake-net']
+        hardware_devices = ['fake-hw-device']
+        image_meta = mock.NonCallableMock(
+                        properties={'fake-meta': 'fake-meta'})
+        vif_infos = [{'mac_address': 'fake-mac-0'},
+                     {'mac_address': 'fake-mac-1'}]
+        net_devices = ['device-1', 'device-2']
+        fake_get_vif_info.return_value = vif_infos
+        fake_get_hardware_devices.return_value = hardware_devices
+        fake_get_network_device.side_effect = net_devices
+
+        device_change = self._vmops._get_network_device_change(
+            vm_ref, image_meta, network_info)
+
+        fake_get_network_device.assert_has_calls([
+            mock.call(hardware_devices, vif_infos[0]['mac_address']),
+            mock.call(hardware_devices, vif_infos[1]['mac_address'])
+        ])
+
+        client_factory = self._session.vim.client.factory
+        fake_set_net_device_backing.assert_has_calls([
+            mock.call(client_factory, net_devices[0], vif_infos[0]),
+            mock.call(client_factory, net_devices[1], vif_infos[1])
+        ])
+
+        self.assertEqual(len(device_change), 2)
+        self.assertEqual(device_change[0].device, net_devices[0])
+        self.assertEqual(device_change[0].operation, 'edit')
+        self.assertEqual(device_change[1].device, net_devices[1])
+        self.assertEqual(device_change[1].operation, 'edit')
+
+    def test_get_network_device_change_fails_mac_address(self):
+        with test.nested(
+                mock.patch.object(self._session, '_call_method'),
+                mock.patch.object(vif, 'get_vif_info'),
+                mock.patch.object(vif, 'get_network_device'),
+                mock.patch.object(vm_util, 'set_net_device_backing')
+        ) as (fake_call_method, fake_get_vif_info, fake_get_network_device,
+              fake_set_net_device_backing):
+            vif_info = [{'mac_address': 'fake-mac-0'},
+                        {'mac_address': 'fake-mac-999'}]
+            vm_ref = 'fake-ref'
+            network_info = ['fake-net']
+            hardware_devices = ['fake-hw-device']
+            image_meta = mock.MagicMock(properties={'fake-meta': 'fake-meta'})
+            fake_get_vif_info.return_value = vif_info
+            fake_call_method.return_value = hardware_devices
+            # For one of the mac addresses we couldn't find a network device
+            fake_get_network_device.side_effect = ['fake-device', None]
+
+            self.assertRaises(exception.NotFound,
+                              self._vmops._get_network_device_change,
+                              vm_ref, image_meta, network_info)
+
+            fake_get_network_device.assert_has_calls([
+                mock.call(hardware_devices, vif_info[0]['mac_address']),
+                mock.call(hardware_devices, vif_info[1]['mac_address'])
+            ])
+
+            fake_set_net_device_backing.assert_called_once_with(
+                self._session.vim.client.factory, 'fake-device', vif_info[0])
+
+    @mock.patch.object(ds_util, 'get_datastore')
+    @mock.patch.object(images, 'get_vsphere_location')
+    @mock.patch.object(vmops.VMwareVMOps, "_get_vm_networking_spec")
     @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid')
     @mock.patch.object(vmops.VMwareVMOps, '_resize_create_ephemerals_and_swap')
     @mock.patch.object(vmops.VMwareVMOps, "_remove_ephemerals_and_swap")
-    @mock.patch.object(vm_util, 'get_vmdk_info')
     @mock.patch.object(vmops.VMwareVMOps, "_resize_disk")
     @mock.patch.object(vmops.VMwareVMOps, "_resize_vm")
-    @mock.patch.object(vm_util, 'power_on_instance')
+    @mock.patch.object(vmops.VMwareVMOps, "update_cluster_placement")
+    @mock.patch.object(vmops.VMwareVMOps, "disable_drs_if_needed")
     @mock.patch.object(vmops.VMwareVMOps, "_update_instance_progress")
-    @mock.patch.object(vm_util, 'get_vm_ref', return_value='fake-ref')
+    @mock.patch.object(vm_util, 'power_on_instance')
+    @mock.patch.object(vm_util, "reconfigure_vm")
+    @mock.patch.object(vm_util, 'get_vm_ref',
+                       return_value='fake-ref')
     def test_finish_migration_root_block_device(self, fake_get_vm_ref,
-                                                fake_progress, fake_power_on,
+                                                fake_reconfiugre_vm,
+                                                fake_power_on,
+                                                fake_progress,
+                                                fake_disable_drs_if_needed,
+                                                fake_update_cluster_placement,
                                                 fake_resize_vm,
                                                 fake_resize_disk,
-                                                fake_get_vmdk_info,
                                                 fake_remove_eph_and_swap,
                                                 fake_resize_create_eph_swap,
-                                                fake_bdm_get_by_instance_uuid):
+                                                fake_bdm_get_by_instance_uuid,
+                                                fake_get_vm_networking_spec,
+                                                fake_get_vsphere_location,
+                                                fake_get_datastore):
+        fake_get_datastore.return_value = self._ds
+        vm_ref = fake_get_vm_ref.return_value
         # shrinking the root-disk should be ignored
         bdms = objects.block_device.block_device_make_list_from_dicts(
             self._context, [
@@ -1314,32 +1675,33 @@ class VMwareVMOpsTestCase(test.TestCase):
         fake_bdm_get_by_instance_uuid.return_value = bdms
 
         migration = objects.Migration(source_compute="nova",
-                                      dest_compute="nova")
+                                      dest_compute="nova",
+                                      uuid=uuidsentinel.migration)
+        network_info = []
         self._vmops.finish_migration(context=self._context,
                                      migration=migration,
                                      instance=self._instance,
                                      disk_info=None,
-                                     network_info=None,
+                                     network_info=network_info,
                                      block_device_info=None,
                                      resize_instance=True,
                                      image_meta=self._image_meta,
                                      power_on=True)
-        fake_get_vm_ref.assert_called_once_with(self._session,
-                                                self._instance)
+        fake_get_vm_ref.assert_called_once_with(self._session, self._instance)
         fake_resize_create_eph_swap.assert_called_once_with(
-            'fake-ref', self._instance, None)
-        fake_remove_eph_and_swap.assert_called_once_with('fake-ref')
-        fake_power_on.assert_called_once_with(self._session, self._instance,
-                                              vm_ref='fake-ref')
+            vm_ref, self._instance, None)
+        fake_remove_eph_and_swap.assert_called_once_with(vm_ref)
+        fake_power_on.assert_called_once_with(self._session, self._instance)
         fake_resize_vm.assert_called_once_with(self._context, self._instance,
-                                               'fake-ref',
+                                               vm_ref,
                                                self._instance.flavor,
                                                self._image_meta)
-        fake_get_vmdk_info.assert_not_called()
+        fake_get_vm_networking_spec.assert_called_once_with(self._instance,
+            network_info)
         fake_resize_disk.assert_not_called()
         calls = [mock.call(self._context, self._instance, step=i,
                            total_steps=vmops.RESIZE_TOTAL_STEPS)
-                 for i in range(2, 7)]
+                 for i in range(5, 10)]
         fake_progress.assert_has_calls(calls)
 
     @mock.patch.object(vutil, 'WithRetrieval')
@@ -3464,3 +3826,9 @@ class VMwareVMOpsTestCase(test.TestCase):
                                 swap=33550336,
                                 extra_specs=flavor_extra_specs)
         return image_meta, flavor
+
+    def test_get_host_ip_addr(self):
+        encoded = self._vmops.get_host_ip_addr()
+        expected = '1.0|{}'.format(uuidsentinel.vcenter)
+
+        self.assertEqual(expected, encoded)

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -160,6 +160,7 @@ class VMwareVCDriver(driver.ComputeDriver):
                                         virtapi,
                                         self._volumeops,
                                         self._cluster_ref,
+                                        self._vcenter_uuid,
                                         datastore_regex=self._datastore_regex,
                                         datastore_hagroup_regex=
                                             self._datastore_hagroup_regex)
@@ -174,7 +175,7 @@ class VMwareVCDriver(driver.ComputeDriver):
 
         virtapi._compute.additional_endpoints.extend([
             special_spawning._SpecialVmSpawningServer(self),
-            VmwareRpcService(self)])
+            VmwareRpcService(self._vmops)])
 
     def _check_min_version(self):
         min_version = v_utils.convert_version_to_int(constants.MIN_VC_VERSION)
@@ -287,12 +288,13 @@ class VMwareVCDriver(driver.ComputeDriver):
         off the instance before the end.
         """
         # TODO(PhilDay): Add support for timeout (clean shutdown)
-        return self._vmops.migrate_disk_and_power_off(context, instance,
-                                                      dest, flavor)
+        return self._vmops.migrate_disk_and_power_off(
+            context, instance, dest, flavor, network_info, block_device_info)
 
     def confirm_migration(self, context, migration, instance, network_info):
         """Confirms a resize, destroying the source VM."""
-        self._vmops.confirm_migration(migration, instance, network_info)
+        self._vmops.confirm_migration(context, migration, instance,
+                                      network_info)
 
     def finish_revert_migration(self, context, instance, network_info,
                                 block_device_info=None, power_on=True):
@@ -561,7 +563,7 @@ class VMwareVCDriver(driver.ComputeDriver):
 
     def get_host_ip_addr(self):
         """Returns the IP address of the vCenter host."""
-        return CONF.vmware.host_ip
+        return self._vmops.get_host_ip_addr()
 
     def snapshot(self, context, instance, image_id, update_task_state):
         """Create snapshot from a running VM instance."""
@@ -586,10 +588,7 @@ class VMwareVCDriver(driver.ComputeDriver):
             for disk in block_device_mapping:
                 connection_info = disk['connection_info']
                 try:
-                    # NOTE(claudiub): Passing None as the context, as it is
-                    # not currently used.
-                    self.detach_volume(None, connection_info, instance,
-                                       disk.get('device_name'))
+                    self._volumeops.detach_volume(connection_info, instance)
                 except exception.DiskNotFound:
                     LOG.warning('The volume %s does not exist!',
                                 disk.get('device_name'),
@@ -612,10 +611,15 @@ class VMwareVCDriver(driver.ComputeDriver):
         if not instance.node:
             return
 
-        # A resize uses the same instance on the VC. We do not delete that
-        # VM in the event of a revert
+        # While resize_reverting, we use the special vm name to identify the
+        # temporary vm, so we need to use the correct vm_ref for destroying it.
         if instance.task_state == task_states.RESIZE_REVERTING:
-            return
+            vm_ref = vm_util.get_vm_ref(self._session, instance)
+            vm_name = vm_util.get_vm_name(self._session, vm_ref)
+            if vm_name != instance.uuid:
+                # This is an older migration that doesn't have a clone.
+                # By reverting it, we shouldn't destroy the VM.
+                return
 
         # We need to detach attached volumes
         if block_device_info is not None:

--- a/nova/virt/vmwareapi/error_util.py
+++ b/nova/virt/vmwareapi/error_util.py
@@ -41,3 +41,8 @@ class PbmDefaultPolicyUnspecified(exception.Invalid):
 
 class PbmDefaultPolicyDoesNotExist(exception.NovaException):
     msg_fmt = _("The default PBM policy doesn't exist on the backend.")
+
+
+class InvalidHostAddrFormat(exception.NovaException):
+    msg_fmt = _("The provided host address couldn't be recognised as a valid "
+                "format supported by the VMwareVCDriver.")

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -839,6 +839,64 @@ def get_hardware_devices(session, vm_ref):
     return vim_util.get_array_items(hardware_devices)
 
 
+def _in_boot_order(disk1, disk2):
+    return (disk2.controllerKey > disk1.controllerKey
+        or disk2.controllerKey == disk2.controllerKey
+        and disk2.unitNumber > disk1.unitNumber)
+
+
+def get_hardware_devices_by_type(session, vm_ref):
+    nics = {}
+    controllers = {}
+    disks = {}
+    swap = []
+    ephemeral = []
+    first_device = None
+
+    for device in get_hardware_devices(session, vm_ref):
+        device_type = device.__class__.__name__
+        if device_type in ALL_SUPPORTED_NETWORK_DEVICES:
+            mac_address = getattr(device, 'macAddress', None)
+            if not mac_address:
+                LOG.warning("Could not ge mac address of NIC {}", device.key)
+                continue
+            if mac_address in nics:
+                LOG.warning("Multiple NICs with the same MAC")
+                continue
+
+            nics[mac_address] = device
+        elif device_type in CONTROLLER_TO_ADAPTER_TYPE:
+            controllers[int(device.key)] = device
+        elif device_type == "VirtualDisk":
+            backing_type = device.backing.__class__.__name__
+            if backing_type == "VirtualDiskFlatVer2BackingInfo":
+                if "swap" in device.backing.fileName:
+                    swap.append(device)
+                elif "ephemeral" in device.backing.fileName:
+                    ephemeral.append(device)
+                else:
+                    if not first_device or not _in_boot_order(first_device,
+                                                              device):
+                        first_device = device
+                    uuid = getattr(device.backing, "uuid", None)
+                    if not uuid:
+                        LOG.warning("Failed to get uuid from device {}",
+                                    device.key)
+                        continue
+                    disks[uuid.lower()] = device
+            elif backing_type == "VirtualDiskRawDiskMappingVer1BackingInfo":
+                disks[device.backing.lunUuid.lower()] = device
+
+    return {
+        "nics": nics,
+        "controllers": controllers,
+        "swap": swap,
+        "ephemeral": ephemeral,
+        "disks": disks,
+        "root_device": first_device
+    }
+
+
 def get_vmdk_info(session, vm_ref):
     """Returns information for the first VMDK attached to the given VM."""
     vmdk_file_path = None
@@ -852,10 +910,8 @@ def get_vmdk_info(session, vm_ref):
         if device.__class__.__name__ == "VirtualDisk":
             if device.backing.__class__.__name__ == \
                     "VirtualDiskFlatVer2BackingInfo":
-                if not first_device \
-                    or first_device.controllerKey > device.controllerKey \
-                    or first_device.controllerKey == device.controllerKey \
-                        and first_device.unitNumber > device.unitNumber:
+                if first_device is None or not _in_boot_order(first_device,
+                                                              device):
                     first_device = device
         elif device.__class__.__name__ in CONTROLLER_TO_ADAPTER_TYPE:
             adapter_type_dict[device.key] = CONTROLLER_TO_ADAPTER_TYPE[
@@ -1362,6 +1418,15 @@ def get_vm_state(session, instance):
     vm_state = session._call_method(vutil, "get_object_property",
                                     vm_ref, "runtime.powerState")
     return constants.POWER_STATES[vm_state]
+
+
+def get_vm_name(session, vm_ref):
+    return get_object_property(session, vm_ref, "name")
+
+
+def get_object_property(session, mo_ref, property):
+    return session._call_method(vutil, "get_object_property",
+                                mo_ref, property)
 
 
 def _set_host_reservations(stats, host_reservations_map, host_moref):
@@ -1937,7 +2002,11 @@ def get_vm_detach_port_index(session, vm_ref, iface_id):
 
 
 def power_off_instance(session, instance, vm_ref=None):
-    """Power off the specified instance."""
+    """Power off the specified instance.
+
+    Returns True if the VM was powered off by this call, or False
+    of the VM was already powered off.
+    """
 
     if vm_ref is None:
         vm_ref = get_vm_ref(session, instance)
@@ -1948,8 +2017,10 @@ def power_off_instance(session, instance, vm_ref=None):
                                          "PowerOffVM_Task", vm_ref)
         session._wait_for_task(poweroff_task)
         LOG.debug("Powered off the VM", instance=instance)
+        return True
     except vexc.InvalidPowerStateException:
         LOG.debug("VM already powered off", instance=instance)
+        return False
 
 
 def find_rescue_device(hardware_devices, instance):
@@ -2055,8 +2126,8 @@ def _get_vm_name(display_name, id_):
     return id_[:36]
 
 
-def rename_vm(session, vm_ref, instance):
-    vm_name = _get_vm_name(instance.display_name, instance.uuid)
+def rename_vm(session, vm_ref, instance, vm_name=None):
+    vm_name = vm_name or _get_vm_name(instance.display_name, instance.uuid)
     rename_task = session._call_method(session.vim, "Rename_Task", vm_ref,
                                        newName=vm_name)
     session._wait_for_task(rename_task)
@@ -2117,3 +2188,16 @@ def create_service_locator(client_factory, url, vcenter_instance_uuid,
     sl.credential = credential
     sl.sslThumbprint = ssl_thumbprint
     return sl
+
+
+def reconfigure_vm_device_change(session, vm_ref, device_change):
+    """Reconfigure a VM to add/edit/remove devices.
+
+    The device_change should be a VirtualDeviceConfigSpec.
+    """
+    if not device_change:
+        return
+    client_factory = session.vim.client.factory
+    config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
+    config_spec.deviceChange = device_change
+    reconfigure_vm(session, vm_ref, config_spec)

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -21,13 +21,16 @@ Class for VM tasks like spawn, snapshot, suspend, resume etc.
 
 import collections
 import copy
-import decorator
 import itertools
 import math
+from operator import itemgetter
 import os
 import re
-import six
+import sys
 import time
+
+import decorator
+import six
 
 from oslo_concurrency import lockutils
 from oslo_log import log as logging
@@ -75,7 +78,8 @@ CONF = nova.conf.CONF
 
 LOG = logging.getLogger(__name__)
 
-RESIZE_TOTAL_STEPS = 7
+RESIZE_TOTAL_STEPS = 11
+HOST_IP_ADDR_SEPARATOR = "|"
 
 
 class VirtualMachineInstanceConfigInfo(object):
@@ -135,17 +139,39 @@ def retry_if_task_in_progress(f, *args, **kwargs):
             pass
 
 
+@decorator.decorator
+def log_exception(f, except_=None, *args, **kwargs):
+    try:
+        return f(*args, **kwargs)
+    except Exception as e:
+        if not except_ or not isinstance(e, except_):
+            LOG.exception("Unexpected exception")
+        six.reraise(*sys.exc_info())
+
+
 class VMwareVMOps(object):
     """Management class for VM-related tasks."""
 
+    """Version that ensures the consistency of the migration logic.
+
+    During the cold migration (_migrate_disk_and_power_off) the source host
+    performs some calls on the destination vCenter service, for which we
+    expect that the destination compute host would behave the same. For
+    migrations where we receive a different migration_version, we must reject
+    and throw an error.
+    """
+    MIGRATION_VERSION = "1.0"
+
     def __init__(self, session, virtapi, volumeops, cluster=None,
-                 datastore_regex=None, datastore_hagroup_regex=None):
+                 vcenter_uuid=None, datastore_regex=None,
+                 datastore_hagroup_regex=None):
         """Initializer."""
         self.compute_api = compute.API()
         self._session = session
         self._virtapi = virtapi
         self._volumeops = volumeops
         self._cluster = cluster
+        self._vcenter_uuid = vcenter_uuid
         self._property_collector = None
         self._property_collector_version = ''
         self._root_resource_pool = vm_util.get_res_pool_ref(self._session,
@@ -335,6 +361,30 @@ class VMwareVMOps(object):
                                                  vm_name=vm_name)
 
         return config_spec
+
+    def get_host_ip_addr(self):
+        data = [
+            self.MIGRATION_VERSION,
+            self._vcenter_uuid
+        ]
+        return HOST_IP_ADDR_SEPARATOR.join(data)
+
+    @staticmethod
+    def _decode_host_addr(encoded_addr):
+        parts = encoded_addr.split(HOST_IP_ADDR_SEPARATOR)
+        try:
+            return {'migration_version': parts[0],
+                    'vcenter_uuid': parts[1]}
+        except Exception as error:
+            LOG.error("Failed to decode the host address: %s", error)
+            raise error_util.InvalidHostAddrFormat()
+
+    def _is_in_place_migration(self, migration):
+        try:
+            self._decode_host_addr(migration.dest_host)
+            return False
+        except error_util.InvalidHostAddrFormat:
+            return True
 
     def build_virtual_machine(self, instance, context, image_info, datastore,
                               network_info, extra_specs, metadata, vm_folder,
@@ -2200,10 +2250,31 @@ class VMwareVMOps(object):
         self._create_swap(block_device_info, instance, vm_ref, dc_info,
                           datastore, folder, vmdk.adapter_type)
 
-    def migrate_disk_and_power_off(self, context, instance, dest, flavor):
+    @log_exception(except_=exception.InstanceFaultRollback)
+    def migrate_disk_and_power_off(self, context, instance, dest, flavor,
+                                   network_info, block_device_info):
         """Transfers the disk of a running instance in multiple phases, turning
         off the instance before the end.
         """
+        try:
+            decoded = self._decode_host_addr(dest)
+        except error_util.InvalidHostAddrFormat:
+            message = ("Can't migrate to the destination host because its "
+                       "information couldn't be understood. Probably it is "
+                       "an older version of VMwareVCDriver which doesn't "
+                       "support cross-host migration.")
+            raise exception.InstanceFaultRollback(
+                exception.MigrationError(message=message))
+
+        if decoded['migration_version'] != self.MIGRATION_VERSION:
+            message = ("Can't migrate to the destination host because of "
+                       "version mismatch. Current version is %(source)s but "
+                       "the destination host has %(dest)s") % {
+                          'source': self.MIGRATION_VERSION,
+                          'dest': decoded['migration_version']}
+            raise exception.InstanceFaultRollback(
+                exception.MigrationError(message=message))
+
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
 
@@ -2224,13 +2295,34 @@ class VMwareVMOps(object):
                                        step=0,
                                        total_steps=RESIZE_TOTAL_STEPS)
 
+        # Ensure the VM is named as expected (and not just the instance uuid)
+        vm_util.rename_vm(self._session, vm_ref, instance)
+
         # 1. Power off the instance
-        vm_util.power_off_instance(self._session, instance, vm_ref)
+        vm_was_on = vm_util.power_off_instance(self._session, instance,
+                                               vm_ref)
+
         self._update_instance_progress(context, instance,
                                        step=1,
                                        total_steps=RESIZE_TOTAL_STEPS)
 
+        try:
+            return self._do_migrate_disk_and_power_off(context, instance,
+                decoded, flavor, network_info, block_device_info)
+        except Exception as e:
+            LOG.exception("Failed to _do_migrate_disk_and_power_off")
+            hardware = vm_util.get_hardware_devices_by_type(self._session,
+                vm_ref)
+
+            self._do_finish_revert_migration(context, instance,
+                block_device_info, network_info, vm_ref, hardware)
+
+            if vm_was_on:
+                vm_util.power_on_instance(self._session, instance)
+            raise exception.InstanceFaultRollback(e)
+
     def get_vif_info(self, ctxt, vif_model=None, network_info=None):
+        """ctxt is only there to provide the same signature as rpc calls"""
         vif_info = vmwarevif.get_vif_info(self._session,
                                           self._cluster,
                                           utils.is_neutron(),
@@ -2244,8 +2336,61 @@ class VMwareVMOps(object):
 
         return VmwareRpcApi(migration.dest_compute)
 
-    def confirm_migration(self, migration, instance, network_info):
+    def confirm_migration(self, context, migration, instance, network_info):
         """Confirms a resize, destroying the source VM."""
+        # To ensure compatibility with unfinished migrations with the previous
+        # code, we check the version of the migration and call the appropriate
+        # function for the kind of migration.
+        if self._is_in_place_migration(migration):
+            self._do_confirm_in_place_migration(instance)
+        else:
+            self._do_confirm_migration(context, instance, migration)
+
+    def _do_migrate_disk_and_power_off(self, context, instance, dest, flavor,
+                                       network_info, block_device_info):
+        source_vm_ref = vm_util.get_vm_ref(self._session, instance)
+        # 2. Detach the volumes
+        self._detach_volumes(instance, block_device_info)
+
+        self._update_instance_progress(context, instance,
+                                       step=2,
+                                       total_steps=RESIZE_TOTAL_STEPS)
+
+        # 3. Detach network interfaces
+        device_change = self._get_remove_network_device_change(source_vm_ref)
+
+        vm_util.reconfigure_vm_device_change(self._session, source_vm_ref,
+                                             device_change)
+        self._update_instance_progress(context, instance,
+                                       step=3,
+                                       total_steps=RESIZE_TOTAL_STEPS)
+
+        # 4. Copy the VM to the dest
+        self._do_migrate_disk(context, source_vm_ref, instance, dest, flavor)
+        self._update_instance_progress(context, instance,
+                                       step=4,
+                                       total_steps=RESIZE_TOTAL_STEPS)
+
+    def _do_confirm_migration(self, context, instance, migration):
+        original_vm_ref = vm_util.search_vm_ref_by_identifier(self._session,
+                                                              migration.uuid)
+        if not original_vm_ref:
+            LOG.warning(("Cannot find source vm for instance {}"
+                         " in migration {}").format(
+                         instance.uuid, migration.uuid), instance=instance)
+            # We do not want to call destroy without an explicit vm-ref,
+            # as that will fall back to destroying now active vm
+        else:
+            vm_util.destroy_vm(self._session, instance, original_vm_ref)
+        target = self.api_for_migration(migration)
+        target.confirm_migration_destination(context, instance)
+
+    def confirm_migration_destination(self, context, instance):
+        # Set the final name to the VM
+        vm_ref = vm_util.get_vm_ref(self._session, instance)
+        vm_util.rename_vm(self._session, vm_ref, instance)
+
+    def _do_confirm_in_place_migration(self, instance):
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
         if not vmdk.device:
@@ -2291,6 +2436,60 @@ class VMwareVMOps(object):
     def finish_revert_migration(self, context, instance, network_info,
                                 block_device_info, power_on=True):
         """Finish reverting a resize."""
+        # This DB call can be removed in Train, when the migration object will
+        # be passed as parameter.
+        migration = objects.Migration.get_by_id_and_instance(
+            context, instance.migration_context.migration_id,
+            instance.uuid)
+
+        # To ensure compatibility with unfinished migrations with the previous
+        # code, we check the version of the migration and call the appropriate
+        # function for the kind of migration.
+        if self._is_in_place_migration(migration):
+            self._do_finish_revert_in_place_migration(
+                context, instance, block_device_info, network_info)
+        else:
+            # This is the new
+            vm_ref = vm_util.search_vm_ref_by_identifier(self._session,
+                                                         migration.uuid)
+            self._do_finish_revert_migration(context, instance,
+                                             block_device_info,
+                                             network_info, vm_ref)
+
+        if power_on:
+            vm_util.power_on_instance(self._session, instance)
+
+    def _do_finish_revert_migration(self, context, instance,
+                                    block_device_info, network_info,
+                                    vm_ref, existing_hardware=None):
+        """Adds networking and volumes back to an instance.
+
+        This is being used when a user reverts a migration, or when the
+        driver rolls back a failed migration in _migrate_disk_and_power_off()
+        """
+        # First we change the uuid back, so that the VM can be found again
+        if network_info and existing_hardware:
+            nics = existing_hardware["nics"]
+            network_info = [vif for vif in network_info
+                            if vif['address'] not in nics]
+        config_spec = self._get_vm_networking_spec(instance, network_info)
+        config_spec.instanceUuid = instance.uuid
+        vm_util.reconfigure_vm(self._session, vm_ref, config_spec)
+        vm_util.vm_ref_cache_update(instance.uuid, vm_ref)
+        self._update_vnic_index(context, instance, network_info)
+
+        # Now the disks
+        disks = existing_hardware["disks"] if existing_hardware else {}
+        vi = self._get_instance_config_info(context, instance)
+        self._attach_volumes(instance, block_device_info, vi.ii.adapter_type,
+                             existing_disks=disks)
+        # Finally, we rename the VM so that we can discriminate between
+        # incompletely and completely configured vms by the naming scheme
+        # (as it is during instance creation)
+        vm_util.rename_vm(self._session, vm_ref, instance)
+
+    def _do_finish_revert_in_place_migration(self, context, instance,
+                                             block_device_info, network_info):
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         # Ensure that the VM is off
         vm_util.power_off_instance(self._session, instance, vm_ref)
@@ -2332,9 +2531,6 @@ class VMwareVMOps(object):
             finally:
                 self._attach_volumes(instance, block_device_info, adapter_type)
 
-        if power_on:
-            vm_util.power_on_instance(self._session, instance)
-
     def finish_migration(self, context, migration, instance, disk_info,
                          network_info, image_meta, resize_instance=False,
                          block_device_info=None, power_on=True):
@@ -2344,70 +2540,85 @@ class VMwareVMOps(object):
         flavor = instance.flavor
         boot_from_volume = compute_utils.is_volume_backed_instance(context,
                                                                    instance)
-        reattach_volumes = False
-        # 2. Relocate the VM if necessary
-        # If the dest_compute is different from the source_compute, it means we
-        # need to relocate the VM here since we are running on the dest_compute
-        if migration.source_compute != migration.dest_compute:
-            # Get the root disk vmdk object's adapter type
-            vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
-            adapter_type = vmdk.adapter_type
 
-            self._detach_volumes(instance, block_device_info)
-            reattach_volumes = True
-            LOG.debug("Relocating VM for migration to %s",
-                      migration.dest_compute, instance=instance)
-            try:
-                self._relocate_vm(vm_ref, context, instance, network_info,
-                                  image_meta)
-                LOG.debug("Relocated VM to %s", migration.dest_compute,
-                          instance=instance)
-            except Exception as e:
-                with excutils.save_and_reraise_exception():
-                    LOG.error("Relocating the VM failed with error: %s", e,
-                              instance=instance)
-                    self._attach_volumes(instance, block_device_info,
-                                         adapter_type)
-
-            self.update_cluster_placement(context, instance)
-            self.disable_drs_if_needed(instance)
-
-        self._update_instance_progress(context, instance,
-                                       step=2,
-                                       total_steps=RESIZE_TOTAL_STEPS)
-        # 3.Reconfigure the VM and disk
-        self._resize_vm(context, instance, vm_ref, flavor, image_meta)
-        if not boot_from_volume and resize_instance:
-            vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
-            self._resize_disk(instance, vm_ref, vmdk, flavor)
-        self._update_instance_progress(context, instance,
-                                       step=3,
-                                       total_steps=RESIZE_TOTAL_STEPS)
-
-        # 4. Purge ephemeral and swap disks
-        self._remove_ephemerals_and_swap(vm_ref)
-        self._update_instance_progress(context, instance,
-                                       step=4,
-                                       total_steps=RESIZE_TOTAL_STEPS)
-        # 5. Update ephemerals
-        self._resize_create_ephemerals_and_swap(vm_ref, instance,
-                                                block_device_info)
+        # 4. Reconfigure the VM and disk
         self._update_instance_progress(context, instance,
                                        step=5,
                                        total_steps=RESIZE_TOTAL_STEPS)
+        self._resize_vm(context, instance, vm_ref, flavor, image_meta)
 
-        # 6. Attach the volumes (if necessary)
-        if reattach_volumes:
-            self._attach_volumes(instance, block_device_info, adapter_type)
+        if not boot_from_volume and resize_instance:
+            vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
+            self._resize_disk(instance, vm_ref, vmdk, flavor)
+
+        # 5. Purge ephemeral and swap disks
         self._update_instance_progress(context, instance,
                                        step=6,
                                        total_steps=RESIZE_TOTAL_STEPS)
-        # 7. Start VM
-        if power_on:
-            vm_util.power_on_instance(self._session, instance, vm_ref=vm_ref)
+        self._remove_ephemerals_and_swap(vm_ref)
+
+        # 6. Update ephemerals
         self._update_instance_progress(context, instance,
                                        step=7,
                                        total_steps=RESIZE_TOTAL_STEPS)
+        self._resize_create_ephemerals_and_swap(vm_ref, instance,
+                                                block_device_info)
+        # 7. Attach the volumes
+        self._update_instance_progress(context, instance,
+                                       step=8,
+                                       total_steps=RESIZE_TOTAL_STEPS)
+
+        vi = self._get_instance_config_info(context, instance, image_meta)
+        self._attach_volumes(instance, block_device_info, vi.ii.adapter_type)
+
+        # 8. Create the networking
+        self._update_instance_progress(context, instance,
+                                       step=9,
+                                       total_steps=RESIZE_TOTAL_STEPS)
+        config_spec = self._get_vm_networking_spec(instance, network_info)
+        vm_util.reconfigure_vm(self._session, vm_ref, config_spec)
+        self._update_vnic_index(context, instance, network_info)
+
+        # 9. Update DRS
+        self._update_instance_progress(context, instance,
+                                       step=10,
+                                       total_steps=RESIZE_TOTAL_STEPS)
+        self.update_cluster_placement(context, instance)
+        self.disable_drs_if_needed(instance)
+
+        # 10. Start VM
+        client_factory = self._session.vim.client.factory
+        # Set the machine.id parameter of the instance to inject
+        # the NIC configuration inside the VM
+        if CONF.flat_injected:
+            self._set_machine_id(client_factory, instance, network_info,
+                                 vm_ref=vm_ref)
+
+        # Set the vnc configuration of the instance, vnc port starts from 5900
+        if CONF.vnc.enabled:
+            self._get_and_set_vnc_config(client_factory, instance, vm_ref)
+
+        self._update_instance_progress(context, instance,
+                                       step=11,
+                                       total_steps=RESIZE_TOTAL_STEPS)
+
+        if power_on:
+            vm_util.power_on_instance(self._session, instance)
+
+    def _get_vm_networking_spec(self, instance, network_info):
+        client_factory = self._session.vim.client.factory
+        config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
+        extra_specs = self._get_extra_specs(instance.flavor,
+                                            instance.image_meta)
+        vif_model = instance.image_meta.properties.get('hw_vif_model',
+            constants.DEFAULT_VIF_MODEL)
+
+        vm_util.append_vif_infos_to_config_spec(
+            client_factory,
+            config_spec,
+            self.get_vif_info(None, vif_model, network_info),
+            extra_specs.vif_limits)
+        return config_spec
 
     def _relocate_vm(self, vm_ref, context, instance, network_info,
                      image_meta=None):
@@ -2431,36 +2642,43 @@ class VMwareVMOps(object):
                                         res_pool=self._root_resource_pool,
                                         folder=folder, datastore=datastore.ref)
 
-        # Iterate over the network adapters and update the backing
-        if network_info:
-            spec.deviceChange = []
-            vif_model = image_meta.properties.get('hw_vif_model',
-                                                  constants.DEFAULT_VIF_MODEL)
-            hardware_devices = vm_util.get_hardware_devices(self._session,
-                                                            vm_ref)
-            vif_infos = vmwarevif.get_vif_info(self._session,
-                                               self._cluster,
-                                               utils.is_neutron(),
-                                               vif_model,
-                                               network_info)
-            for vif_info in vif_infos:
-                device = vmwarevif.get_network_device(hardware_devices,
-                                                      vif_info['mac_address'])
-                if not device:
-                    msg = _("No device with MAC address %s exists on the "
-                            "VM") % vif_info['mac_address']
-                    raise exception.NotFound(msg)
-
-                # Update the network device backing
-                config_spec = client_factory.create(
-                    'ns0:VirtualDeviceConfigSpec')
-                vm_util.set_net_device_backing(
-                    client_factory, device, vif_info)
-                config_spec.operation = "edit"
-                config_spec.device = device
-                spec.deviceChange.append(config_spec)
-
+        spec.deviceChange = self._get_network_device_change(vm_ref,
+                                                            image_meta,
+                                                            network_info)
         vm_util.relocate_vm(self._session, vm_ref, spec=spec)
+
+    def _get_network_device_change(self, vm_ref, image_meta, network_info):
+        device_changes = []
+        if not network_info:
+            return device_changes
+
+        # Iterate over the network adapters and update the backing
+        vif_model = image_meta.properties.get('hw_vif_model',
+                                                constants.DEFAULT_VIF_MODEL)
+        hardware_devices = vm_util.get_hardware_devices(self._session, vm_ref)
+        vif_infos = vmwarevif.get_vif_info(self._session,
+                                           self._cluster,
+                                           utils.is_neutron(),
+                                           vif_model,
+                                           network_info)
+        client_factory = self._session.vim.client.factory
+
+        for vif_info in vif_infos:
+            device = vmwarevif.get_network_device(hardware_devices,
+                                                    vif_info['mac_address'])
+            if not device:
+                msg = _("No device with MAC address %s exists on the "
+                        "VM") % vif_info['mac_address']
+                raise exception.NotFound(msg)
+
+            # Update the network device backing
+            config_spec = client_factory.create('ns0:VirtualDeviceConfigSpec')
+            vm_util.set_net_device_backing(client_factory, device, vif_info)
+            config_spec.operation = "edit"
+            config_spec.device = device
+            device_changes.append(config_spec)
+
+        return device_changes
 
     def live_migration(self, instance, migrate_data, volume_mapping):
         defaults = migrate_data.relocate_defaults
@@ -2530,20 +2748,161 @@ class VMwareVMOps(object):
         vm_util.relocate_vm(self._session, vm_ref, spec=relocate_spec)
 
     def _detach_volumes(self, instance, block_device_info):
-        block_devices = driver.block_device_info_get_mapping(block_device_info)
-        for disk in block_devices:
-            self._volumeops.detach_volume(disk['connection_info'], instance)
-
-    def _attach_volumes(self, instance, block_device_info, adapter_type):
         disks = driver.block_device_info_get_mapping(block_device_info)
-        # make sure the disks are attached by the boot_index order (if any)
+        # Detach the volumes in reverse order, so if we roll it back
+        # that the device order will still be preserved
         for disk in sorted(disks,
-                           key=lambda d: d['boot_index']
-                           if 'boot_index' in d and d['boot_index'] > -1
-                           else len(disks)):
+                           reverse=True,
+                           key=itemgetter('mount_device')):
+            try:
+                self._volumeops.detach_volume(disk['connection_info'],
+                                              instance)
+            except exception.DiskNotFound:
+                LOG.warning(("Cannot find disk {}."
+                             " Assuming it to be removed").format(disk))
+
+    def _attach_volumes(self, instance, block_device_info, adapter_type,
+                        existing_disks=None):
+        disks = driver.block_device_info_get_mapping(block_device_info)
+        # make sure the disks are attached by the device_name order
+        for disk in sorted(disks,
+                           key=itemgetter('mount_device')):
+            if existing_disks and disk['volume_id'] in existing_disks:
+                continue
+
             adapter_type = disk.get('disk_bus') or adapter_type
             self._volumeops.attach_volume(disk['connection_info'], instance,
                                           adapter_type)
+
+    def _get_remove_network_device_change(self, vm_ref):
+        device_change = []
+        for device in vm_util.get_hardware_devices(self._session, vm_ref):
+            if (device.__class__.__name__
+                    not in vm_util.ALL_SUPPORTED_NETWORK_DEVICES):
+                continue
+            # Update the network device backing
+            config_spec = self._session.vim.client.factory.create(
+                'ns0:VirtualDeviceConfigSpec')
+            config_spec.operation = "remove"
+            config_spec.device = device
+            device_change.append(config_spec)
+        return device_change
+
+    def get_relocate_spec(self, context, instance, flavor,
+                          factory=None, remote=False):
+        session = self._session
+        cluster = self._cluster
+
+        if not remote:
+            disk_move_type = "moveAllDiskBackingsAndAllowSharing"
+            service_spec = None
+        else:
+            # For migration to other vCenter service the disk_move_type
+            # needs to be moveAllDiskBackingsAndDisallowSharing
+            disk_move_type = "moveAllDiskBackingsAndDisallowSharing"
+            service_spec = self._get_service_locator_spec()
+
+        image_meta = instance.image_meta
+        storage_policy = self._get_storage_policy(flavor)
+        allowed_ds_types = ds_util.get_allowed_datastore_types(
+            image_meta.properties.hw_disk_type)
+        res_pool = vm_util.get_res_pool_ref(session, cluster)
+        datastore = ds_util.get_datastore(session, cluster,
+                                          self._datastore_regex,
+                                          storage_policy,
+                                          allowed_ds_types)
+        dc_info = self.get_datacenter_ref_and_name(datastore.ref)
+        folder = self._get_project_folder(dc_info, instance.project_id,
+                                          'Instances')
+
+        factory = factory or session.vim.client.factory
+        rel_spec = vm_util.relocate_vm_spec(factory,
+                                            disk_move_type=disk_move_type,
+                                            res_pool=res_pool, folder=folder,
+                                            datastore=datastore.ref)
+        rel_spec.service = service_spec
+        return rel_spec
+
+    def change_vm_instance_uuid(self, context, instance, vm_ref, uuid=None):
+        # NOTE: the caller must take care that it is safe to assign the UUID
+        # to the VM. Calling this with an UUID that's already assigned to
+        # another VM will break NSX-T.
+        session = self._session
+        uuid = uuid or instance.uuid
+        cf = session.vim.client.factory
+        config_spec = cf.create('ns0:VirtualMachineConfigSpec')
+        config_spec.instanceUuid = uuid
+        config_spec.extraConfig = vm_util.create_extra_config(cf,
+            {'nvp.vm-uuid': uuid})  # Another way to identify the vm
+
+        vm_util.reconfigure_vm(session, vm_ref, config_spec)
+        if uuid != instance.uuid:
+            # After reconfigure to clear any cache update before it
+            vm_util.vm_ref_cache_delete(instance.uuid)
+        vm_util.vm_ref_cache_update(uuid, vm_ref)
+
+    def rollback_migrate_disk(self, context, instance, cloned_vm_ref):
+        return vm_util.destroy_vm(self._session, instance, cloned_vm_ref)
+
+    def _do_migrate_disk(self, context, vm_ref, instance, dest_data, flavor):
+        """Copies the VM to the destination by doing a clone.
+
+        If the destination is another vCenter service, it creates a new
+        VMwareAPISession to the destination vCenter service to gather the
+        needed info for cloning the vm: datastore, service locator, folder.
+        """
+
+        migration = objects.Migration.get_by_id_and_instance(
+            context, instance.migration_context.migration_id,
+            instance.uuid)
+
+        target = self.api_for_migration(migration)
+        factory = self._session.vim.client.factory
+        rel_spec = target.get_relocate_spec(context, instance, flavor,
+                                            factory=factory)
+
+        # We name the VM just by the instance.uuid to follow the same pattern
+        # as in the instance creation
+        # This causes the folder on the datastore to be named by the
+        # instance.uuid potentially with a suffix in case the source and
+        # destination are on the same datastore
+        cloned_vm = self._clone_vm(vm_ref, rel_spec, name=instance.uuid)
+        LOG.info("Cloned VM with temporary name '%s'", instance.uuid,
+                 instance=instance)
+        try:
+            # keep track of the old vm by assigning migration.uuid to it
+            self.change_vm_instance_uuid(context, instance, vm_ref,
+                                         uuid=migration.uuid)
+
+            target.change_vm_instance_uuid(context, instance, cloned_vm)
+        except Exception:
+            with excutils.save_and_reraise_exception():
+                target.rollback_migrate_disk(context, instance, cloned_vm)
+
+        source_name = "{} (Mig {})".format(instance.uuid, migration.uuid)
+        vm_util.rename_vm(self._session, vm_ref, instance, vm_name=source_name)
+
+    def _get_service_locator_spec(self):
+        cf = self._session.vim.client.factory
+        url = "https://{}:{}".format(CONF.vmware.host_ip,
+                                     CONF.vmware.host_port)
+        credential = vm_util.create_service_locator_name_password(
+            cf, CONF.vmware.host_username, CONF.vmware.host_password)
+        return vm_util.create_service_locator(cf, url, self._vcenter_uuid,
+                                              credential)
+
+    def _clone_vm(self, vm_ref, rel_spec, name):
+        """Returns a MoRef of the newly-created VM"""
+        client_factory = self._session.vim.client.factory
+        clone_spec = vm_util.clone_vm_spec(client_factory, rel_spec)
+        vm_clone_task = self._session._call_method(self._session.vim,
+                                                   "CloneVM_Task",
+                                                   vm_ref,
+                                                   folder=rel_spec.folder,
+                                                   name=name,
+                                                   spec=clone_spec)
+        task_info = self._session._wait_for_task(vm_clone_task)
+        return task_info.result
 
     def poll_rebooting_instances(self, timeout, instances):
         """Poll for rebooting instances."""
@@ -2639,6 +2998,8 @@ class VMwareVMOps(object):
 
     @staticmethod
     def _get_machine_id_str(network_info):
+        if not network_info:
+            return
         machine_id_str = ''
         for vif in network_info:
             # TODO(vish): add support for dns2
@@ -3790,3 +4151,12 @@ class VMwareVMOps(object):
                                                        datastore.ref)
             LOG.debug("Moved instance %s in server-group %s to hagroup %s.",
                       instance.uuid, sg_uuid, hagroup)
+    def _get_instance_config_info(self, context, instance, image_meta=None):
+        """Returns VirtualMachineInstanceConfigInfo based on instance."""
+        image_meta = image_meta or instance.image_meta
+        image_info = images.VMwareImage.from_image(context,
+                                                   instance.image_ref,
+                                                   image_meta)
+        extra_specs = self._get_extra_specs(instance.flavor, image_meta)
+        return self._get_vm_config_info(context, instance, image_info,
+                                        extra_specs)


### PR DESCRIPTION
Prior to this, the driver was performing migration/resize in a
way that could lead a VM into an inconsistent state and wast not
following the way nova does the allocations during a migration.
Nova expects the driver to do the following steps
* mirate_disk_and_power_off() - copies the disk to the dest compute
* finish_resize() - powers up the VM in the dest compute
This change removes the RelocateVM_Task and introduces a new
CloneVM_Task instead, in migrate_disk_and_power_off().

Change-Id: I9d6f715faecc6782f93a3cd7f83f85f5ece02e60