### PR TITLE
vmware: Set profile on volume attachment

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -1872,7 +1872,8 @@ class VMwareAPIVMTestCase(test.TestCase,
         return {'driver_volume_type': type,
                 'serial': 'volume-fake-id',
                 'data': {'volume': 'vm-10',
-                         'volume_id': 'volume-fake-id'}}
+                         'volume_id': 'volume-fake-id',
+                         'profile_id': 'fake-profile-id'}}
 
     @mock.patch.object(vmops.VMwareVMOps, 'update_cached_instances')
     @mock.patch('nova.virt.vmwareapi.volumeops.VMwareVolumeOps.'
@@ -1930,7 +1931,7 @@ class VMwareAPIVMTestCase(test.TestCase,
             attach_disk_to_vm.assert_called_once_with(mock.sentinel.vm_ref,
                 self.instance, adapter_type, disk_type, vmdk_path='fake-path',
                 volume_uuid=connection_info['data']['volume_id'],
-                backing_uuid=disk_uuid)
+                backing_uuid=disk_uuid, profile_id='fake-profile-id')
 
     def test_detach_vmdk_disk_from_vm(self):
         self._create_vm()
@@ -1998,7 +1999,8 @@ class VMwareAPIVMTestCase(test.TestCase,
                                     mount_point)
 
             mock_attach_disk.assert_called_once_with(mock.ANY, self.instance,
-                mock.ANY, 'rdmp', device_name=mock.ANY)
+                mock.ANY, 'rdmp', device_name=mock.ANY,
+                profile_id='fake-profile-id')
             mock_iscsi_get_target.assert_called_once_with(
                 connection_info['data'])
 

--- a/nova/tests/unit/virt/vmwareapi/test_volumeops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_volumeops.py
@@ -255,7 +255,8 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
                                'serial': 'volume-fake-id',
                                'data': {'volume': 'vm-10',
                                         'volume_id':
-                                        'd11a82de-ddaa-448d-b50a-a255a7e61a1e'
+                                        'd11a82de-ddaa-448d-b50a-a255a7e61a1e',
+                                        'profile_id': 'fake-profile-id'
                                         }}
             instance = mock.MagicMock(name='fake-name',
                                       vm_state=vm_states.ACTIVE)
@@ -271,7 +272,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
             consolidate_vmdk_volume.assert_called_once_with(
                 instance, mock.sentinel.vm_ref, virtual_disk,
                 mock.sentinel.volume_ref, adapter_type=adapter_type,
-                disk_type='fake-disk-type')
+                disk_type='fake-disk-type', profile_id='fake-profile-id')
             detach_disk_from_vm.assert_called_once_with(
                 mock.sentinel.vm_ref, instance, virtual_disk,
                 volume_uuid=connection_info['data']['volume_id'])
@@ -404,7 +405,8 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
         connection_info = {'driver_volume_type': constants.DISK_FORMAT_VMDK,
                            'serial': 'volume-fake-id',
                            'data': {'volume': 'vm-10',
-                                    'volume_id': 'volume-fake-id'}}
+                                    'volume_id': 'volume-fake-id',
+                                    'profile_id': 'fake-profile-id'}}
         vm_ref = 'fake-vm-ref'
         volume_device = mock.MagicMock()
         volume_device.backing.fileName = 'fake-path'
@@ -443,7 +445,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
                 vm_ref, self._instance, adapter_type,
                 constants.DISK_TYPE_PREALLOCATED, vmdk_path='fake-path',
                 volume_uuid=connection_info['data']['volume_id'],
-                backing_uuid=disk_uuid)
+                backing_uuid=disk_uuid, profile_id='fake-profile-id')
             if adapter_type == constants.ADAPTER_TYPE_IDE:
                 get_vm_state.assert_called_once_with(self._volumeops._session,
                                                      self._instance)
@@ -480,7 +482,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
                 self.assertTrue(get_scsi_adapter_type.called)
             attach_disk_to_vm.assert_called_once_with(vm_ref,
                 self._instance, adapter_type, 'rdmp',
-                device_name=mock.sentinel.device_name)
+                device_name=mock.sentinel.device_name, profile_id=None)
 
     def test_attach_volume_vmdk(self):
         for adapter_type in (None, constants.DEFAULT_ADAPTER_TYPE,
@@ -553,7 +555,8 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
 
         self._volumeops._consolidate_vmdk_volume(instance, vm_ref, device,
                                                  volume_ref, adapter_type,
-                                                 disk_type)
+                                                 disk_type,
+                                                 profile_id='fake-profile-id')
 
         get_vmdk_base_volume_device.assert_called_once_with(volume_ref)
         relocate_vm.assert_called_once_with(self._session,
@@ -562,7 +565,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
             volume_ref, instance, original_device, destroy_disk=True)
         attach_disk_to_vm.assert_called_once_with(
             volume_ref, instance, adapter_type, disk_type,
-            vmdk_path=new_file_name)
+            vmdk_path=new_file_name, profile_id='fake-profile-id')
 
     @mock.patch.object(volumeops.VMwareVolumeOps,
                        '_get_vmdk_base_volume_device')
@@ -613,7 +616,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
             volume_ref, instance, original_device)
         attach_disk_to_vm.assert_called_once_with(
             volume_ref, instance, adapter_type, disk_type,
-            vmdk_path=new_file_name)
+            vmdk_path=new_file_name, profile_id=None)
 
     def test_iscsi_get_host_iqn(self):
         host_mor = mock.Mock()

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -1008,6 +1008,11 @@ class VMwareVCDriver(driver.ComputeDriver):
             if datastore:
                 data["datastore_ref"] = vim_util.get_moref(datastore,
                                                         "Datastore")
+
+            profile_id = data.get("profile_id")
+            if profile_id:
+                data["profile_id"] = profile_id
+
             volume_infos.append(data)
         return self._volumeops.map_volumes_to_devices(instance, volume_infos)
 

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -742,7 +742,8 @@ def get_vmdk_attach_config_spec(client_factory,
                                 controller_key=None,
                                 unit_number=None,
                                 device_name=None,
-                                disk_io_limits=None):
+                                disk_io_limits=None,
+                                profile_id=None):
     """Builds the vmdk attach config spec."""
     config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
 
@@ -750,7 +751,8 @@ def get_vmdk_attach_config_spec(client_factory,
     virtual_device_config_spec = _create_virtual_disk_spec(client_factory,
                                 controller_key, disk_type, file_path,
                                 disk_size, linked_clone,
-                                unit_number, device_name, disk_io_limits)
+                                unit_number, device_name, disk_io_limits,
+                                profile_id=profile_id)
 
     device_config_spec.append(virtual_device_config_spec)
 
@@ -1033,7 +1035,8 @@ def _create_virtual_disk_spec(client_factory, controller_key,
                               linked_clone=False,
                               unit_number=None,
                               device_name=None,
-                              disk_io_limits=None):
+                              disk_io_limits=None,
+                              profile_id=None):
     """Builds spec for the creation of a new/ attaching of an already existing
     Virtual Disk to the VM.
     """
@@ -1090,6 +1093,12 @@ def _create_virtual_disk_spec(client_factory, controller_key,
             'ns0:StorageIOAllocationInfo')
 
     virtual_device_config.device = virtual_disk
+
+    if profile_id:
+        disk_profile = \
+            client_factory.create('ns0:VirtualMachineDefinedProfileSpec')
+        disk_profile.profileId = profile_id
+        virtual_device_config.profile = [disk_profile]
 
     return virtual_device_config
 

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -62,7 +62,8 @@ class VMwareVolumeOps(object):
                           adapter_type, disk_type, vmdk_path=None,
                           disk_size=None, linked_clone=False,
                           device_name=None, disk_io_limits=None,
-                          volume_uuid=None, backing_uuid=None):
+                          volume_uuid=None, backing_uuid=None,
+                          profile_id=None):
         """Attach disk to VM by reconfiguration.
 
         If volume_uuid and backing_uuid are given, also store the uuid of the
@@ -79,7 +80,8 @@ class VMwareVolumeOps(object):
         vmdk_attach_config_spec = vm_util.get_vmdk_attach_config_spec(
                                     client_factory, disk_type, vmdk_path,
                                     disk_size, linked_clone, controller_key,
-                                    unit_number, device_name, disk_io_limits)
+                                    unit_number, device_name, disk_io_limits,
+                                    profile_id=profile_id)
         if controller_spec:
             vmdk_attach_config_spec.deviceChange.append(controller_spec)
 
@@ -385,7 +387,8 @@ class VMwareVolumeOps(object):
         self.attach_disk_to_vm(vm_ref, instance, adapter_type, vmdk.disk_type,
                                vmdk_path=vmdk.path,
                                volume_uuid=data['volume_id'],
-                               backing_uuid=vmdk.device.backing.uuid)
+                               backing_uuid=vmdk.device.backing.uuid,
+                               profile_id=data['profile_id'])
 
         LOG.debug("Attached VMDK: %s", connection_info, instance=instance)
 
@@ -412,7 +415,8 @@ class VMwareVolumeOps(object):
 
         self.attach_disk_to_vm(vm_ref, instance,
                                adapter_type, 'rdmp',
-                               device_name=device_name)
+                               device_name=device_name,
+                               profile_id=data.get('profile_id'))
         LOG.debug("Attached ISCSI: %s", connection_info, instance=instance)
 
     def attach_volume(self, connection_info, instance, adapter_type=None):
@@ -453,7 +457,8 @@ class VMwareVolumeOps(object):
         return self._get_res_pool_of_host(host)
 
     def _consolidate_vmdk_volume(self, instance, vm_ref, device, volume_ref,
-                                 adapter_type=None, disk_type=None):
+                                 adapter_type=None, disk_type=None,
+                                 profile_id=None):
         """Consolidate volume backing VMDK files if needed.
 
         The volume's VMDK file attached to an instance can be moved by SDRS
@@ -530,7 +535,8 @@ class VMwareVolumeOps(object):
         # Attach the current volume to the volume_ref
         self.attach_disk_to_vm(volume_ref, instance,
                                adapter_type, disk_type,
-                               vmdk_path=current_device_path)
+                               vmdk_path=current_device_path,
+                               profile_id=profile_id)
 
     def _get_vmdk_backed_disk_device(self, vm_ref, connection_info_data):
         # Get the vmdk file name that the VM is pointing to
@@ -575,7 +581,8 @@ class VMwareVolumeOps(object):
 
         self._consolidate_vmdk_volume(instance, vm_ref, device, volume_ref,
                                       adapter_type=adapter_type,
-                                      disk_type=disk_type)
+                                      disk_type=disk_type,
+                                      profile_id=data.get('profile_id'))
 
         self.detach_disk_from_vm(vm_ref, instance, device,
                                  volume_uuid=data['volume_id'])
@@ -690,7 +697,8 @@ class VMwareVolumeOps(object):
                     instance,
                     constants.DEFAULT_ADAPTER_TYPE,
                     disk_type,
-                    current_device_path
+                    current_device_path,
+                    profile_id=data.get("profile_id")
                     )
             except Exception:
                 LOG.exception("Failed to attach volume {}. Device {}".format(


### PR DESCRIPTION
If we attach a volume to a VM, we have to set the storage-profile.
Otherwise, the VM will not be compliant to the profile and - especially
on VMFS datastores - cannot be storage-vMotioned around if the
storage-profile includes storage-IO control. With setting the profile
for each disk-attachment, the VM also shows compliant to these profiles
in the UI.

Change-Id: Idad6293dc7dfdf46fed584b9c116c03f928d44fe