### PR TITLE
vmware: Use vmdk size from .ova files

### DIFF
--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -490,9 +490,6 @@ def fetch_image_ova(context, instance, session, vm_name, ds_name,
               {'image_ref': image_ref, 'vm_name': vm_name},
               instance=instance)
 
-    metadata = IMAGE_API.get(context, image_ref)
-    file_size = int(metadata['size'])
-
     vm_import_spec = _build_import_spec_for_import_vapp(
         session, vm_name, ds_name)
 
@@ -508,6 +505,7 @@ def fetch_image_ova(context, instance, session, vm_name, ds_name,
                 vmdk_name = get_vmdk_name_from_ovf(xmlstr)
             elif vmdk_name and tar_info.name.startswith(vmdk_name):
                 # Actual file name is <vmdk_name>.XXXXXXX
+                file_size = tar_info.size
                 extracted = tar.extractfile(tar_info)
                 imported_vm_ref = _import_image(session, extracted,
                                                 vm_import_spec, vm_name,


### PR DESCRIPTION
Since .ova files contain more than just the .vmdk, the size reported by
glance is not the size of the actual upload. Since olso.vmware now has a
guard against not-finished uploads integrated, we cannot just use the
size from glance. Instead, we switch to using the size of the .vmdk as
reported by the tar file.

Change-Id: I05cdc3fc47974ceb34a72704d79b3f7c54c05d41