### PR TITLE
Vmwareapi: Use oslo_vmware get_object_property instead of nova one

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_network_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_network_util.py
@@ -49,45 +49,21 @@ class GetNetworkWithTheNameTestCase(test.NoDBTestCase):
         """Returns a set of results for a cluster network lookup.
 
         This is an example:
-        (ObjectContent){
-           obj =
-              (obj){
-                 value = "domain-c7"
-                 _type = "ClusterComputeResource"
-              }
-           propSet[] =
-              (DynamicProperty){
-                 name = "network"
-                 val =
-                    (ArrayOfManagedObjectReference){
-                       ManagedObjectReference[] =
-                          (ManagedObjectReference){
-                             value = "network-54"
-                             _type = "Network"
-                          },
-                          (ManagedObjectReference){
-                             value = "dvportgroup-14"
-                             _type = "DistributedVirtualPortgroup"
-                          },
-                    }
-              },
+        (ArrayOfManagedObjectReference){
+        ManagedObjectReference[] = [
+            (ManagedObjectReference){
+                value = "network-54"
+                _type = "Network"
+            },
+            (ManagedObjectReference){
+                value = "dvportgroup-14"
+                _type = "DistributedVirtualPortgroup"
+            },
         }]
         """
-
-        objects = []
-        obj = ObjectContent(obj=vim_util.get_moref("domain-c7",
-                                                   "ClusterComputeResource"),
-                            propSet=[])
-        value = fake.DataObject()
-        value.ManagedObjectReference = []
-        for network in networks:
-            value.ManagedObjectReference.append(network)
-
-        obj.propSet.append(
-                    DynamicProperty(name='network',
-                                    val=value))
-        objects.append(obj)
-        return ResultSet(objects=objects)
+        array = fake._create_array_of_type("ManagedObjectReference")
+        array.ManagedObjectReference = networks
+        return array
 
     def test_get_network_no_match(self):
         net_morefs = [vim_util.get_moref("dvportgroup-135",
@@ -96,13 +72,14 @@ class GetNetworkWithTheNameTestCase(test.NoDBTestCase):
                                          "DistributedVirtualPortgroup")]
         networks = self._build_cluster_networks(net_morefs)
 
-        def mock_call_method(module, method, *args, **kwargs):
-            if method == 'get_object_properties':
+        def mock_call_method(module, method, mo_ref, property):
+            if method != 'get_object_property':
+                raise RuntimeError('Unexpected method')
+            if mo_ref == 'fake_cluster':
                 return networks
-            if method == 'get_object_property':
-                result = fake.DataObject()
-                result.name = 'no-match'
-                return result
+            result = fake.DataObject()
+            result.name = 'no-match'
+            return result
 
         with mock.patch.object(self._session, '_call_method',
                                mock_call_method):
@@ -116,15 +93,16 @@ class GetNetworkWithTheNameTestCase(test.NoDBTestCase):
                                          "DistributedVirtualPortgroup")]
         networks = self._build_cluster_networks(net_morefs)
 
-        def mock_call_method(module, method, *args, **kwargs):
-            if method == 'get_object_properties':
+        def mock_call_method(module, method, mo_ref, property):
+            if method != 'get_object_property':
+                raise RuntimeError('Unexpected method')
+            if mo_ref == 'fake_cluster':
                 return networks
-            if method == 'get_object_property':
-                result = fake.DataObject()
-                result.name = name
-                result.key = 'fake_key'
-                result.distributedVirtualSwitch = 'fake_dvs'
-                return result
+            result = fake.DataObject()
+            result.name = name
+            result.key = 'fake_key'
+            result.distributedVirtualSwitch = 'fake_dvs'
+            return result
 
         with mock.patch.object(self._session, '_call_method',
                                mock_call_method):
@@ -143,11 +121,12 @@ class GetNetworkWithTheNameTestCase(test.NoDBTestCase):
         net_morefs = [vim_util.get_moref("network-54", "Network")]
         networks = self._build_cluster_networks(net_morefs)
 
-        def mock_call_method(module, method, *args, **kwargs):
-            if method == 'get_object_properties':
+        def mock_call_method(module, method, mo_ref, property):
+            if method != 'get_object_property':
+                raise RuntimeError('Unexpected method')
+            if mo_ref == 'fake_cluster':
                 return networks
-            if method == 'get_object_property':
-                return 'fake_net'
+            return 'fake_net'
 
         with mock.patch.object(self._session, '_call_method',
                                mock_call_method):

--- a/nova/virt/vmwareapi/network_util.py
+++ b/nova/virt/vmwareapi/network_util.py
@@ -62,60 +62,48 @@ def _get_network_obj(session, network_objects, network_name):
     """
 
     network_obj = {}
-    # network_objects is actually a RetrieveResult object from vSphere API call
-    for obj_content in network_objects:
-        # the propset attribute "need not be set" by returning API
-        if not hasattr(obj_content, 'propSet'):
-            continue
-        prop_dict = vm_util.propset_dict(obj_content.propSet)
-        network_refs = prop_dict.get('network')
-        if network_refs:
-            network_refs = network_refs.ManagedObjectReference
-            for network in network_refs:
-                # Get network properties
-                if network._type == 'DistributedVirtualPortgroup':
-                    props = session._call_method(vutil,
-                                                 "get_object_property",
-                                                 network,
-                                                 "config")
-                    # NOTE(asomya): This only works on ESXi if the port binding
-                    # is set to ephemeral
-                    net_name = _get_name_from_dvs_name(props.name)
-                    if network_name in net_name:
-                        network_obj['type'] = 'DistributedVirtualPortgroup'
-                        network_obj['dvpg'] = props.key
-                        dvs_props = session._call_method(vutil,
-                                        "get_object_property",
-                                        props.distributedVirtualSwitch,
-                                        "uuid")
-                        network_obj['dvsw'] = dvs_props
-                        return network_obj
-                else:
-                    props = session._call_method(vutil,
-                                                 "get_object_property",
-                                                 network,
-                                                 "summary.name")
-                    if props == network_name:
-                        network_obj['type'] = 'Network'
-                        network_obj['name'] = network_name
-                        return network_obj
+    for network in vim_util.get_array_items(network_objects):
+        # Get network properties
+        if network._type == 'DistributedVirtualPortgroup':
+            props = session._call_method(vutil,
+                                         "get_object_property",
+                                         network,
+                                         "config")
+            # NOTE(asomya): This only works on ESXi if the port binding
+            # is set to ephemeral
+            net_name = _get_name_from_dvs_name(props.name)
+            if network_name in net_name:
+                network_obj['type'] = 'DistributedVirtualPortgroup'
+                network_obj['dvpg'] = props.key
+                dvs_props = session._call_method(vutil,
+                    "get_object_property", props.distributedVirtualSwitch,
+                    "uuid")
+                network_obj['dvsw'] = dvs_props
+                return network_obj
+        else:
+            props = session._call_method(vutil,
+                                         "get_object_property",
+                                         network,
+                                         "summary.name")
+            if props == network_name:
+                network_obj['type'] = 'Network'
+                network_obj['name'] = network_name
+                return network_obj
 
 
 def get_network_with_the_name(session, network_name="vmnet0", cluster=None):
     """Gets reference to the network whose name is passed as the
     argument.
     """
-    vm_networks = session._call_method(vim_util,
-                                       'get_object_properties',
-                                       None, cluster,
-                                       'ClusterComputeResource', ['network'])
+    network_objs = session._call_method(vutil,
+                                        "get_object_property",
+                                        cluster,
+                                        "network")
 
-    with vutil.WithRetrieval(session.vim, vm_networks) as network_objs:
-        network_obj = _get_network_obj(session, network_objs, network_name)
-        if network_obj:
-            return network_obj
-
-    LOG.debug("Network %s not found on cluster!", network_name)
+    network_obj = _get_network_obj(session, network_objs, network_name)
+    if not network_obj:
+        LOG.debug("Network %s not found on cluster!", network_name)
+    return network_obj
 
 
 def get_vswitch_for_vlan_interface(session, vlan_interface, cluster=None):

--- a/nova/virt/vmwareapi/vim_util.py
+++ b/nova/virt/vmwareapi/vim_util.py
@@ -57,30 +57,6 @@ def object_to_dict(obj, list_depth=1):
     return d
 
 
-def get_object_properties(vim, collector, mobj, type, properties):
-    """Gets the properties of the Managed object specified."""
-    client_factory = vim.client.factory
-    if mobj is None:
-        return None
-    usecoll = collector
-    if usecoll is None:
-        usecoll = vim.service_content.propertyCollector
-    property_filter_spec = client_factory.create('ns0:PropertyFilterSpec')
-    property_spec = client_factory.create('ns0:PropertySpec')
-    property_spec.all = (properties is None or len(properties) == 0)
-    property_spec.pathSet = properties
-    property_spec.type = type
-    object_spec = client_factory.create('ns0:ObjectSpec')
-    object_spec.obj = mobj
-    object_spec.skip = False
-    property_filter_spec.propSet = [property_spec]
-    property_filter_spec.objectSet = [object_spec]
-    options = client_factory.create('ns0:RetrieveOptions')
-    options.maxObjects = CONF.vmware.maximum_objects
-    return vim.RetrievePropertiesEx(usecoll, specSet=[property_filter_spec],
-                                    options=options)
-
-
 def get_objects(vim, type, properties_to_collect=None, all=False):
     """Gets the list of objects of the type specified."""
     return vutil.get_objects(vim, type, CONF.vmware.maximum_objects,


### PR DESCRIPTION
get_network_with_the_name is the last place where
the nova function of the same name is used instead
of the one implemented in oslo_vmware.

Change-Id: I4293f3b2a7551793dd53dd427383583469ed0868