### PR TITLE
nova-manage: Don't fail on no Ironic nodes found

### DIFF
--- a/nova/cmd/manage.py
+++ b/nova/cmd/manage.py
@@ -2343,8 +2343,14 @@ class PlacementCommands(object):
                         unmapped_hosts.add(host)
                         continue
                     except exception.ComputeHostNotFound:
-                        # Don't fail on this now, we can dump it at the end.
-                        computes_not_found.add(host)
+                        # Don't fail on this now, we can dump it at the end. We
+                        # only need to dump it, if it's a non-ironic host
+                        # though, as for ironic there can be hosts that
+                        # currently don't have any node assigned e.g.
+                        # conductor-groups that are only used for
+                        # testing/during buildup.
+                        if 'ironic' not in host:
+                            computes_not_found.add(host)
                         continue
                     except exception.TooManyComputesForHost as e:
                         # TODO(mriedem): Should we treat this like the other


### PR DESCRIPTION
There can be Ironic hosts, that only have nodes assigned when those
nodes are getting repairs or getting build up. Those Ironic hosts would
come up empty when searching for ComputeNodes in the sync_aggregates
command and would be reported as a problem, which makes the command
fail with exit-code 5. Since it's no problem if an Ironic Host doesn't
have a ComputeNode, because each node is its own resource provider in
placement anyways, we ignore Ironic hosts without nodes now in the
error-reporting.

Change-Id: I163f3e46f2e375531b870a363b84bba67816954d