### PR TITLE
Transport context to all threads

### DIFF
--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -7890,9 +7890,15 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase):
         self.assertEqual(driver_console.get_connection_info.return_value,
                          console)
 
+    @mock.patch('nova.utils.pass_context')
     @mock.patch('nova.compute.manager.ComputeManager.'
                 '_do_live_migration')
-    def _test_max_concurrent_live(self, mock_lm):
+    def _test_max_concurrent_live(self, mock_lm, mock_pass_context):
+        # pass_context wraps the function, which doesn't work with a mock
+        # So we simply mock it too
+        def _mock_pass_context(runner, func, *args, **kwargs):
+            return runner(func, *args, **kwargs)
+        mock_pass_context.side_effect = _mock_pass_context
 
         @mock.patch('nova.objects.Migration.save')
         def _do_it(mock_mig_save):

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -804,15 +804,13 @@ def _serialize_profile_info():
     return trace_info
 
 
-def spawn(func, *args, **kwargs):
-    """Passthrough method for eventlet.spawn.
+def pass_context(runner, func, *args, **kwargs):
+    """Generalised passthrough method
 
-    This utility exists so that it can be stubbed for testing without
-    interfering with the service spawns.
-
-    It will also grab the context from the threadlocal store and add it to
-    the store on the new thread.  This allows for continuity in logging the
-    context when using this method to spawn a new thread.
+    It will grab the context from the threadlocal store and add it to
+    the store on the runner.  This allows for continuity in logging the
+    context when using this method to spawn a new thread through the
+    runner function
     """
     _context = common_context.get_current()
     profiler_info = _serialize_profile_info()
@@ -827,7 +825,21 @@ def spawn(func, *args, **kwargs):
             profiler.init(**profiler_info)
         return func(*args, **kwargs)
 
-    return eventlet.spawn(context_wrapper, *args, **kwargs)
+    return runner(context_wrapper, *args, **kwargs)
+
+
+def spawn(func, *args, **kwargs):
+    """Passthrough method for eventlet.spawn.
+
+    This utility exists so that it can be stubbed for testing without
+    interfering with the service spawns.
+
+    It will also grab the context from the threadlocal store and add it to
+    the store on the new thread.  This allows for continuity in logging the
+    context when using this method to spawn a new thread.
+    """
+
+    return pass_context(eventlet.spawn, func, *args, **kwargs)
 
 
 def spawn_n(func, *args, **kwargs):
@@ -840,20 +852,7 @@ def spawn_n(func, *args, **kwargs):
     the store on the new thread.  This allows for continuity in logging the
     context when using this method to spawn a new thread.
     """
-    _context = common_context.get_current()
-    profiler_info = _serialize_profile_info()
-
-    @functools.wraps(func)
-    def context_wrapper(*args, **kwargs):
-        # NOTE: If update_store is not called after spawn_n it won't be
-        # available for the logger to pull from threadlocal storage.
-        if _context is not None:
-            _context.update_store()
-        if profiler_info and profiler:
-            profiler.init(**profiler_info)
-        func(*args, **kwargs)
-
-    eventlet.spawn_n(context_wrapper, *args, **kwargs)
+    pass_context(eventlet.spawn_n, func, *args, **kwargs)
 
 
 def is_none_string(val):


### PR DESCRIPTION
The nova.utils.spawn and spawn_n methods transport
the context (and profiling information) to the
newly created threads. But the same isn't done
when submitting work to thread-pools in the
ComputeManager.

The code doing that is extracted to a new
function and called to submit the work to the
thread-pools.

Change-Id: I9085deaa8cf0b167d87db68e4afc4a463c00569c