### PR TITLE
Vmwareapi: Fix attachment of multiple nics

### DIFF
--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -322,8 +322,9 @@ def append_vif_infos_to_config_spec(client_factory,
     if not hasattr(config_spec, 'deviceChange') or \
             not config_spec.deviceChange:
         config_spec.deviceChange = []
-    for vif_info in vif_infos:
-        vif_spec = _create_vif_spec(client_factory, vif_info, vif_limits)
+    for offset, vif_info in enumerate(vif_infos):
+        vif_spec = _create_vif_spec(client_factory, vif_info, vif_limits,
+            offset)
         config_spec.deviceChange.append(vif_spec)
 
     if not hasattr(config_spec, 'extraConfig') or \
@@ -605,7 +606,7 @@ def convert_vif_model(name):
     return name
 
 
-def _create_vif_spec(client_factory, vif_info, vif_limits=None):
+def _create_vif_spec(client_factory, vif_info, vif_limits=None, offset=0):
     """Builds a config spec for the addition of a new network
     adapter to the VM.
     """
@@ -633,7 +634,8 @@ def _create_vif_spec(client_factory, vif_info, vif_limits=None):
     # The Server assigns a Key to the device. Here we pass a -ve temporary key.
     # -ve because actual keys are +ve numbers and we don't
     # want a clash with the key that server might associate with the device
-    net_device.key = -47
+    # We add a potential offset, so that multiple nics do not get the same key
+    net_device.key = -47 + offset
     net_device.addressType = "manual"
     net_device.macAddress = mac_address
     net_device.wakeOnLanEnabled = True


### PR DESCRIPTION
If multiple nics are attached, they need different device-keys
otherwise the vmwareapi will reject the request

Change-Id: I0aa58ad11c499e9423c7ecc7998325b05dd9147e