### PR TITLE
Vmware: Remove nvp.vm-uuid on clone

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1499,6 +1499,9 @@ class VMwareVMOps(object):
         config_spec.numCoresPerSocket = 1
         config_spec.memoryMB = 16
         config_spec.uuid = image_id  # Not instanceUuid,
+        config_spec.extraConfig = vm_util.create_extra_config(client_factory,
+            {'nvp.vm-uuid': ''})  # Another way to identify the vm
+
         # as we need to import the same image in different datastores
 
         if disks:


### PR DESCRIPTION
The clone created in a snapshot would also contain
the nvp.vm-uuid field in the extra-config.
If we delete then the original vm, the fallback mechanism
of searching for the VM by extra-config would trigger,
and find the snapshot and delete that instead.

Change-Id: I6a66fa07dfe864ad4deedc1cafe537959cd969f4