### PR TITLE
vmware: Reserve memory for large VMs

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -363,7 +363,7 @@ class VMwareVMOps(object):
                     setattr(getattr(extra_specs, resource + '_limits'),
                             key, type(value))
         if CONF.vmware.reserve_all_memory \
-                or utils.is_big_vm(int(flavor.memory_mb), flavor):
+                or utils.is_large_vm(int(flavor.memory_mb), flavor):
             extra_specs.memory_limits.reservation = int(flavor.memory_mb)
         else:
             try:


### PR DESCRIPTION
Instead of only reserving memory for big VMs, we now also reserve memory
for large VMs, because we want to help DRS with scheduling those VMs
correctly (i.e. by configured memory) and improve performance for the
VMs.

Change-Id: I8b3a1a63ea4c1d459ed5c731d5ef94343d9e6046