### PR TITLE
Fix NetworkInfoAsyncWrapper registration order

### DIFF
--- a/nova/network/model.py
+++ b/nova/network/model.py
@@ -643,6 +643,13 @@ try:
         def serialize(self, value, **kwargs):
             return 'NetworkInfoAsyncWrapper with {}'.format(value._gt)
 
-    serialization_manager.register(NetworkInfoAsyncWrapperSerializer)
+    # NOTE(jkulik): We cannot just use
+    # serialization_manager.register(NetworkInfoAsyncWrapperSerializer)
+    # because that would append to the list of serializers which already has
+    # the more generic IteratorSerializer in it, which would react on
+    # NetworkInfo inheriting from list. Therefore, we go through the very, very
+    # private attribute.
+    serialization_manager._SerializationManager__registry.insert(
+        0, NetworkInfoAsyncWrapperSerializer)
 except ImportError:
     pass


### PR DESCRIPTION
As it turns out, the serializer for NetworkInfoAsyncWrapper we
introduced in Ie170e951e4d8d007a48d5878ec957e2e95155628 and which's
registration we already fixed in
Ib6f436ded2481d99dc1b32c54974c37b94281b81 was never called, because the
more generic IteratorSerializer is registered before it via the base.py
of raven.utils.serializer. Since SerializationManager.register() always
appends to the list, there's no way for us to let our serializer come
earlier in the list than getting dirty. While we could monkeypatch our
own implementation of a SerializationManager into the module, too, we
rather just access private parts of the already existing
SerializationManager and prepend our serializer to the list of
serializers, as it's more specific than the others.

Change-Id: I66d2f2ae36c994eb846ca9a69dcecf7b3ee641aa