### PR TITLE
Cherry-Pick: Retry image download if it's corrupted

### DIFF
--- a/nova/image/glance.py
+++ b/nova/image/glance.py
@@ -181,7 +181,8 @@ class GlanceClientWrapper(object):
         kwargs = kwargs or {}
         retry_excs = (glanceclient.exc.ServiceUnavailable,
                 glanceclient.exc.InvalidEndpoint,
-                glanceclient.exc.CommunicationError)
+                glanceclient.exc.CommunicationError,
+                IOError)
         num_attempts = 1 + CONF.glance.num_retries
         controller_name = controller or 'images'
 

--- a/nova/tests/unit/image/test_glance.py
+++ b/nova/tests/unit/image/test_glance.py
@@ -458,6 +458,20 @@ class TestGlanceClientWrapperRetries(test.NoDBTestCase):
     @mock.patch('random.shuffle')
     @mock.patch('time.sleep')
     @mock.patch('nova.image.glance._glanceclient_from_endpoint')
+    def test_retry_works_for_corrupted_image(self, create_client_mock,
+                                         sleep_mock, shuffle_mock):
+        side_effect = [
+            IOError,
+            None
+        ]
+        self._mock_client_images_response(create_client_mock, side_effect)
+        self.flags(num_retries=1, group='glance')
+        client = glance.GlanceClientWrapper()
+        self.assert_retry_attempted(sleep_mock, client, 'https://host2:9293')
+
+    @mock.patch('random.shuffle')
+    @mock.patch('time.sleep')
+    @mock.patch('nova.image.glance._glanceclient_from_endpoint')
     def test_retry_works_with_generators(self, create_client_mock,
                                          sleep_mock, shuffle_mock):
         def some_generator(exception):

--- a/releasenotes/notes/bug-retry-corrupted-download-5798b0df44a00e4e.yaml
+++ b/releasenotes/notes/bug-retry-corrupted-download-5798b0df44a00e4e.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    `Bug 1950657 <https://bugs.launchpad.net/nova/+bug/1950657>`_, fixing
+    behavior when nova-compute wouldn't retry image download when gets
+    "Corrupt image download" error from glanceclient and has num_retries
+    config option set.


### PR DESCRIPTION
Adding IOError in list of catching exceptions in order to
fix behavior when nova-compute wouldn't retry image download
when got "Corrupt image download" error from glanceclient
and had num_retries config option set.

Closes-Bug: #1950657
Change-Id: Iae4fd0579f71d3ba6793dbdb037275352d7e57b0