### PR TITLE
vmware: Remove redundant code of profile_id.

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -1012,11 +1012,6 @@ class VMwareVCDriver(driver.ComputeDriver):
             if datastore:
                 data["datastore_ref"] = vim_util.get_moref(datastore,
                                                         "Datastore")
-
-            profile_id = data.get("profile_id")
-            if profile_id:
-                data["profile_id"] = profile_id
-
             volume_infos.append(data)
         return self._volumeops.map_volumes_to_devices(instance, volume_infos)
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -4151,6 +4151,7 @@ class VMwareVMOps(object):
                                                        datastore.ref)
             LOG.debug("Moved instance %s in server-group %s to hagroup %s.",
                       instance.uuid, sg_uuid, hagroup)
+
     def _get_instance_config_info(self, context, instance, image_meta=None):
         """Returns VirtualMachineInstanceConfigInfo based on instance."""
         image_meta = image_meta or instance.image_meta


### PR DESCRIPTION
This removes redundant code introduced in
Idad6293dc7dfdf46fed584b9c116c03f928d44fe

Also fixes warnings of `tox -e pep8`.