### PR TITLE
Vmware: Warn about failed drs override removal

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2195,8 +2195,8 @@ class VMwareVMOps(object):
                                                             vm_ref,
                                                             operation='remove')
             except Exception:
-                LOG.exception('Could not remove DRS override.',
-                              instance=instance)
+                LOG.warning('Could not remove DRS override.',
+                            instance=instance)
 
         self._clean_up_after_special_spawning(context, flavor.memory_mb,
                                               flavor)


### PR DESCRIPTION
An error needs manual intervention, and an exception debugging from
a developer. This, however, is a known behaviour which potentially
can lead to problems, hence a warning

Change-Id: I9479fb6405485e763a6344e7f44a60f75891adcb