### PR TITLE
Cherry-Pick: Fix aggregate placement sync issue

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -5596,19 +5596,21 @@ class AggregateAPI(base.Base):
 
         aggregate.add_host(host_name)
         self.scheduler_client.update_aggregates(context, [aggregate])
+        nodes = objects.ComputeNodeList.get_all_by_host(context, host_name)
+        node_name = nodes[0].hypervisor_hostname
         try:
             self.placement_client.aggregate_add_host(
-                context, aggregate.uuid, host_name)
+                context, aggregate.uuid, node_name)
         except exception.PlacementAPIConnectFailure:
             # NOTE(jaypipes): Rocky should be able to tolerate the nova-api
             # service not communicating with the Placement API, so just log a
             # warning here.
             # TODO(jaypipes): Remove this in Stein, when placement must be able
             # to be contacted from the nova-api service.
-            LOG.warning("Failed to associate %s with a placement "
+            LOG.warning("Failed to associate %s (%s) with a placement "
                         "aggregate: %s. There was a failure to communicate "
                         "with the placement service.",
-                        host_name, aggregate.uuid)
+                        host_name, node_name, aggregate.uuid)
         except (exception.ResourceProviderNotFound,
                 exception.ResourceProviderAggregateRetrievalFailed,
                 exception.ResourceProviderUpdateFailed,
@@ -5619,10 +5621,10 @@ class AggregateAPI(base.Base):
             # would just be confused). So, we just log a warning here, noting
             # that on the next run of nova-manage placement sync_aggregates
             # things will go back to normal
-            LOG.warning("Failed to associate %s with a placement "
+            LOG.warning("Failed to associate %s (%s) with a placement "
                         "aggregate: %s. This may be corrected after running "
                         "nova-manage placement sync_aggregates.",
-                        host_name, err)
+                        host_name, node_name, err)
         self._update_az_cache_for_host(context, host_name, aggregate.metadata)
         # NOTE(jogo): Send message to host to support resource pools
         self.compute_rpcapi.add_aggregate_host(context,
@@ -5660,21 +5662,25 @@ class AggregateAPI(base.Base):
             action=fields_obj.NotificationAction.REMOVE_HOST,
             phase=fields_obj.NotificationPhase.START)
 
-        aggregate.delete_host(host_name)
-        self.scheduler_client.update_aggregates(context, [aggregate])
+        # Remove the resource provider from the provider aggregate first before
+        # we change anything on the nova side because if we did the nova stuff
+        # first we can't re-attempt this from the compute API if cleaning up
+        # placement fails.
+        nodes = objects.ComputeNodeList.get_all_by_host(context, host_name)
+        node_name = nodes[0].hypervisor_hostname
         try:
             self.placement_client.aggregate_remove_host(
-                context, aggregate.uuid, host_name)
+                context, aggregate.uuid, node_name)
         except exception.PlacementAPIConnectFailure:
             # NOTE(jaypipes): Rocky should be able to tolerate the nova-api
             # service not communicating with the Placement API, so just log a
             # warning here.
             # TODO(jaypipes): Remove this in Stein, when placement must be able
             # to be contacted from the nova-api service.
-            LOG.warning("Failed to remove association of %s with a placement "
-                        "aggregate: %s. There was a failure to communicate "
-                        "with the placement service.",
-                        host_name, aggregate.uuid)
+            LOG.warning("Failed to remove association of %s (%s) with a "
+                        "placement aggregate: %s. There was a failure to "
+                        "communicate with the placement service.",
+                        host_name, node_name, aggregate.uuid)
         except (exception.ResourceProviderNotFound,
                 exception.ResourceProviderAggregateRetrievalFailed,
                 exception.ResourceProviderUpdateFailed,
@@ -5685,10 +5691,13 @@ class AggregateAPI(base.Base):
             # would just be confused). So, we just log a warning here, noting
             # that on the next run of nova-manage placement sync_aggregates
             # things will go back to normal
-            LOG.warning("Failed to remove association of %s with a placement "
-                        "aggregate: %s. This may be corrected after running "
-                        "nova-manage placement sync_aggregates.",
-                        host_name, err)
+            LOG.warning("Failed to remove association of %s (%s) with a "
+                        "placement aggregate: %s. This may be corrected after "
+                        "running nova-manage placement sync_aggregates.",
+                        host_name, node_name, err)
+
+        aggregate.delete_host(host_name)
+        self.scheduler_client.update_aggregates(context, [aggregate])
         self._update_az_cache_for_host(context, host_name, aggregate.metadata)
         self.compute_rpcapi.remove_aggregate_host(context,
                 aggregate=aggregate, host_param=host_name, host=host_name)

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -11804,14 +11804,22 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         self.assertRaises(exception.AggregateNotFound,
                           self.api.delete_aggregate, self.context, aggr.id)
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_check_az_for_aggregate(self, mock_add_host):
+    def test_check_az_for_aggregate(self, mock_add_host, mock_get_all_by_host):
         # Ensure all conflict hosts can be returned
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host1 = values[0][1][0]
         fake_host2 = values[0][1][1]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host1,
+                hypervisor_hostname=fake_host1),
+                     objects.ComputeNode(
+                host=fake_host2,
+                hypervisor_hostname=fake_host2)])
         aggr1 = self._init_aggregate_with_host(None, 'fake_aggregate1',
                                                fake_zone, fake_host1)
         aggr1 = self._init_aggregate_with_host(aggr1, None, None, fake_host2)
@@ -11839,15 +11847,20 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         self.assertEqual(msg.event_type,
                          'aggregate.updateprop.end')
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_update_aggregate_no_az(self, mock_add_host):
+    def test_update_aggregate_no_az(self, mock_add_host, mock_get_all_by_host):
         # Ensure metadata without availability zone can be
         # updated,even the aggregate contains hosts belong
         # to another availability zone
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         self._init_aggregate_with_host(None, 'fake_aggregate1',
                                        fake_zone, fake_host)
         aggr2 = self._init_aggregate_with_host(None, 'fake_aggregate2', None,
@@ -11863,15 +11876,21 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         self.assertEqual(msg.event_type,
                          'aggregate.updateprop.end')
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_update_aggregate_az_change(self, mock_add_host):
+    def test_update_aggregate_az_change(self, mock_add_host,
+                                        mock_get_all_by_host):
         # Ensure availability zone can be updated,
         # when the aggregate is the only one with
         # availability zone
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         aggr1 = self._init_aggregate_with_host(None, 'fake_aggregate1',
                                                fake_zone, fake_host)
         self._init_aggregate_with_host(None, 'fake_aggregate2', None,
@@ -11887,15 +11906,21 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         self.assertEqual(msg.event_type,
                          'aggregate.updatemetadata.end')
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_update_aggregate_az_fails(self, mock_add_host):
+    def test_update_aggregate_az_fails(self, mock_add_host,
+                                       mock_get_all_by_host):
         # Ensure aggregate's availability zone can't be updated,
         # when aggregate has hosts in other availability zone
         fake_notifier.NOTIFICATIONS = []
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         self._init_aggregate_with_host(None, 'fake_aggregate1',
                                        fake_zone, fake_host)
         aggr2 = self._init_aggregate_with_host(None, 'fake_aggregate2', None,
@@ -11905,6 +11930,10 @@ class ComputeAPIAggrTestCase(BaseTestCase):
                           self.api.update_aggregate,
                           self.context, aggr2.id, metadata)
         fake_host2 = values[0][1][1]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host2,
+                hypervisor_hostname=fake_host2)])
         aggr3 = self._init_aggregate_with_host(None, 'fake_aggregate3',
                                                None, fake_host2)
         metadata = {'availability_zone': fake_zone}
@@ -11922,14 +11951,20 @@ class ComputeAPIAggrTestCase(BaseTestCase):
                           self.api.update_aggregate, self.context,
                           aggr4.id, metadata)
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_update_aggregate_az_fails_with_nova_az(self, mock_add_host):
+    def test_update_aggregate_az_fails_with_nova_az(self, mock_add_host,
+                                                    mock_get_all_by_host):
         # Ensure aggregate's availability zone can't be updated,
         # when aggregate has hosts in other availability zone
         fake_notifier.NOTIFICATIONS = []
         values = _create_service_entries(self.context)
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         self._init_aggregate_with_host(None, 'fake_aggregate1',
                                        CONF.default_availability_zone,
                                        fake_host)
@@ -11983,16 +12018,22 @@ class ComputeAPIAggrTestCase(BaseTestCase):
                         matchers.DictMatches({'availability_zone': 'fake_zone',
                         'foo_key2': 'foo_value2'}))
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
     @mock.patch('nova.compute.utils.notify_about_aggregate_action')
-    def test_update_aggregate_metadata_no_az(self, mock_notify, mock_add_host):
+    def test_update_aggregate_metadata_no_az(self, mock_notify, mock_add_host,
+                                             mock_get_all_by_host):
         # Ensure metadata without availability zone can be
         # updated,even the aggregate contains hosts belong
         # to another availability zone
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         self._init_aggregate_with_host(None, 'fake_aggregate1',
                                        fake_zone, fake_host)
         aggr2 = self._init_aggregate_with_host(None, 'fake_aggregate2', None,
@@ -12016,15 +12057,21 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         self.assertThat(aggr2.metadata,
                         matchers.DictMatches({'foo_key2': 'foo_value3'}))
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_update_aggregate_metadata_az_change(self, mock_add_host):
+    def test_update_aggregate_metadata_az_change(self, mock_add_host,
+                                                 mock_get_all_by_host):
         # Ensure availability zone can be updated,
         # when the aggregate is the only one with
         # availability zone
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         aggr1 = self._init_aggregate_with_host(None, 'fake_aggregate1',
                                                fake_zone, fake_host)
         self._init_aggregate_with_host(None, 'fake_aggregate2', None,
@@ -12056,15 +12103,21 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         self.assertThat(aggr.metadata, matchers.DictMatches(
             {'availability_zone': 'new_fake_zone', 'foo_key1': 'foo_value1'}))
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_update_aggregate_metadata_az_fails(self, mock_add_host):
+    def test_update_aggregate_metadata_az_fails(self, mock_add_host,
+                                                mock_get_all_by_host):
         # Ensure aggregate's availability zone can't be updated,
         # when aggregate has hosts in other availability zone
         fake_notifier.NOTIFICATIONS = []
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         self._init_aggregate_with_host(None, 'fake_aggregate1',
                                        fake_zone, fake_host)
         aggr2 = self._init_aggregate_with_host(None, 'fake_aggregate2', None,
@@ -12137,33 +12190,46 @@ class ComputeAPIAggrTestCase(BaseTestCase):
             mock.call(context=self.context, aggregate=AggregateIdMatcher(aggr),
                       action='delete', phase='end')])
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_remove_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_delete_non_empty_aggregate(self, mock_add_host, mock_remove_host):
+    def test_delete_non_empty_aggregate(self, mock_add_host, mock_remove_host,
+                                        mock_get_all_by_host):
         # Ensure InvalidAggregateAction is raised when non empty aggregate.
         _create_service_entries(self.context,
                                 [['fake_availability_zone', ['fake_host']]])
         aggr = self.api.create_aggregate(self.context, 'fake_aggregate',
                                          'fake_availability_zone')
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host='fake_host',
+                hypervisor_hostname='fake_host')])
+
         self.api.add_host_to_aggregate(self.context, aggr.id, 'fake_host')
         self.assertRaises(exception.InvalidAggregateActionDelete,
                           self.api.delete_aggregate, self.context, aggr.id)
         mock_remove_host.assert_not_called()
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
     @mock.patch('nova.compute.utils.notify_about_aggregate_action')
     @mock.patch.object(availability_zones,
                        'update_host_availability_zone_cache')
-    def test_add_host_to_aggregate(self, mock_az, mock_notify, mock_add_host):
+    def test_add_host_to_aggregate(self, mock_az, mock_notify, mock_add_host,
+                                   mock_get_all_by_host):
         # Ensure we can add a host to an aggregate.
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
         aggr = self.api.create_aggregate(self.context,
                                          'fake_aggregate', fake_zone)
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
 
         def fake_add_aggregate_host(*args, **kwargs):
             hosts = kwargs["aggregate"].hosts
@@ -12193,12 +12259,18 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         mock_add_host.assert_called_once_with(
             self.context, aggr.uuid, fake_host)
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_add_host_to_aggr_with_no_az(self, mock_add_host):
+    def test_add_host_to_aggr_with_no_az(self, mock_add_host,
+                                         mock_get_all_by_host):
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         aggr = self.api.create_aggregate(self.context,
                                          'fake_aggregate', fake_zone)
         aggr = self.api.add_host_to_aggregate(self.context, aggr.id,
@@ -12211,13 +12283,18 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         self.assertIn(fake_host, aggr.hosts)
         self.assertIn(fake_host, aggr_no_az.hosts)
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_add_host_to_multi_az(self, mock_add_host):
+    def test_add_host_to_multi_az(self, mock_add_host, mock_get_all_by_host):
         # Ensure we can't add a host to different availability zone
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         aggr = self.api.create_aggregate(self.context,
                                          'fake_aggregate', fake_zone)
         aggr = self.api.add_host_to_aggregate(self.context,
@@ -12231,13 +12308,19 @@ class ComputeAPIAggrTestCase(BaseTestCase):
                           self.context, aggr2.id, fake_host)
         self.assertEqual(1, mock_add_host.call_count)
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_add_host_to_multi_az_with_nova_agg(self, mock_add_host):
+    def test_add_host_to_multi_az_with_nova_agg(self, mock_add_host,
+                                                mock_get_all_by_host):
         # Ensure we can't add a host if already existing in an agg with AZ set
         #  to default
         values = _create_service_entries(self.context)
         fake_host = values[0][1][0]
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=fake_host,
+                hypervisor_hostname=fake_host)])
         aggr = self.api.create_aggregate(self.context,
                                          'fake_aggregate',
                                          CONF.default_availability_zone)
@@ -12252,15 +12335,21 @@ class ComputeAPIAggrTestCase(BaseTestCase):
                           self.context, aggr2.id, fake_host)
         self.assertEqual(1, mock_add_host.call_count)
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_add_host_to_aggregate_multiple(self, mock_add_host):
+    def test_add_host_to_aggregate_multiple(self, mock_add_host,
+                                            mock_get_all_by_host):
         # Ensure we can add multiple hosts to an aggregate.
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         aggr = self.api.create_aggregate(self.context,
                                          'fake_aggregate', fake_zone)
         for host in values[0][1]:
+            mock_get_all_by_host.return_value = objects.ComputeNodeList(
+                objects=[objects.ComputeNode(
+                    host=host,
+                    hypervisor_hostname=host)])
             aggr = self.api.add_host_to_aggregate(self.context,
                                                   aggr.id, host)
         self.assertEqual(len(aggr.hosts), len(values[0][1]))
@@ -12319,6 +12408,7 @@ class ComputeAPIAggrTestCase(BaseTestCase):
                           self.context, aggr.id, 'invalid_host')
         mock_add_host.assert_not_called()
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_remove_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
@@ -12327,13 +12417,18 @@ class ComputeAPIAggrTestCase(BaseTestCase):
     @mock.patch.object(availability_zones,
                        'update_host_availability_zone_cache')
     def test_remove_host_from_aggregate_active(
-            self, mock_az, mock_notify, mock_add_host, mock_remove_host):
+            self, mock_az, mock_notify, mock_add_host, mock_remove_host,
+            mock_get_all_by_host):
         # Ensure we can remove a host from an aggregate.
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         aggr = self.api.create_aggregate(self.context,
                                          'fake_aggregate', fake_zone)
         for host in values[0][1]:
+            mock_get_all_by_host.return_value = objects.ComputeNodeList(
+                objects=[objects.ComputeNode(
+                    host=host,
+                    hypervisor_hostname=host)])
             aggr = self.api.add_host_to_aggregate(self.context,
                                                   aggr.id, host)
         host_to_remove = values[0][1][0]
@@ -12347,6 +12442,11 @@ class ComputeAPIAggrTestCase(BaseTestCase):
 
         fake_notifier.NOTIFICATIONS = []
         mock_notify.reset_mock()
+        mock_get_all_by_host.reset_mock()
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=host_to_remove,
+                hypervisor_hostname=host_to_remove)])
         expected = self.api.remove_host_from_aggregate(self.context,
                                                        aggr.id,
                                                        host_to_remove)
@@ -12428,14 +12528,20 @@ class ComputeAPIAggrTestCase(BaseTestCase):
         self.assertEqual('foo_value1', test_agg_meta['foo_key1'])
         self.assertEqual('foo_value2', test_agg_meta['foo_key2'])
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
-    def test_aggregate_list_with_hosts(self, mock_add_host):
+    def test_aggregate_list_with_hosts(self, mock_add_host,
+                                       mock_get_all_by_host):
         values = _create_service_entries(self.context)
         fake_zone = values[0][0]
         host_aggregate = self.api.create_aggregate(self.context,
                                                    'fake_aggregate',
                                                    fake_zone)
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host=values[0][1][0],
+                hypervisor_hostname=values[0][1][0])])
         self.api.add_host_to_aggregate(self.context, host_aggregate.id,
                                        values[0][1][0])
         aggregate_list = self.api.get_aggregate_list(self.context)
@@ -12491,17 +12597,23 @@ class ComputeAPIAggrCallsSchedulerTestCase(test.NoDBTestCase):
             self.api.delete_aggregate(self.context, 1)
         delete_aggregate.assert_called_once_with(self.context, agg)
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
     @mock.patch('nova.compute.utils.notify_about_aggregate_action')
     @mock.patch('nova.compute.rpcapi.ComputeAPI.add_aggregate_host')
     @mock.patch.object(scheduler_client.SchedulerClient, 'update_aggregates')
     def test_add_host_to_aggregate(self, update_aggregates, mock_add_agg,
-                                   mock_notify, mock_add_host):
+                                   mock_notify, mock_add_host,
+                                   mock_get_all_by_host):
         self.api.is_safe_to_update_az = mock.Mock()
         self.api._update_az_cache_for_host = mock.Mock()
         agg = objects.Aggregate(name='fake', metadata={}, uuid=uuids.agg)
         agg.add_host = mock.Mock()
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host='fakehost',
+                hypervisor_hostname='fakehost')])
         with test.nested(
                 mock.patch.object(objects.Service, 'get_by_compute_host',
                                   return_value=objects.Service(
@@ -12516,6 +12628,7 @@ class ComputeAPIAggrCallsSchedulerTestCase(test.NoDBTestCase):
         mock_add_host.assert_called_once_with(
             self.context, agg.uuid, 'fakehost')
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_remove_host')
     @mock.patch('nova.compute.utils.notify_about_aggregate_action')
@@ -12523,10 +12636,15 @@ class ComputeAPIAggrCallsSchedulerTestCase(test.NoDBTestCase):
     @mock.patch.object(scheduler_client.SchedulerClient, 'update_aggregates')
     def test_remove_host_from_aggregate(self, update_aggregates,
                                         mock_remove_agg, mock_notify,
-                                        mock_remove_host):
+                                        mock_remove_host,
+                                        mock_get_all_by_host):
         self.api._update_az_cache_for_host = mock.Mock()
         agg = objects.Aggregate(name='fake', metadata={}, uuid=uuids.agg)
         agg.delete_host = mock.Mock()
+        mock_get_all_by_host.return_value = objects.ComputeNodeList(
+            objects=[objects.ComputeNode(
+                host='fakehost',
+                hypervisor_hostname='fakehost')])
         with test.nested(
                 mock.patch.object(objects.Service, 'get_by_compute_host'),
                 mock.patch.object(objects.Aggregate, 'get_by_id',

--- a/nova/tests/unit/virt/xenapi/test_xenapi.py
+++ b/nova/tests/unit/virt/xenapi/test_xenapi.py
@@ -3325,12 +3325,13 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                aggregate, 'fake_host')
         self.assertIn('aggregate in error', str(ex))
 
+    @mock.patch.object(objects.ComputeNodeList, 'get_all_by_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_remove_host')
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'aggregate_add_host')
     def test_remove_host_from_aggregate_error(
-            self, mock_add_host, mock_remove_host):
+            self, mock_add_host, mock_remove_host, mock_get_all_by_host):
         # Ensure we can remove a host from an aggregate even if in error.
         values = _create_service_entries(self.context)
         fake_zone = list(values.keys())[0]
@@ -3343,6 +3344,10 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                            aggr.id,
                                            metadata)
         for aggregate_host in values[fake_zone]:
+            mock_get_all_by_host.return_value = objects.ComputeNodeList(
+                objects=[objects.ComputeNode(
+                    host=aggregate_host,
+                    hypervisor_hostname=aggregate_host)])
             aggr = self.api.add_host_to_aggregate(self.context,
                                                   aggr.id, aggregate_host)
         # let's mock the fact that the aggregate is in error!


### PR DESCRIPTION
Use node name to sync the nova aggregate to placement resource provider
aggregate.

Change-Id: I08f2f07c0c695d1dd5b4fa72d0155e02b1872b0a
closes-bug: #1877229