### PR TITLE
Fix #324 Migrate disk with minimal VM

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1499,6 +1499,9 @@ class VMwareVMOpsTestCase(test.TestCase):
         self.assertEqual(self._instance.uuid, kwargs['name'])
         spec = kwargs['spec']
         self.assertFalse(spec.powerOn)
+        self.assertEqual(4, spec.config.memoryMB)
+        self.assertEqual(1, spec.config.numCPUs)
+        self.assertEqual(1, spec.config.numCoresPerSocket)
         # Relocate spec
         self.assertEqual(datastore_ref, spec.location.datastore)
         if remote:

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2884,7 +2884,8 @@ class VMwareVMOps(object):
         # This causes the folder on the datastore to be named by the
         # instance.uuid potentially with a suffix in case the source and
         # destination are on the same datastore
-        cloned_vm = self._clone_vm(vm_ref, rel_spec, name=instance.uuid)
+        cloned_vm = self._clone_vm(vm_ref, rel_spec, name=instance.uuid,
+                                   config_spec=config_spec)
         LOG.info("Cloned VM with temporary name '%s'", instance.uuid,
                  instance=instance)
         try:


### PR DESCRIPTION
In #324 there was introduced a minimal configuration for the
cloned VM. However, _clone_vm was never called with that config.