### PR TITLE
Vmwareapi: Migrate disk with minimal vm

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2861,6 +2861,16 @@ class VMwareVMOps(object):
         rel_spec = target.get_relocate_spec(context, instance, flavor,
                                             factory=factory)
 
+        # Scale the cloned vm down to minimal resources,
+        # so that it fits the source hypervisor as well as the destination.
+        # The actual size will configured after the migration, and should
+        # fit thanks to the scheduler logic
+        client_factory = self._session.vim.client.factory
+        config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
+        config_spec.memoryMB = 4
+        config_spec.numCPUs = 1
+        config_spec.numCoresPerSocket = 1
+
         # We name the VM just by the instance.uuid to follow the same pattern
         # as in the instance creation
         # This causes the folder on the datastore to be named by the
@@ -2891,10 +2901,11 @@ class VMwareVMOps(object):
         return vm_util.create_service_locator(cf, url, self._vcenter_uuid,
                                               credential)
 
-    def _clone_vm(self, vm_ref, rel_spec, name):
+    def _clone_vm(self, vm_ref, rel_spec, name, config_spec=None):
         """Returns a MoRef of the newly-created VM"""
         client_factory = self._session.vim.client.factory
         clone_spec = vm_util.clone_vm_spec(client_factory, rel_spec)
+        clone_spec.config = config_spec
         vm_clone_task = self._session._call_method(self._session.vim,
                                                    "CloneVM_Task",
                                                    vm_ref,


### PR DESCRIPTION
When simply cloning the original VM, the size might not
fit on the target hypervisor.
Resizing it to the target size might not fit on the
source hypervisor.
So we simply scale it to minimal size, as we are going
to reconfigure it to the proper size on the target
hypervisor anyway.

Change-Id: Ia05e5b3a5d6913bfcef01fa97465a1aaa69872d0