### PR TITLE
vmware: datastore_hagroup_regex ignores case

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -248,7 +248,7 @@ If this setting is set, datastores are split into 2 ha-groups to distribute
 anti-affin servers between them. The datastores found with the datastore_regex
 setting belong to either HA-group A or B by applying this regex onto the
 datastore name. This setting must include a matched group of the name
-"hagroup".
+"hagroup". The regex defined here is used ignoring case.
 """),
     cfg.FloatOpt('task_poll_interval',
                  default=0.5,

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -127,7 +127,7 @@ class VMwareVCDriver(driver.ComputeDriver):
                 raise error_util.DatastoreRegexUnspecified()
             try:
                 self._datastore_hagroup_regex = \
-                    re.compile(CONF.vmware.datastore_hagroup_regex)
+                    re.compile(CONF.vmware.datastore_hagroup_regex, re.I)
             except re.error:
                 raise exception.InvalidInput(reason=
                     "Invalid Regular Expression {}"


### PR DESCRIPTION
When finding hagroups in datastores with the regex from
datastore_hagroup_regex, we use re.I to ignore the case so that an error
made by an operator in naming the datastore does not break the feature.

Change-Id: I4de760d99513abc9977f698aaba85b6456709ca6