### PR TITLE
VMware: root disk anti affinity

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -240,6 +240,16 @@ Possible values:
 
 * Any matching regular expression to a datastore must be given
 """),
+    cfg.StrOpt('datastore_hagroup_regex',
+                help="""
+Regular expression pattern to retrieve ha-group from datastore name
+
+If this setting is set, datastores are split into 2 ha-groups to distribute
+anti-affin servers between them. The datastores found with the datastore_regex
+setting belong to either HA-group A or B by applying this regex onto the
+datastore name. This setting must include a matched group of the name
+"hagroup".
+"""),
     cfg.FloatOpt('task_poll_interval',
                  default=0.5,
                  help="""

--- a/nova/objects/migrate_data.py
+++ b/nova/objects/migrate_data.py
@@ -511,11 +511,11 @@ class VMWareLiveMigrateData(LiveMigrateData):
     # Version 1.1: Added dest_cluster_ref, is_same_vcenter,
     #              instance_already_migrated, relocate_defaults_json,
     #              vif_infos_json for cross-vcenter migration
-    VERSION = '1.1'
+    # Version 1.2: Removed datastore_regex
+    VERSION = '1.2'
 
     fields = {
         'cluster_name': fields.StringField(nullable=False),
-        'datastore_regex': fields.StringField(nullable=False),
         'dest_cluster_ref': fields.StringField(nullable=False),
         'is_same_vcenter': fields.BooleanField(default=True),
         'instance_already_migrated': fields.BooleanField(default=False),
@@ -560,3 +560,5 @@ class VMWareLiveMigrateData(LiveMigrateData):
             for k in ('is_same_vcenter', 'instance_already_migrated',
                       'relocate_defaults_json', 'vif_infos_json'):
                 primitive.pop(k, None)
+        if target_version >= (1, 2):
+            primitive.pop('datastore_regex', None)

--- a/nova/tests/unit/notifications/objects/test_notification.py
+++ b/nova/tests/unit/notifications/objects/test_notification.py
@@ -412,7 +412,7 @@ notification_object_data = {
     'ServerGroupPayload': '1.1-4ded2997ea1b07038f7af33ef5c45f7f',
     'ServiceStatusNotification': '1.0-a73147b93b520ff0061865849d3dfa56',
     'ServiceStatusPayload': '1.1-7b6856bd879db7f3ecbcd0ca9f35f92f',
-    'VMWareLiveMigrateData': '1.1-ecaa7a47c0742ccb302711896a1c3eba',
+    'VMWareLiveMigrateData': '1.2-3072c2eb508ae0259825200239b9051f',
 }
 
 

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1166,7 +1166,7 @@ object_data = {
     'VirtCPUTopology': '1.0-fc694de72e20298f7c6bab1083fd4563',
     'VirtualInterface': '1.3-efd3ca8ebcc5ce65fff5a25f31754c54',
     'VirtualInterfaceList': '1.0-9750e2074437b3077e46359102779fc6',
-    'VMWareLiveMigrateData': '1.1-ecaa7a47c0742ccb302711896a1c3eba',
+    'VMWareLiveMigrateData': '1.2-3072c2eb508ae0259825200239b9051f',
     'VolumeUsage': '1.0-6c8190c46ce1469bb3286a1f21c2e475',
     'XenDeviceBus': '1.0-272a4f899b24e31e42b2b9a7ed7e9194',
     'XenapiLiveMigrateData': '1.4-7dc9417e921b2953faa6751f18785f3f',

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1664,8 +1664,8 @@ class VMwareVMOpsTestCase(test.TestCase):
             from_image.assert_called_once_with(self._context,
                                                self._instance.image_ref,
                                                self._image_meta)
-            get_vm_config_info.assert_called_once_with(self._instance,
-                image_info, extra_specs)
+            get_vm_config_info.assert_called_once_with(self._context,
+                self._instance, image_info, extra_specs)
             build_virtual_machine.assert_called_once_with(
                 self._instance, self._context, image_info, vi.datastore, [],
                 extra_specs, self._get_metadata(), 'fake_vm_folder')
@@ -1730,8 +1730,8 @@ class VMwareVMOpsTestCase(test.TestCase):
             from_image.assert_called_once_with(self._context,
                                                self._instance.image_ref,
                                                self._image_meta)
-            get_vm_config_info.assert_called_once_with(self._instance,
-                image_info, extra_specs)
+            get_vm_config_info.assert_called_once_with(self._context,
+                self._instance, image_info, extra_specs)
             build_virtual_machine.assert_called_once_with(
                 self._instance, self._context, image_info, vi.datastore, [],
                 extra_specs, self._get_metadata(is_image_used=False),
@@ -1788,7 +1788,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                            self._instance.image_ref,
                                            self._image_meta)
         get_vm_config_info.assert_called_once_with(
-            self._instance, image_info, extra_specs)
+            self._context, self._instance, image_info, extra_specs)
         build_virtual_machine.assert_called_once_with(
             self._instance, self._context, image_info, vi.datastore, [],
             extra_specs, self._get_metadata(is_image_used=False),
@@ -2050,7 +2050,7 @@ class VMwareVMOpsTestCase(test.TestCase):
             image_id=self._image_id,
             file_size=image_size)
         vi = self._vmops._get_vm_config_info(
-            self._instance, image_info, extra_specs)
+            self._context, self._instance, image_info, extra_specs)
 
         self._vmops._volumeops = mock.Mock()
         network_info = mock.Mock()
@@ -2200,8 +2200,8 @@ class VMwareVMOpsTestCase(test.TestCase):
         mock_get_datacenter_ref_and_name.return_value = self._dc_info
         extra_specs = vm_util.ExtraSpecs()
 
-        vi = self._vmops._get_vm_config_info(self._instance, image_info,
-                                             extra_specs)
+        vi = self._vmops._get_vm_config_info(self._context, self._instance,
+                                             image_info, extra_specs)
         self.assertEqual(image_info, vi.ii)
         self.assertEqual(self._ds, vi.datastore)
         self.assertEqual(self._instance.flavor.root_gb, vi.root_gb)
@@ -2338,8 +2338,8 @@ class VMwareVMOpsTestCase(test.TestCase):
 
         from_image.assert_called_once_with(
             self._context, self._instance.image_ref, {})
-        get_vm_config_info.assert_called_once_with(self._instance,
-            image_info, extra_specs)
+        get_vm_config_info.assert_called_once_with(self._context,
+            self._instance, image_info, extra_specs)
         build_virtual_machine.assert_called_once_with(self._instance,
                                                       self._context,
             image_info, vi.datastore, [], extra_specs, metadata, 'fake-folder')

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -777,6 +777,8 @@ class VMwareVCDriver(driver.ComputeDriver):
                     sleep_time = random.uniform(0.5, spacing)
                     time.sleep(sleep_time)
                     self._vmops.sync_server_group(context, sg_uuid)
+                    self._vmops.update_server_group_hagroup_disk_placement(
+                        context, sg_uuid)
             except Exception as e:
                 LOG.exception("Finished server-group sync-loop with error: %s",
                               e)

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -729,6 +729,8 @@ class VMwareVCDriver(driver.ComputeDriver):
 
     def sync_server_group(self, context, sg_uuid):
         self._vmops.sync_server_group(context, sg_uuid)
+        self._vmops.update_server_group_hagroup_disk_placement(context,
+                                                               sg_uuid)
 
     def _server_group_sync_loop(self, compute_host):
         """Retrieve all groups from the cluster and from the DB and call

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -778,7 +778,6 @@ class VMwareVCDriver(driver.ComputeDriver):
 
         data.cluster_name = self._cluster_name
         data.dest_cluster_ref = vim_util.get_moref_value(self._cluster_ref)
-        data.datastore_regex = CONF.vmware.datastore_regex
         client_factory = self._session.vim.client.factory
 
         service = vm_util.create_service_locator(client_factory,

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -117,6 +117,25 @@ class VMwareVCDriver(driver.ComputeDriver):
                     _("Invalid Regular Expression %s")
                     % CONF.vmware.datastore_regex)
 
+        self._datastore_hagroup_regex = None
+        if CONF.vmware.datastore_hagroup_regex:
+            # NOTE(jkulik): In theory, this is not necessary if pbm_enabled is
+            # set, but to keep the amount of code necessary for supporting
+            # datastore hagroups small, we just focus on one way of doing
+            # things right now.
+            if not self._datastore_regex:
+                raise error_util.DatastoreRegexUnspecified()
+            try:
+                self._datastore_hagroup_regex = \
+                    re.compile(CONF.vmware.datastore_hagroup_regex)
+            except re.error:
+                raise exception.InvalidInput(reason=
+                    "Invalid Regular Expression {}"
+                    .format(CONF.vmware.datastore_hagroup_regex))
+
+            if 'hagroup' not in self._datastore_hagroup_regex.groupindex:
+                raise error_util.DatastoreRegexNoHagroup()
+
         self._session = VMwareAPISession(scheme=scheme)
 
         self._check_min_version()
@@ -141,7 +160,9 @@ class VMwareVCDriver(driver.ComputeDriver):
                                         virtapi,
                                         self._volumeops,
                                         self._cluster_ref,
-                                        datastore_regex=self._datastore_regex)
+                                        datastore_regex=self._datastore_regex,
+                                        datastore_hagroup_regex=
+                                            self._datastore_hagroup_regex)
         self._vc_state = host.VCState(self._session,
                                       self._nodename,
                                       self._cluster_ref,

--- a/nova/virt/vmwareapi/ds_util.py
+++ b/nova/virt/vmwareapi/ds_util.py
@@ -47,7 +47,9 @@ _DS_DC_MAPPING = {}
 
 def _select_datastore(session, datastores, best_match, datastore_regex=None,
                       storage_policy=None,
-                      allowed_ds_types=ALL_SUPPORTED_DS_TYPES):
+                      allowed_ds_types=ALL_SUPPORTED_DS_TYPES,
+                      datastore_hagroup_regex=None,
+                      datastore_hagroup=None):
     """Find the most preferable datastore in a given RetrieveResult object.
 
     :param session: vmwareapi session
@@ -56,6 +58,9 @@ def _select_datastore(session, datastores, best_match, datastore_regex=None,
     :param datastore_regex: an optional regular expression to match names
     :param storage_policy: storage policy for the datastore
     :param allowed_ds_types: a list of acceptable datastore type names
+    :param datastore_hagroup_regex: an optional regular expression to retrieve
+                                    the hagroup from the name
+    :param datastore_hagroup: an optional hagroup name to filter datastores by
     :return: datastore_ref, datastore_name, capacity, freespace
     """
 
@@ -72,7 +77,8 @@ def _select_datastore(session, datastores, best_match, datastore_regex=None,
             continue
 
         propdict = vm_util.propset_dict(obj_content.propSet)
-        if _is_datastore_valid(propdict, datastore_regex, allowed_ds_types):
+        if _is_datastore_valid(propdict, datastore_regex, allowed_ds_types,
+                               datastore_hagroup_regex, datastore_hagroup):
             new_ds = ds_obj.Datastore(
                     ref=obj_content.obj,
                     name=propdict['summary.name'],
@@ -86,7 +92,8 @@ def _select_datastore(session, datastores, best_match, datastore_regex=None,
     return best_match
 
 
-def _is_datastore_valid(propdict, datastore_regex, ds_types):
+def _is_datastore_valid(propdict, datastore_regex, ds_types,
+                        datastore_hagroup_regex=None, datastore_hagroup=None):
     """Checks if a datastore is valid based on the following criteria.
 
        Criteria:
@@ -94,6 +101,8 @@ def _is_datastore_valid(propdict, datastore_regex, ds_types):
        - Datastore is not in maintenance mode (optional)
        - Datastore's type is one of the given ds_types
        - Datastore matches the supplied regex (optional)
+       - Datastore matches the supplied hagroup regex (optional)
+       - Datastore's hagroup matches the supplied hagroup (optional)
 
        :param propdict: datastore summary dict
        :param datastore_regex : Regex to match the name of a datastore.
@@ -101,17 +110,37 @@ def _is_datastore_valid(propdict, datastore_regex, ds_types):
 
     # Local storage identifier vSphere doesn't support CIFS or
     # vfat for datastores, therefore filtered
-    return (propdict.get('summary.accessible') and
-            (propdict.get('summary.maintenanceMode') is None or
-             propdict.get('summary.maintenanceMode') == 'normal') and
-            propdict['summary.type'] in ds_types and
-            (datastore_regex is None or
-             datastore_regex.match(propdict['summary.name'])))
+    valid = (propdict.get('summary.accessible') and
+             (propdict.get('summary.maintenanceMode') is None or
+              propdict.get('summary.maintenanceMode') == 'normal') and
+             propdict['summary.type'] in ds_types and
+             (datastore_regex is None or
+              datastore_regex.match(propdict['summary.name'])))
+
+    if not valid:
+        return False
+
+    if datastore_hagroup_regex:
+        m = datastore_hagroup_regex.search(propdict['summary.name'])
+        if not m:
+            return False
+        hagroup = m.group('hagroup').lower()
+    else:
+        # here could be different ways to get the hagroup e.g. by customValue
+        # attribute of the datastore
+        hagroup = None
+
+    if datastore_hagroup and datastore_hagroup.lower() != hagroup:
+        return False
+
+    return True
 
 
 def get_datastore(session, cluster, datastore_regex=None,
                   storage_policy=None,
-                  allowed_ds_types=ALL_SUPPORTED_DS_TYPES):
+                  allowed_ds_types=ALL_SUPPORTED_DS_TYPES,
+                  datastore_hagroup_regex=None,
+                  datastore_hagroup=None):
     """Get the datastore list and choose the most preferable one."""
     datastore_ret = session._call_method(vutil,
                                          "get_object_property",
@@ -138,7 +167,9 @@ def get_datastore(session, cluster, datastore_regex=None,
                                        best_match,
                                        datastore_regex,
                                        storage_policy,
-                                       allowed_ds_types)
+                                       allowed_ds_types,
+                                       datastore_hagroup_regex,
+                                       datastore_hagroup)
     if best_match:
         return best_match
 
@@ -146,10 +177,15 @@ def get_datastore(session, cluster, datastore_regex=None,
         raise exception.DatastoreNotFound(
             _("Storage policy %s did not match any datastores")
             % storage_policy)
+    # here could be different ways to get the hagroup e.g. by customValue
+    # attribute of the datastore
     if datastore_regex:
-        raise exception.DatastoreNotFound(
-            _("Datastore regex %s did not match any datastores")
-            % datastore_regex.pattern)
+        msg = "Datastore regex {} did not match any datastores" \
+              .format(datastore_regex.pattern)
+        if datastore_hagroup_regex:
+            msg += " or no datastore matched hagroup {} found via regex {}" \
+                   .format(datastore_hagroup, datastore_hagroup_regex.pattern)
+        raise exception.DatastoreNotFound(msg)
     raise exception.DatastoreNotFound()
 
 

--- a/nova/virt/vmwareapi/error_util.py
+++ b/nova/virt/vmwareapi/error_util.py
@@ -21,6 +21,16 @@ from nova import exception
 from nova.i18n import _
 
 
+class DatastoreRegexUnspecified(exception.Invalid):
+    msg_fmt = "vmware.datastore_hagroup_regex is set without " \
+              "vmware.datastore_regex being set."
+
+
+class DatastoreRegexNoHagroup(exception.Invalid):
+    msg_fmt = "vmware.datastore_hagroup_regex is set but does not contain " \
+              "a named group 'hagroup'"
+
+
 class NoRootDiskDefined(exception.NovaException):
     msg_fmt = _("No root disk defined.")
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -788,7 +788,13 @@ class VMwareVMOps(object):
         not_deleted_members = self._get_server_group_members_for_hagroup(
             context, server_group)
         member_index = not_deleted_members.index(instance.uuid)
-        hagroup = ['A', 'B'][member_index % 2]
+        # the first two  instances are hard-mapped to A and B respectively, so
+        # we can make sure we have at least one instance on either hagroup. the
+        # other instances we map basically randomly.
+        if member_index < 2:
+            hagroup = ['A', 'B'][member_index % 2]
+        else:
+            hagroup = ['A', 'B'][int(instance.uuid[0], 16) % 2]
 
         return self._datastore_hagroup_regex, hagroup
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -3604,8 +3604,8 @@ class VMwareVMOps(object):
             self._cluster, placementSpec=placement_spec)
         return result
 
-    def relocate_vm_config_and_ephemeral_disk(self, context, instance,
-                                              target_ds_ref):
+    def _relocate_vm_config_and_ephemeral_disk(self, context, instance,
+                                               target_ds_ref):
         """svMotion the instance to another datastore
 
         Volumes attached to the instance are kept in their place, only the
@@ -3676,6 +3676,20 @@ class VMwareVMOps(object):
                   vutil.get_moref_value(vm_ref),
                   vutil.get_moref_value(target_ds_ref),
                   instance=instance)
+
+    def relocate_vm_config_and_ephemeral_disk(self, context, instance,
+                                              target_ds_ref):
+
+        @utils.synchronized(instance.uuid)
+        def _locked_relocate_vm_config_and_ephemeral_disk(context,
+                                                          instance,
+                                                          target_ds_ref):
+            return self._relocate_vm_config_and_ephemeral_disk(context,
+                                                               instance,
+                                                               target_ds_ref)
+
+        return _locked_relocate_vm_config_and_ephemeral_disk(context, instance,
+                                                             target_ds_ref)
 
     def update_server_group_hagroup_disk_placement(self, context, sg_uuid):
         """Checks and remedies a server-group's VMs' root disk placement

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -138,7 +138,7 @@ class VMwareVMOps(object):
     """Management class for VM-related tasks."""
 
     def __init__(self, session, virtapi, volumeops, cluster=None,
-                 datastore_regex=None):
+                 datastore_regex=None, datastore_hagroup_regex=None):
         """Initializer."""
         self.compute_api = compute.API()
         self._session = session
@@ -150,6 +150,7 @@ class VMwareVMOps(object):
         self._root_resource_pool = vm_util.get_res_pool_ref(self._session,
                                                             self._cluster)
         self._datastore_regex = datastore_regex
+        self._datastore_hagroup_regex = datastore_hagroup_regex
         self._base_folder = self._get_base_folder()
         self._tmp_folder = 'vmware_temp'
         self._datastore_browser_mapping = {}

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -698,7 +698,47 @@ class VMwareVMOps(object):
                             tmp_image_ds_loc.parent,
                             vi.cache_image_folder)
 
-    def _get_vm_config_info(self, instance, image_info, extra_specs):
+    def _get_hagroup_info(self, context, instance):
+        """Return hagroup regex and hagroup for the given instance
+
+        The hagroup computes from the server-group the instance is in and thus
+        this function may return (None, None) if the server isn't in a
+        server-group.
+        """
+        # this currently means the hagroup feature is disabled
+        if not self._datastore_hagroup_regex:
+            return None, None
+
+        instance_group_object = objects.instance_group.InstanceGroup
+        try:
+            server_group = instance_group_object.get_by_instance_uuid(
+                context, instance.uuid)
+        except nova.exception.InstanceGroupNotFound:
+            return None, None
+
+        # we don't handle affinity here, just anti-affinity
+        if 'anti-affinity' not in server_group.policy:
+            return None, None
+
+        # query all instances not deleted in server_group.members. this
+        # will only filter in the current cell, but that should be a big
+        # enough radius as cells are AZs in our env - except in qa-de-1
+        # TODO(jkulik): Do we need this to work across cells?
+        InstanceList = objects.instance.InstanceList
+        filters = {'uuid': server_group.members, 'deleted': False}
+        instances = InstanceList.get_by_filters(context, filters,
+                                                expected_attrs=[])
+        existing_instance_uuids = set(i.uuid for i in instances)
+        # we need to keep the order of the members here and thus filter the
+        # members by the found instances
+        not_deleted_members = [m for m in server_group.members
+                               if m in existing_instance_uuids]
+        member_index = not_deleted_members.index(instance.uuid)
+        hagroup = ['A', 'B'][member_index % 2]
+
+        return self._datastore_hagroup_regex, hagroup
+
+    def _get_vm_config_info(self, context, instance, image_info, extra_specs):
         """Captures all relevant information from the spawn parameters."""
 
         boot_from_volume = compute_utils.is_volume_backed_instance(
@@ -711,11 +751,14 @@ class VMwareVMOps(object):
                                                  reason=reason)
         allowed_ds_types = ds_util.get_allowed_datastore_types(
             image_info.disk_type)
+        hagroup_re, hagroup = self._get_hagroup_info(context, instance)
         datastore = ds_util.get_datastore(self._session,
                                           self._cluster,
                                           self._datastore_regex,
                                           extra_specs.storage_policy,
-                                          allowed_ds_types)
+                                          allowed_ds_types,
+                                          datastore_hagroup_regex=hagroup_re,
+                                          datastore_hagroup=hagroup)
         dc_info = self.get_datacenter_ref_and_name(datastore.ref)
 
         return VirtualMachineInstanceConfigInfo(instance,
@@ -1039,7 +1082,8 @@ class VMwareVMOps(object):
                     image_info.file_size) / units.Gi /
                     templ_instance.flavor.root_gb))
 
-            vi = self._get_vm_config_info(templ_instance,
+            vi = self._get_vm_config_info(context,
+                                          templ_instance,
                                           image_info,
                                           extra_specs)
 
@@ -1177,7 +1221,7 @@ class VMwareVMOps(object):
 
         extra_specs = self._get_extra_specs(instance.flavor, image_meta)
 
-        vi = self._get_vm_config_info(instance, image_info,
+        vi = self._get_vm_config_info(context, instance, image_info,
                                       extra_specs)
 
         boot_from_volume = compute_utils.is_volume_backed_instance(
@@ -2319,10 +2363,13 @@ class VMwareVMOps(object):
         storage_policy = self._get_storage_policy(instance.flavor)
         allowed_ds_types = ds_util.get_allowed_datastore_types(
             image_meta.properties.hw_disk_type)
+        hagroup_re, hagroup = self._get_hagroup_info(context, instance)
         datastore = ds_util.get_datastore(self._session, self._cluster,
                                           self._datastore_regex,
                                           storage_policy,
-                                          allowed_ds_types)
+                                          allowed_ds_types,
+                                          datastore_hagroup_regex=hagroup_re,
+                                          datastore_hagroup=hagroup)
         dc_info = self.get_datacenter_ref_and_name(datastore.ref)
         folder = self._get_project_folder(dc_info, instance.project_id,
                                           'Instances')
@@ -3456,7 +3503,8 @@ class VMwareVMOps(object):
 
         extra_specs = self._get_extra_specs(flavor, image_meta)
 
-        vi = self._get_vm_config_info(instance, image_info, extra_specs)
+        vi = self._get_vm_config_info(context, instance, image_info,
+                                      extra_specs)
 
         vm_folder = self._get_project_folder(vi.dc_info,
             project_id=instance.project_id, type_='Instances')


### PR DESCRIPTION
This set of patches enables us to make sure that the first two servers in a server-group are placed on different datastores, levering a naming-scheme for datastores to achieve this.

For this to work properly, all volumes attached to a VM need a profile assinged to the VM for that disk. Otherwise, the storage-vMotion will just fail no matter if there's a profile in the VirtualMachineRelocateSpec or not. We will have to remedy that in production and need to patch the attachment process in Nova to include the profile-id for volumes.