### PR TITLE
Revert "bigvm: Mirror aggregates to bigvm provider"

### DIFF
--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -780,8 +780,7 @@ class BigVmManager(manager.Manager):
 
             # add the newly-created resource-provider to the parent uuid's
             # aggregate
-            client.set_aggregates_for_provider(context, new_rp_uuid,
-                                               agg_info.aggregates)
+            client.set_aggregates_for_provider(context, new_rp_uuid, [rp_uuid])
 
             # make the newly-created resource-provider share its resources with
             # its aggregates


### PR DESCRIPTION
This reverts commit a8c511287c2f696082767c86e04cbca81df00078.

This has the side-effect of providing the CUSTOM_BIGVM resource to all
resource providers in the same shard and AZ. We don't want that not only
because this means any BB could just spawn a big VM, but also because
nova-compute then does not find its bigvm resource provider and can't
set it to reserved and thus it will never be marked as used for
nova-bigvm.