### PR TITLE
vmware: Fix UnboundLocal error in manage_image_cache

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -3154,6 +3154,10 @@ class VMwareVMOps(object):
         datastores = ds_util.get_available_datastores(self._session,
                                                       self._cluster,
                                                       self._datastore_regex)
+
+        if not datastores:
+            return
+
         datastores_info = []
         for ds in datastores:
             dc_info = self.get_datacenter_ref_and_name(ds.ref)


### PR DESCRIPTION
When we don't find any datastores for whatever reason, we don't have the
"dc_info" variable set and thus cannot call
self._age_cached_image_templates() with it as it results in an
UnboundLocal exception.

Change-Id: I2dca6d2d6ab7ca5cbc4ef7d2c316faaf6edfee7d