### PR TITLE
vmware: Set migration.dataTimeout for big VMs

### DIFF
--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -110,7 +110,8 @@ class ExtraSpecs(object):
                  storage_policy=None, cores_per_socket=None,
                  memory_limits=None, disk_io_limits=None,
                  vif_limits=None, hv_enabled=None, firmware=None,
-                 hw_video_ram=None, numa_prefer_ht=None):
+                 hw_video_ram=None, numa_prefer_ht=None,
+                 migration_data_timeout=None):
         """ExtraSpecs object holds extra_specs for the instance."""
         self.cpu_limits = cpu_limits or Limits()
         self.memory_limits = memory_limits or Limits()
@@ -123,6 +124,7 @@ class ExtraSpecs(object):
         self.firmware = firmware
         self.hw_video_ram = hw_video_ram
         self.numa_prefer_ht = numa_prefer_ht
+        self.migration_data_timeout = migration_data_timeout
 
 
 class HistoryCollectorItems(six.Iterator):
@@ -453,6 +455,14 @@ def get_vm_create_spec(client_factory, instance, data_store_name,
         opt.value = extra_specs.numa_prefer_ht
         extra_config.append(opt)
 
+    # big VMs need more time to settle to make reconfigures possible after they
+    # ran for some time
+    if extra_specs.migration_data_timeout is not None:
+        opt = client_factory.create('ns0:OptionValue')
+        opt.key = 'migration.dataTimeout'
+        opt.value = extra_specs.migration_data_timeout
+        extra_config.append(opt)
+
     config_spec.extraConfig = extra_config
 
     append_vif_infos_to_config_spec(client_factory,
@@ -556,6 +566,14 @@ def get_vm_resize_spec(client_factory, vcpus, memory_mb, extra_specs,
         opt = client_factory.create('ns0:OptionValue')
         opt.key = 'numa.vcpu.preferHT'
         opt.value = extra_specs.numa_prefer_ht
+        extra_config.append(opt)
+
+    # big VMs need more time to settle to make reconfigures possible after they
+    # ran for some time
+    if extra_specs.migration_data_timeout is not None:
+        opt = client_factory.create('ns0:OptionValue')
+        opt.key = 'migration.dataTimeout'
+        opt.value = extra_specs.migration_data_timeout
         extra_config.append(opt)
 
     resize_spec.extraConfig = extra_config

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -443,9 +443,11 @@ class VMwareVMOps(object):
         extra_specs.hw_version = hw_version
         if utils.is_big_vm(int(flavor.memory_mb), flavor):
             extra_specs.numa_prefer_ht = 'TRUE'
+            extra_specs.migration_data_timeout = '900'
         else:
             # empty value should delete the option. we need that for resizes.
             extra_specs.numa_prefer_ht = ''
+            extra_specs.migration_data_timeout = ''
 
         video_ram = image_meta.properties.get('hw_video_ram', 0)
         max_vram = int(flavor.extra_specs.get('hw_video:ram_max_mb', 0))


### PR DESCRIPTION
When VMs with lots of CPUs are running for a longer period of time, a
task to reconfigure the VM might end up hanging in the vCenter.

According to VMware support, this problem happens if those VMs are
running for a longer period of time and with the large number of CPUs
have accumulated enough differences between those CPUs, that getting
them all into a state where a reconfigure can be executed takes more
time than the default 2s (iirc). The advanced setting to increase this
time is "migration.dataTimeout".

For simplicity reasons and because it shouldn't hurt (according to
VMware), we set it on all big VMs. That way, we do not have to figure
out if the VM consumes enough CPUs of the hypervisor to need this
setting.

Change-Id: Id8bda847c9e48997b385d9e1079ee9e99af9b8e8