### PR TITLE
[vmware] Pull the image from Swift directly

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -494,6 +494,14 @@ Possible values:
  * integer >= time in seconds to sleep between runs
  * intger < 0: disable the sync-loop
 """),
+    cfg.StrOpt('allow_pulling_images_from_url',
+               default=True,
+               help="""
+Allow VMware to pull images directly from Swift. By enabling this, images
+that are stored in Swift will be downloaded by VMWare from the `direct_url`,
+instead of the nova-compute service having to proxy the image between glance
+and VMware.
+"""),
 ]
 
 ALL_VMWARE_OPTS = (vmwareapi_vif_opts +

--- a/nova/tests/unit/virt/vmwareapi/test_images.py
+++ b/nova/tests/unit/virt/vmwareapi/test_images.py
@@ -22,6 +22,7 @@ import mock
 from oslo_utils import units
 from oslo_vmware import rw_handles
 
+import nova.conf
 from nova import exception
 from nova import objects
 from nova import test
@@ -30,6 +31,8 @@ from nova.tests import uuidsentinel
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import images
 from nova.virt.vmwareapi import vm_util
+
+CONF = nova.conf.CONF
 
 
 class VMwareImagesTestCase(test.NoDBTestCase):
@@ -183,6 +186,8 @@ class VMwareImagesTestCase(test.NoDBTestCase):
                                           mock_read_class):
         """Test fetching streamOptimized disk image."""
         session = mock.MagicMock()
+        CONF.set_override('allow_pulling_images_from_url', False,
+                          'vmware')
 
         with test.nested(
              mock.patch.object(images.IMAGE_API, 'get'),

--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -29,6 +29,7 @@ from oslo_utils import encodeutils
 from oslo_utils import strutils
 from oslo_utils import units
 from oslo_vmware import exceptions as vexc
+from oslo_vmware.image_transfer import image_pull_from_url
 from oslo_vmware import rw_handles
 
 from nova import exception
@@ -352,19 +353,37 @@ def fetch_image_stream_optimized(context, instance, session, vm_name,
               "as VM named '%(vm_name)s'",
               {'image_ref': image_ref, 'vm_name': vm_name},
               instance=instance)
-
-    metadata = IMAGE_API.get(context, image_ref)
+    allow_url = CONF.vmware.allow_pulling_images_from_url
+    metadata = IMAGE_API.get(context, image_ref,
+                             include_locations=allow_url)
     file_size = int(metadata['size'])
 
     vm_import_spec = _build_import_spec_for_import_vapp(
             session, vm_name, ds_name)
 
-    read_iter = IMAGE_API.download(context, image_ref)
-    read_handle = rw_handles.ImageReadHandle(read_iter)
+    url_handle = None
+    if allow_url:
+        try:
+            url_handle = rw_handles.SwiftUrlPullHandle(
+                metadata.get('direct_url', None),
+                context.get_auth_plugin().auth_token)
+        except ValueError as e:
+            LOG.debug(e)
 
-    imported_vm_ref = _import_image(session, read_handle, vm_import_spec,
-                                    vm_name, vm_folder_ref, res_pool_ref,
-                                    file_size)
+    if url_handle:
+        imported_vm_ref = image_pull_from_url(url_handle,
+                                              session=session,
+                                              resource_pool=res_pool_ref,
+                                              vm_import_spec=vm_import_spec,
+                                              vm_folder=vm_folder_ref,
+                                              image_size=file_size)
+    else:
+        read_iter = IMAGE_API.download(context, image_ref)
+        read_handle = rw_handles.ImageReadHandle(read_iter)
+
+        imported_vm_ref = _import_image(session, read_handle, vm_import_spec,
+                                        vm_name, vm_folder_ref, res_pool_ref,
+                                        file_size)
 
     LOG.info("Downloaded image file data %(image_ref)s",
              {'image_ref': instance.image_ref}, instance=instance)


### PR DESCRIPTION
By using HttpNfcLeasePullFromUrls_Task we can convert an import
lease to pull the image from a Swift URL, instead of nova pushing
the bytes into the HttpNfcLease.