### PR TITLE
Vmwareapi: Set hw version on resize

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1040,7 +1040,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
-                       return_value='fake-spec')
+                       return_value=mock.Mock(version=None))
     @mock.patch.object(vm_util, 'get_vm_ref', return_value='vm-ref')
     def test_resize_vm(self, fake_get_vm_ref,
                        fake_resize_spec, fake_reconfigure,
@@ -1062,14 +1062,15 @@ class VMwareVMOpsTestCase(test.TestCase):
             self._session.vim.client.factory, 2, 1024, extra_specs,
             metadata=self._metadata)
         fake_reconfigure.assert_called_once_with(self._session,
-                                                 vm_ref, 'fake-spec')
+                                                 vm_ref,
+                                                 fake_resize_spec.return_value)
 
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
     @mock.patch.object(vmops.VMwareVMOps, '_clean_up_after_special_spawning')
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
-                       return_value='fake-spec')
+                       return_value=mock.MagicMock(version=None))
     @mock.patch.object(vm_util, 'get_vm_ref',
                        return_value=mock.sentinel.vm_ref)
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
@@ -1102,7 +1103,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vmops.VMwareVMOps, '_clean_up_after_special_spawning')
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
-                       return_value='fake-spec')
+                       return_value=mock.MagicMock(version=None))
     @mock.patch.object(vm_util, 'get_vm_ref',
                        return_value=mock.sentinel.vm_ref)
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -546,6 +546,7 @@ def get_vm_resize_spec(client_factory, vcpus, memory_mb, extra_specs,
     resize_spec.memoryAllocation = _get_allocation_info(
         client_factory, extra_specs.memory_limits,
         'ns0:ResourceAllocationInfo')
+    resize_spec.version = extra_specs.hw_version
     # NOTE(jkulik) We used to set this setting instead of `memoryAllocation`,
     # so we need to deconfigure it on VMs created before the patch adding
     # `memoryAllocation` support on resize.

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2161,6 +2161,10 @@ class VMwareVMOps(object):
         instance.progress = progress
         instance.save()
 
+    @staticmethod
+    def _hw_version_to_int(version):
+        return int(version.split('-', 1)[1])
+
     def _resize_vm(self, context, instance, vm_ref, flavor, image_meta):
         """Resizes the VM according to the flavor."""
         client_factory = self._session.vim.client.factory
@@ -2172,6 +2176,20 @@ class VMwareVMOps(object):
                                                     extra_specs,
                                                     metadata=metadata)
         vm_util.reconfigure_vm(self._session, vm_ref, vm_resize_spec)
+
+        if vm_resize_spec.version:
+            current_version = self._session._call_method(vutil,
+                'get_object_property', vm_ref, 'config.version')
+            _current = self._hw_version_to_int(current_version)
+            _required = self._hw_version_to_int(vm_resize_spec.version)
+
+            if _current < _required:
+                LOG.debug("Upgrading vm version from %s to %s",
+                          current_version, vm_resize_spec.version,
+                          instance=instance)
+                upgrade_task = self._session._call_method(self._session.vim,
+                    "UpgradeVM_Task", vm_ref, version=vm_resize_spec.version)
+                self._session._wait_for_task(upgrade_task)
 
         old_flavor = instance.old_flavor
         old_needs_override = utils.is_big_vm(int(old_flavor.memory_mb),
@@ -4015,8 +4033,6 @@ class VMwareVMOps(object):
                                                  int(flavor.vcpus),
                                                  int(flavor.memory_mb),
                                                  extra_specs)
-        # The last mandatory field for config_spec per doc
-        config_spec.version = extra_specs.hw_version
         placement_spec.configSpec = config_spec
 
         vm_group_name = self._get_admin_group_name_for_instance(instance)


### PR DESCRIPTION
Resizing to a different flavour may imply also
a different hw-version, so we need to set it
otherwise it will stay on the previous one,
which may be incompatible with the desired configuration.

Only upgrade is possible though.

Change-Id: I7976a377c3e8944483a10fdada391e8c51640e30