### PR TITLE
Support split of large VMs and memory reservation handling

### DIFF
--- a/nova/conf/base.py
+++ b/nova/conf/base.py
@@ -73,7 +73,7 @@ having more or equal to this setting's amount of RAM is a big VM.
 """),
     cfg.IntOpt(
         'largevm_mb',
-        default=230 * 1024,      # 230 GB
+        default=512 * 1024 + 10,      # a little over 512 GB
         min=0,
         help="""
 Instance memory usage identifying it as large VM
@@ -84,6 +84,20 @@ differently than big VMs. Every VM having more or equal to this setting's
 amount of RAM and less than bigvm_mb is a large VM.
 
 See also: nova.utils.is_large_vm()
+"""),
+    cfg.IntOpt(
+        'full_reservation_memory_mb',
+        default=230 * 1024,      # 230 GiB
+        help="""
+Instance memory usage identifying a VM as needing memory reservations
+
+VMs starting from this amount of memory will get their memory reserved. This
+setting acts in addition to the flavor's CUSTOM_MEMORY_RESERVABLE_MB resource
+definition. The flavor's setting takes precedence if set.
+
+A negative value disables this feature.
+
+See also: nova.utils.get_reserved_memory()
 """),
     cfg.StrOpt(
         'bigvm_deployment_rp_name_prefix',

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -1428,6 +1428,28 @@ def is_large_vm(memory_mb, flavor):
     return True
 
 
+def get_reserved_memory(flavor):
+    # baremetals don't need reservation as they have their whole host
+    if is_baremetal_flavor(flavor):
+        return 0
+
+    # explicit definitions in the flavor take precedence over any heuristic
+    try:
+        key = MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY
+        memory_mb = int(flavor.extra_specs[key])
+    except (ValueError, KeyError):
+        pass
+    else:
+        if memory_mb > 0:
+            return min(flavor.memory_mb, memory_mb)
+
+    if CONF.full_reservation_memory_mb >= 0 \
+            and flavor.memory_mb >= CONF.full_reservation_memory_mb:
+        return flavor.memory_mb
+
+    return 0
+
+
 def vm_needs_special_spawning(memory_mb, flavor):
     if is_big_vm(memory_mb, flavor):
         return True

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -421,18 +421,13 @@ class VMwareVMOps(object):
                 if value:
                     setattr(getattr(extra_specs, resource + '_limits'),
                             key, type(value))
-        if CONF.vmware.reserve_all_memory \
-                or utils.is_large_vm(int(flavor.memory_mb), flavor):
+        if CONF.vmware.reserve_all_memory:
             extra_specs.memory_limits.reservation = int(flavor.memory_mb)
         else:
-            try:
-                memory_reserved_mb = int(flavor.extra_specs[
-                    utils.MEMORY_RESERVABLE_MB_RESOURCE_SPEC_KEY])
-                if memory_reserved_mb > 0:
-                    extra_specs.memory_limits.reservation = min(
-                        int(flavor.memory_mb), memory_reserved_mb)
-            except (ValueError, KeyError):
-                pass
+            memory_reserved_mb = \
+                utils.get_reserved_memory(flavor)
+            if memory_reserved_mb > 0:
+                extra_specs.memory_limits.reservation = memory_reserved_mb
         extra_specs.cpu_limits.validate()
         extra_specs.memory_limits.validate()
         extra_specs.disk_io_limits.validate()


### PR DESCRIPTION
We've recently changed that not all large VMs need DRS disabled - only
the ones over 512 GiB memory. The VMs in the previously also included
range for large VMs of 230 GiB - 512 GiB do still need memory
reservations, though. While we could do this via flavor, we failed to do
so. Additionally, this would limit the amount of large VMs we can spawn
on a cluster.

To keep the same behavior we previously had for large VMs, we now split
memory reservations from big/large VM detection with the following
result:
1) a big VM will get DRS disabled - big VMs are VMs bigger than 1024 GiB
2) a large VM will get DRS disabled - large VMs are VMs bigger than 512
GiB
3) all VMs defining CUSTOM_MEMORY_RESERVABLE_MB resources in their
flavor get that amount of memory reserved
4) all VMs above full_reservation_memory_mb config setting get all their
memory reserved

Therefore, is_big_vm() and is_large_vm() now only handle DRS settings
and special spawning behavior.

Side effect is, that nova-bigvm or rather the special spawning code now
doesn't consider 230 GiB - 512 GiB VMs as non-movable anymore and thus
finds more free hosts.

Change-Id: I2088afecf367efc380f9a0a88e5d18251a19e3a5