### PR TITLE
vmware: Enable disabled DRS rules in sync

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -3972,6 +3972,13 @@ class VMwareVMOps(object):
                 LOG.debug('Sync for server-group %s done', sg_uuid)
                 return
 
+            if not rule.enabled:
+                LOG.debug('Enabling DRS rule %s.', rule_name)
+                rule.enabled = True
+                cluster_util.update_rule(
+                    self._session, self._cluster, rule)
+                LOG.info('Enabled DRS rule %s.', rule_name)
+
             expected_moref_values = set(vutil.get_moref_value(m)
                                         for m in expected_members.values())
             existing_moref_values = set(vutil.get_moref_value(m)


### PR DESCRIPTION
When syncing a server-group's DRS rule(s) we now also enable a found
rule in case it is disabled. We don't know how this happens, but
sometimes rules get disabled and we need them to be enabled to guarantee
the customer the appropriate (anti-)affinity settings.

Change-Id: Ibc8eb6800640855513716412266fcbb9fbc4db42