### PR TITLE
Pass _nova_check_type through scheduler_hints & set live_migrate

### DIFF
--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -327,12 +327,7 @@ class ComputeTaskManager(base.Base):
             # original RequestSpec object for make sure the scheduler verifies
             # the right one and not the original flavor
             request_spec.flavor = flavor
-
-            if (not request_spec.obj_attr_is_set('scheduler_hints')
-                    or request_spec.scheduler_hints is None):
-                request_spec._from_hints(scheduler_hints)
-            else:
-                request_spec.scheduler_hints.update(scheduler_hints)
+            request_spec.update_scheduler_hints(scheduler_hints)
 
         task = self._build_cold_migrate_task(context, instance, flavor,
                 request_spec, clean_shutdown, host_list)

--- a/nova/objects/request_spec.py
+++ b/nova/objects/request_spec.py
@@ -306,6 +306,13 @@ class RequestSpec(base.NovaObject):
 
         return spec
 
+    def update_scheduler_hints(self, scheduler_hints):
+        if (not self.obj_attr_is_set('scheduler_hints')
+                or self.scheduler_hints is None):
+            self._from_hints(scheduler_hints)
+        else:
+            self.scheduler_hints.update(scheduler_hints)
+
     def get_scheduler_hint(self, hint_name, default=None):
         """Convenient helper for accessing a particular scheduler hint since
         it is hydrated by putting a single item into a list.

--- a/nova/scheduler/filters/cpu_info_migration_filter.py
+++ b/nova/scheduler/filters/cpu_info_migration_filter.py
@@ -22,8 +22,7 @@ from nova.context import get_admin_context
 from nova.exception import ComputeHostNotFound
 from nova.objects.compute_node import ComputeNode
 from nova.scheduler import filters
-from nova.scheduler.utils import request_is_rebuild
-from nova.scheduler.utils import request_is_resize
+from nova.scheduler.utils import request_is_live_migrate
 
 LOG = logging.getLogger(__name__)
 
@@ -44,12 +43,10 @@ class CpuInfoMigrationFilter(filters.BaseHostFilter):
     def filter_all(self, filter_obj_list, spec_obj):
         source_host = spec_obj.get_scheduler_hint('source_host')
         source_node = spec_obj.get_scheduler_hint('source_node')
-        # This filter only applies to live-migration,
-        # Not normal builds, resizes, and rebuilds
-        if (not source_host
-                or not source_node
-                or request_is_resize(spec_obj)
-                or request_is_rebuild(spec_obj)):
+
+        if (not request_is_live_migrate(spec_obj)
+                or not source_host
+                or not source_node):
             return filter_obj_list
 
         try:

--- a/nova/scheduler/utils.py
+++ b/nova/scheduler/utils.py
@@ -904,8 +904,8 @@ def request_is_rebuild(spec_obj):
         return False
     if 'scheduler_hints' not in spec_obj:
         return False
-    check_type = spec_obj.scheduler_hints.get('_nova_check_type')
-    return check_type == ['rebuild']
+    check_type = spec_obj.get_scheduler_hint('_nova_check_type')
+    return check_type == 'rebuild'
 
 
 def request_is_resize(spec_obj):
@@ -917,8 +917,21 @@ def request_is_resize(spec_obj):
         return False
     if 'scheduler_hints' not in spec_obj:
         return False
-    check_type = spec_obj.scheduler_hints.get('_nova_check_type')
-    return check_type == ['resize']
+    check_type = spec_obj.get_scheduler_hint('_nova_check_type')
+    return check_type == 'resize'
+
+
+def request_is_live_migrate(spec_obj):
+    """Returns True if request is for a live migration
+
+    :param spec_obj: An objects.RequestSpec to examine (or None).
+    """
+    if not spec_obj:
+        return False
+    if 'scheduler_hints' not in spec_obj:
+        return False
+    check_type = spec_obj.get_scheduler_hint('_nova_check_type')
+    return check_type == 'live_migrate'
 
 
 def claim_resources(ctx, client, spec_obj, instance_uuid, alloc_req,

--- a/nova/tests/unit/compute/test_compute_api.py
+++ b/nova/tests/unit/compute/test_compute_api.py
@@ -1994,6 +1994,9 @@ class _ComputeAPIUnitTestMixIn(object):
             else:
                 filter_properties = {'ignore_hosts': [fake_inst['host']]}
 
+            filter_properties['scheduler_hints'] = {
+                '_nova_check_type': ['resize']}
+
             if self.cell_type == 'api':
                 mig = mock.MagicMock()
                 mock_migration.return_value = mig
@@ -2029,7 +2032,6 @@ class _ComputeAPIUnitTestMixIn(object):
 
             scheduler_hint = {
                 'filter_properties': filter_properties,
-                '_nova_check_type': ['resize'],
             }
 
         if flavor_id_passed:


### PR DESCRIPTION
The confusing names led apparently to a parameter passed through
scheduler_hint, which is containing a filter_property,
which has scheduler_hints, which is where the parameter should
have ended up.

Additionally, set the live-migrate flag instead of inferring
the state from other flags.

The flags are persisted, so we need to overwrite them.

Change-Id: Id80bfd2f3e4771856cc0d85bc1b85a7d14f3b136