### PR TITLE
[vmwareapi] Limit free space of datastore to capacity

### DIFF
--- a/nova/virt/vmwareapi/ds_util.py
+++ b/nova/virt/vmwareapi/ds_util.py
@@ -199,10 +199,12 @@ def _get_allowed_datastores(datastores, datastore_regex):
         if _is_datastore_valid(propdict,
                                datastore_regex,
                                ALL_SUPPORTED_DS_TYPES):
+            capacity = propdict['summary.capacity']
+            freespace = propdict['summary.freeSpace']
             yield (ds_obj.Datastore(ref=obj_content.obj,
                                     name=propdict['summary.name'],
-                                    capacity=propdict['summary.capacity'],
-                                    freespace=propdict['summary.freeSpace']))
+                                    capacity=capacity,
+                                    freespace=min(freespace, capacity)))
 
 
 def get_available_datastores(session, cluster=None, datastore_regex=None,


### PR DESCRIPTION
Apparently, the vmware api can report datastores with more free space
than capacity, which causes an exception in the olso_vmware api
So we limit the free space to the capacity