### PR TITLE
Vmware: Only change hw_version by flavor

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -407,7 +407,6 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         expected = fake_factory.create('ns0:VirtualMachineConfigSpec')
         expected.memoryMB = memory_mb
         expected.numCPUs = vcpus
-        expected.version = hw_version
         cpuAllocation = fake_factory.create('ns0:ResourceAllocationInfo')
         cpuAllocation.reservation = 0
         cpuAllocation.limit = -1
@@ -441,7 +440,6 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         expected = fake_factory.create('ns0:VirtualMachineConfigSpec')
         expected.memoryMB = memory_mb
         expected.numCPUs = vcpus
-        expected.version = None
         cpuAllocation = fake_factory.create('ns0:ResourceAllocationInfo')
         cpuAllocation.reservation = 6
         cpuAllocation.limit = 7
@@ -451,36 +449,6 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         expected.cpuAllocation = cpuAllocation
         memoryAllocation = fake_factory.create('ns0:ResourceAllocationInfo')
         memoryAllocation.reservation = 127
-        memoryAllocation.limit = -1
-        memoryAllocation.shares = fake_factory.create('ns0:SharesInfo')
-        memoryAllocation.shares.level = 'normal'
-        memoryAllocation.shares.shares = 0
-        expected.memoryAllocation = memoryAllocation
-        expected.extraConfig = []
-        expected.memoryReservationLockedToMax = False
-
-        self.assertEqual(expected, result)
-
-    def test_get_resize_spec_with_hw_version(self):
-        vcpus = 2
-        memory_mb = 2048
-        extra_specs = vm_util.ExtraSpecs(hw_version=mock.sentinel.hw_version)
-        fake_factory = fake.FakeFactory()
-        result = vm_util.get_vm_resize_spec(fake_factory,
-                                            vcpus, memory_mb, extra_specs)
-        expected = fake_factory.create('ns0:VirtualMachineConfigSpec')
-        expected.memoryMB = memory_mb
-        expected.numCPUs = vcpus
-        expected.version = mock.sentinel.hw_version
-        cpuAllocation = fake_factory.create('ns0:ResourceAllocationInfo')
-        cpuAllocation.reservation = 0
-        cpuAllocation.limit = -1
-        cpuAllocation.shares = fake_factory.create('ns0:SharesInfo')
-        cpuAllocation.shares.level = 'normal'
-        cpuAllocation.shares.shares = 0
-        expected.cpuAllocation = cpuAllocation
-        memoryAllocation = fake_factory.create('ns0:ResourceAllocationInfo')
-        memoryAllocation.reservation = 0
         memoryAllocation.limit = -1
         memoryAllocation.shares = fake_factory.create('ns0:SharesInfo')
         memoryAllocation.shares.level = 'normal'

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -546,7 +546,6 @@ def get_vm_resize_spec(client_factory, vcpus, memory_mb, extra_specs,
     resize_spec.memoryAllocation = _get_allocation_info(
         client_factory, extra_specs.memory_limits,
         'ns0:ResourceAllocationInfo')
-    resize_spec.version = extra_specs.hw_version
     # NOTE(jkulik) We used to set this setting instead of `memoryAllocation`,
     # so we need to deconfigure it on VMs created before the patch adding
     # `memoryAllocation` support on resize.


### PR DESCRIPTION
Be more strict in the upgrade policy,
and only upgrade on resize, if the flavor demands it.
Not if the default has changed

Change-Id: I25a6eb352316f986b179204199b098a418991860