### PR TITLE
vmware: Attach root disk first

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1460,7 +1460,8 @@ class VMwareVMOps(object):
             # block_device_mapping (i.e. disk_bus) is valid
             self._is_bdm_valid(block_device_mapping)
 
-            for disk in block_device_mapping:
+            for disk in sorted(block_device_mapping,
+                               key=lambda x: x.get('boot_index') != 0):
                 connection_info = disk['connection_info']
                 adapter_type = disk.get('disk_bus') or vi.ii.adapter_type
 


### PR DESCRIPTION
Since we don't explicitly set a disk as boot disk and instead rely on
the order the disks have on the VirtualMachine, we need to make sure we
attach the root disk first.

Change-Id: I3ae6b5f053a3b171ed0a80215fc4204a2bf32481