### PR TITLE
vmware: Set appropriate settings for resize to > 128 cores

### DIFF
--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -541,6 +541,15 @@ def get_vm_resize_spec(client_factory, vcpus, memory_mb, extra_specs,
     # `memoryAllocation` support on resize.
     resize_spec.memoryReservationLockedToMax = False
 
+    if extra_specs.cores_per_socket:
+        resize_spec.numCoresPerSocket = int(extra_specs.cores_per_socket)
+    # NOTE(jkulik): this only works with 6.7 and newer
+    if int(vcpus) > 128:
+        flags = client_factory.create('ns0:VirtualMachineFlagInfo')
+        flags.vvtdEnabled = True
+        flags.virtualMmuUsage = 'automatic'
+        resize_spec.flags = flags
+
     extra_config = []
     # big VMs need to prefer HT threads to stay in NUMA nodes
     if extra_specs.numa_prefer_ht is not None:


### PR DESCRIPTION
When spawning a VM with more than 128 cores, we set numCoresPerSocket
and some flags e.g. vvtdEnabled. We missed to add the same flags when
resizing to a VM having more than 128 cores. This patch remedies that.

Change-Id: I381a413ecf80af14dd4bf1dfde2d070976b6477a