### PR TITLE
vmware: fix get_rules_by_prefix() wrong attribute

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -307,7 +307,7 @@ def get_rules_by_prefix(session, cluster_ref, rule_prefix):
     cluster_config = session._call_method(
         vutil, "get_object_property", cluster_ref, "configurationEx")
 
-    return [rule for rule in getattr(cluster_config, 'rules', [])
+    return [rule for rule in getattr(cluster_config, 'rule', [])
             if rule.name.startswith(rule_prefix)]
 
 


### PR DESCRIPTION
The DRS rules can be read from the "rule" attribute, not from the
"rules" attribute. We found this, because Nova wasn't deleting
DRS rules for no-longer-existing server-groups.

Change-Id: I86f7ca85d9b0edc1406a54a6f392bfff8f0af00d