### PR TITLE
volume: Treat 404 on attachment_delete as OK

### DIFF
--- a/nova/tests/unit/volume/test_cinder.py
+++ b/nova/tests/unit/volume/test_cinder.py
@@ -519,17 +519,17 @@ class CinderApiTestCase(test.NoDBTestCase):
     @mock.patch('nova.volume.cinder.LOG')
     @mock.patch('nova.volume.cinder.cinderclient')
     def test_attachment_delete_failed(self, mock_cinderclient, mock_log):
+        """A 404 on attachment delete doesn't raise an error
+
+        A attachment being not there is exactly what the call for deletion
+        wants to achieve and thus we don't raise an error and make the call
+        idempotent from Nova side
+        """
         mock_cinderclient.return_value.attachments.delete.side_effect = (
                 cinder_exception.NotFound(404, '404'))
 
         attachment_id = uuids.attachment
-        ex = self.assertRaises(exception.VolumeAttachmentNotFound,
-                               self.api.attachment_delete,
-                               self.ctx,
-                               attachment_id)
-
-        self.assertEqual(404, ex.code)
-        self.assertIn(attachment_id, six.text_type(ex))
+        self.api.attachment_delete(self.ctx, attachment_id)
 
     @mock.patch('nova.volume.cinder.cinderclient',
                 side_effect=exception.CinderAPIVersionNotAvailable(

--- a/nova/volume/cinder.py
+++ b/nova/volume/cinder.py
@@ -1081,12 +1081,21 @@ class API(object):
                 context, '3.44', skip_version_check=True).attachments.delete(
                     attachment_id)
         except cinder_exception.ClientException as ex:
-            with excutils.save_and_reraise_exception():
+            with excutils.save_and_reraise_exception() as ctxt:
+                code = getattr(ex, 'code', None)
+                if code == 404:
+                    # if the attachment does not exist, we ran into some
+                    # race-condition and are probably in a retry here. in any
+                    # case, we got what we came for and thus treat this 404 as
+                    # mission completed
+                    ctxt.reraise = False
+                    return
+
                 LOG.error(('Delete attachment failed for attachment '
                            '%(id)s. Error: %(msg)s Code: %(code)s'),
                           {'id': attachment_id,
                            'msg': six.text_type(ex),
-                           'code': getattr(ex, 'code', None)})
+                           'code': code})
 
     @translate_attachment_exception
     def attachment_complete(self, context, attachment_id):


### PR DESCRIPTION
Since the mission is to delete the attachment, Cinder returning a 404 on
attachment deletion call can be ignored. We've seen this happening where
Cinder took some time to delete the attachment so Nova retried as it got
a 500 back. On this retry, Nova got a 404 and left the BDM entry as
leftover while aborting the deletion, that already happened by driver.

Change-Id: I15dd7b59a2b3c528ecad3b337b92885b4d7bd68f