### PR TITLE
Handle resource_providers is None gracefully

### DIFF
--- a/nova/scheduler/client/report.py
+++ b/nova/scheduler/client/report.py
@@ -487,7 +487,7 @@ class SchedulerReportClient(object):
         resp = self.get(url, version='1.18',
                         global_request_id=context.global_id)
         if resp.status_code == 200:
-            return resp.json()['resource_providers']
+            return resp.json()['resource_providers'] or []
 
         msg = _("[%(placement_req_id)s] Failed to retrieve sharing resource "
                 "providers associated with the following aggregates from "


### PR DESCRIPTION
Apparently, the api can return None under some circumstances.
Handle that gracefully instead of raising an exception.

Change-Id: Id9b2249030a61b7f33cd66ffadb6dc7f284265e7