### PR TITLE
Vmwareapi: Move equality test to tests

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/fake.py
+++ b/nova/tests/unit/virt/vmwareapi/fake.py
@@ -29,6 +29,7 @@ from oslo_utils import units
 from oslo_utils import uuidutils
 from oslo_vmware import exceptions as vexc
 from oslo_vmware.objects import datastore as ds_obj
+from oslo_vmware import vim_util
 
 from nova import exception
 from nova.virt.vmwareapi import constants
@@ -188,6 +189,11 @@ class ManagedObjectReference(object):
 
     def __repr__(self):
         return "{}:{}".format(self._type, self.value)
+
+    def __eq__(self, other):
+        return (other is not None
+                and vim_util.get_moref_value(other) == self.value
+                and vim_util.get_moref_type(other) == self.type)
 
 
 class ObjectContent(object):

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1318,12 +1318,6 @@ class VmMoRefProxy(StableMoRefProxy):
             raise exception.InstanceNotFound(instance_id=self._uuid)
         vm_ref_cache_update(self._uuid, self.moref)
 
-    def __eq__(self, other):
-        try:
-            return self.moref == other.moref
-        except AttributeError:
-            return self.moref == other
-
 
 def get_vm_ref(session, instance):
     """Get reference to the VM through uuid."""


### PR DESCRIPTION
The equality test is only used by the tests
so it is better implemented there.

Change-Id: I51ee54265c4cc2b4f40c0b83f785a49f8a8ebce4