### PR TITLE
VMwareapi: Raise proper exception for missing shadow-vms

### DIFF
--- a/nova/virt/vmwareapi/session.py
+++ b/nova/virt/vmwareapi/session.py
@@ -136,6 +136,10 @@ class VMwareAPISession(api.VMwareAPISession):
                     # We have found the argument with the moref
                     # causing the exception and we can try to recover it
                     arg.fetch_moref(self)
+                    if not arg.moref:
+                        # We didn't recover the reference
+                        ctxt.reraise = True
+                        break
                     moref_arg = get_moref_value(arg.moref)
                     if moref != moref_arg:
                         # We actually recovered, so do not raise `monfe`


### PR DESCRIPTION
If a shadow-vm is missing, we raise an AttributeError,
which is not clearly identifying the reason of the failure.
We better re-raise the original ManagedObjectNotFound exception,
so it is more clearly identifiable

Change-Id: I954c57e97961833208743bc88e3ce75ad23cfe8c