### PR TITLE
Vmware: Remove uuid parameter from get_vmdk_info call

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_images.py
+++ b/nova/tests/unit/virt/vmwareapi/test_images.py
@@ -172,7 +172,7 @@ class VMwareImagesTestCase(test.NoDBTestCase):
             mock_image_transfer.assert_called_once_with(mock_read_handle,
                                                         mock_write_handle)
             mock_get_vmdk_info.assert_called_once_with(
-                    session, mock.sentinel.vm_ref, 'fake-vm')
+                    session, mock.sentinel.vm_ref)
             mock_call_method.assert_called_once_with(
                     session.vim, "MarkAsTemplate", mock.sentinel.vm_ref)
 
@@ -224,7 +224,7 @@ class VMwareImagesTestCase(test.NoDBTestCase):
             mock_call_method.assert_called_once_with(
                     session.vim, "MarkAsTemplate", mock.sentinel.vm_ref)
             mock_get_vmdk_info.assert_called_once_with(
-                    session, mock.sentinel.vm_ref, 'fake-vm')
+                    session, mock.sentinel.vm_ref)
 
     def test_from_image_with_image_ref(self):
         raw_disk_size_in_gb = 83

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -513,6 +513,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         controller_key = 1000
         disk = fake.VirtualDisk()
         disk.controllerKey = controller_key
+        disk.unitNumber = 0
         disk_backing = fake.VirtualDiskFlatVer2BackingInfo()
         disk_backing.fileName = filename
         disk.capacityInBytes = 1024
@@ -522,37 +523,14 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         # Ephemeral disk
         e_disk = fake.VirtualDisk()
         e_disk.controllerKey = controller_key
+        e_disk.unitNumber = 1
         disk_backing = fake.VirtualDiskFlatVer2BackingInfo()
         disk_backing.fileName = '[test_datastore] uuid/ephemeral_0.vmdk'
         e_disk.capacityInBytes = 512
         e_disk.backing = disk_backing
         controller = fake.VirtualLsiLogicSASController()
         controller.key = controller_key
-        devices = [disk, e_disk, controller]
-        return devices
-
-    def _vmdk_path_and_adapter_type_devices_nomatch(self, filename,
-                                                    parent=None):
-        # Test the adapter_type returned for a lsiLogic sas controller
-        controller_key = 1000
-        disk = fake.DataObject()
-        disk.controllerKey = controller_key
-        disk_backing = fake.VirtualDiskFlatVer2BackingInfo()
-        disk_backing.fileName = filename
-        disk.capacityInBytes = 1024
-        if parent:
-            disk_backing.parent = parent
-        disk.backing = disk_backing
-        # Ephemeral disk
-        e_disk = fake.DataObject()
-        e_disk.controllerKey = controller_key
-        disk_backing = fake.VirtualDiskFlatVer2BackingInfo()
-        disk_backing.fileName = '[test_datastore] uuid/ephemeral_0.vmdk'
-        e_disk.capacityInBytes = 512
-        e_disk.backing = disk_backing
-        controller = fake.VirtualLsiLogicSASController()
-        controller.key = controller_key
-        devices = [disk, e_disk, controller]
+        devices = [e_disk, disk, controller]
         return devices
 
     def test_get_vmdk_path_and_adapter_type(self):
@@ -563,33 +541,9 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
             vmdk = vm_util.get_vmdk_info(session, None)
             self.assertEqual(constants.ADAPTER_TYPE_LSILOGICSAS,
                              vmdk.adapter_type)
-            self.assertEqual('[test_datastore] uuid/ephemeral_0.vmdk',
-                             vmdk.path)
-            self.assertEqual(512, vmdk.capacity_in_bytes)
-            self.assertEqual(devices[1], vmdk.device)
-
-    def test_get_vmdk_path_and_adapter_type_with_match(self):
-        n_filename = '[test_datastore] uuid/uuid.vmdk'
-        devices = self._vmdk_path_and_adapter_type_devices(n_filename)
-        session = fake.FakeSession()
-        with mock.patch.object(session, '_call_method', return_value=devices):
-            vmdk = vm_util.get_vmdk_info(session, None, uuid='uuid')
-            self.assertEqual(constants.ADAPTER_TYPE_LSILOGICSAS,
-                             vmdk.adapter_type)
-            self.assertEqual(n_filename, vmdk.path)
+            self.assertEqual(filename, vmdk.path)
             self.assertEqual(1024, vmdk.capacity_in_bytes)
-            self.assertEqual(devices[0], vmdk.device)
-
-    def test_get_vmdk_path_and_adapter_type_with_nomatch(self):
-        n_filename = '[test_datastore] diuu/diuu.vmdk'
-        session = fake.FakeSession()
-        devices = self._vmdk_path_and_adapter_type_devices_nomatch(n_filename)
-        with mock.patch.object(session, '_call_method', return_value=devices):
-            vmdk = vm_util.get_vmdk_info(session, None, uuid='uuid')
-            self.assertIsNone(vmdk.adapter_type)
-            self.assertIsNone(vmdk.path)
-            self.assertEqual(0, vmdk.capacity_in_bytes)
-            self.assertIsNone(vmdk.device)
+            self.assertEqual(devices[1], vmdk.device)
 
     def test_get_vmdk_adapter_type(self):
         # Test for the adapter_type to be used in vmdk descriptor

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -767,7 +767,7 @@ class VMwareVMOpsTestCase(test.TestCase):
             self._vmops._resize_create_ephemerals_and_swap(
                 'vm-ref', self._instance, 'block-devices')
             mock_get_vmdk_info.assert_called_once_with(
-                self._session, 'vm-ref', uuid=self._instance.uuid)
+                self._session, 'vm-ref')
             if vmdk.device:
                 mock_get_datastore_by_ref.assert_called_once_with(
                     self._session, datastore.ref)
@@ -901,7 +901,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                         'fake-spec')
             # Validate disk configuration
             fake_get_vmdk_info.assert_called_once_with(
-                self._session, 'fake-ref', uuid=self._instance.uuid)
+                self._session, 'fake-ref')
             fake_get_browser.assert_called_once_with('fake-ref')
             fake_original_exists.assert_called_once_with(
                  self._session, 'fake-browser',
@@ -1201,7 +1201,7 @@ class VMwareVMOpsTestCase(test.TestCase):
             fake_get_vm_ref.assert_called_once_with(self._session,
                                                     self._instance)
             fake_get_vmdk_info.assert_called_once_with(
-                self._session, 'fake-ref', uuid=self._instance.uuid)
+                self._session, 'fake-ref')
             fake_get_browser.assert_called_once_with('fake-ref')
             fake_original_exists.assert_called_once_with(
                 self._session, 'fake-browser',

--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -368,7 +368,7 @@ def fetch_image_stream_optimized(context, instance, session, vm_name,
 
     LOG.info("Downloaded image file data %(image_ref)s",
              {'image_ref': instance.image_ref}, instance=instance)
-    vmdk = vm_util.get_vmdk_info(session, imported_vm_ref, vm_name)
+    vmdk = vm_util.get_vmdk_info(session, imported_vm_ref)
     vm_util.mark_vm_as_template(session, instance, imported_vm_ref)
     return vmdk.capacity_in_bytes, vmdk.path
 
@@ -514,8 +514,7 @@ def fetch_image_ova(context, instance, session, vm_name, ds_name,
                 LOG.info("Downloaded OVA image file %(image_ref)s",
                          {'image_ref': instance.image_ref}, instance=instance)
                 vmdk = vm_util.get_vmdk_info(session,
-                                             imported_vm_ref,
-                                             vm_name)
+                                             imported_vm_ref)
                 vm_util.mark_vm_as_template(session, instance, imported_vm_ref)
                 return vmdk.capacity_in_bytes, vmdk.path
         raise exception.ImageUnacceptable(

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -913,45 +913,37 @@ def get_hardware_devices(session, vm_ref):
     return vim_util.get_array_items(hardware_devices)
 
 
-def get_vmdk_info(session, vm_ref, uuid=None):
-    """Returns information for the primary VMDK attached to the given VM."""
+def get_vmdk_info(session, vm_ref):
+    """Returns information for the first VMDK attached to the given VM."""
     vmdk_file_path = None
     vmdk_controller_key = None
     disk_type = None
     capacity_in_bytes = 0
-
-    # Determine if we need to get the details of the root disk
-    root_device = None
-
-    vmdk_device = None
+    first_device = None
 
     adapter_type_dict = {}
     for device in get_hardware_devices(session, vm_ref):
         if device.__class__.__name__ == "VirtualDisk":
             if device.backing.__class__.__name__ == \
                     "VirtualDiskFlatVer2BackingInfo":
-                if not root_device \
-                    or root_device.controllerKey > device.controllerKey \
-                    or root_device.controllerKey == device.controllerKey \
-                        and root_device.unitNumber > device.unitNumber:
-                    root_device = device
-                vmdk_device = device
+                if not first_device \
+                    or first_device.controllerKey > device.controllerKey \
+                    or first_device.controllerKey == device.controllerKey \
+                        and first_device.unitNumber > device.unitNumber:
+                    first_device = device
         elif device.__class__.__name__ in CONTROLLER_TO_ADAPTER_TYPE:
             adapter_type_dict[device.key] = CONTROLLER_TO_ADAPTER_TYPE[
                 device.__class__.__name__]
 
-    if uuid:
-        vmdk_device = root_device
-
-    if vmdk_device:
-        vmdk_file_path = vmdk_device.backing.fileName
-        capacity_in_bytes = _get_device_capacity(vmdk_device)
-        vmdk_controller_key = vmdk_device.controllerKey
-        disk_type = _get_device_disk_type(vmdk_device)
+    if first_device:
+        vmdk_file_path = first_device.backing.fileName
+        capacity_in_bytes = _get_device_capacity(first_device)
+        vmdk_controller_key = first_device.controllerKey
+        disk_type = _get_device_disk_type(first_device)
 
     adapter_type = adapter_type_dict.get(vmdk_controller_key)
     return VmdkInfo(vmdk_file_path, adapter_type, disk_type,
-                    capacity_in_bytes, vmdk_device)
+                    capacity_in_bytes, first_device)
 
 
 scsi_controller_classes = {

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -665,9 +665,7 @@ class VMwareVMOps(object):
 
     def _cache_vm_image_from_template(self, vi, templ_vm_ref):
         LOG.debug("Caching VDMK from template VM", instance=vi.instance)
-        vm_name = self._get_image_template_vm_name(vi.ii.image_id,
-                                                   vi.datastore.name)
-        vmdk = vm_util.get_vmdk_info(self._session, templ_vm_ref, vm_name)
+        vmdk = vm_util.get_vmdk_info(self._session, templ_vm_ref)
         # The size of the image is different from the size of the virtual disk.
         # We want to use the latter. On vSAN this is the only way to get this
         # size because there is no VMDK descriptor.
@@ -1080,9 +1078,7 @@ class VMwareVMOps(object):
         task_info = self._session._wait_for_task(vm_clone_task)
         vm_ref = task_info.result
 
-        root_vmdk_info = vm_util.get_vmdk_info(self._session,
-                                               vm_ref,
-                                               uuid=vi.instance.uuid)
+        root_vmdk_info = vm_util.get_vmdk_info(self._session, vm_ref)
         self._extend_if_required(vi.dc_info,
                                  vi.ii,
                                  vi.instance,
@@ -1585,8 +1581,7 @@ class VMwareVMOps(object):
 
         def _get_vm_and_vmdk_attribs():
             # Get the vmdk info that the VM is pointing to
-            vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
-                                              uuid=instance.uuid)
+            vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
             if not vmdk.path:
                 LOG.debug("No root disk defined. Unable to snapshot.",
                           instance=instance)
@@ -1822,8 +1817,7 @@ class VMwareVMOps(object):
         vm_ref = vm_util.get_vm_ref(self._session, instance)
 
         # Get the root disk vmdk object
-        vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
-                                     uuid=instance.uuid)
+        vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
         ds_ref = vmdk.device.backing.datastore
         datastore = ds_obj.get_datastore_by_ref(self._session, ds_ref)
         dc_info = self.get_datacenter_ref_and_name(datastore.ref)
@@ -2084,8 +2078,7 @@ class VMwareVMOps(object):
 
     def _resize_create_ephemerals_and_swap(self, vm_ref, instance,
                                            block_device_info):
-        vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
-                                     uuid=instance.uuid)
+        vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
         if not vmdk.device:
             LOG.debug("No root disk attached!", instance=instance)
             return
@@ -2103,8 +2096,7 @@ class VMwareVMOps(object):
         off the instance before the end.
         """
         vm_ref = vm_util.get_vm_ref(self._session, instance)
-        vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
-                                     uuid=instance.uuid)
+        vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
 
         boot_from_volume = compute_utils.is_volume_backed_instance(context,
                                                                    instance)
@@ -2146,8 +2138,7 @@ class VMwareVMOps(object):
     def confirm_migration(self, migration, instance, network_info):
         """Confirms a resize, destroying the source VM."""
         vm_ref = vm_util.get_vm_ref(self._session, instance)
-        vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
-                                     uuid=instance.uuid)
+        vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
         if not vmdk.device:
             return
         ds_ref = vmdk.device.backing.datastore
@@ -2207,8 +2198,7 @@ class VMwareVMOps(object):
             metadata=metadata)
         vm_util.reconfigure_vm(self._session, vm_ref, vm_resize_spec)
 
-        vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
-                                     uuid=instance.uuid)
+        vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
         if vmdk.device:
             self._revert_migration_update_disks(vm_ref, instance, vmdk,
                                                 block_device_info)
@@ -2251,8 +2241,7 @@ class VMwareVMOps(object):
         # need to relocate the VM here since we are running on the dest_compute
         if migration.source_compute != migration.dest_compute:
             # Get the root disk vmdk object's adapter type
-            vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
-                                         uuid=instance.uuid)
+            vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
             adapter_type = vmdk.adapter_type
 
             self._detach_volumes(instance, block_device_info)
@@ -2280,8 +2269,7 @@ class VMwareVMOps(object):
         # 3.Reconfigure the VM and disk
         self._resize_vm(context, instance, vm_ref, flavor, image_meta)
         if not boot_from_volume and resize_instance:
-            vmdk = vm_util.get_vmdk_info(self._session, vm_ref,
-                                         uuid=instance.uuid)
+            vmdk = vm_util.get_vmdk_info(self._session, vm_ref)
             self._resize_disk(instance, vm_ref, vmdk, flavor)
         self._update_instance_progress(context, instance,
                                        step=3,

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -352,8 +352,7 @@ class VMwareVolumeOps(object):
         # Get details required for adding disk device such as
         # adapter_type, disk_type
         vmdk = vm_util.get_vmdk_info(self._session, volume_ref)
-        instance_root_vmdk_info = vm_util.get_vmdk_info(self._session, vm_ref,
-                                                        uuid=instance.uuid)
+        instance_root_vmdk_info = vm_util.get_vmdk_info(self._session, vm_ref)
         adapter_type = adapter_type or instance_root_vmdk_info.adapter_type
 
         # IDE does not support disk hotplug


### PR DESCRIPTION
We changed the code to ignore the file-name,
as a vmotion will result in renaming of the files
breaking the heuristic to detect the root disk.
Instead we were taking the first disk,
when the uuid parameter was set.

The uuid parameter is not set when working with shadow-vms
and vms for image import. So, no special handling is
needed, we always want the first disk in those cases too
and so we can scrap the uuid argument.

Change-Id: Ib3088cfce4f7a0b24f05d45e7830b011c4a39f42