### PR TITLE
regularly update the flavor-info of instances

### DIFF
--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -1225,6 +1225,17 @@ Possible values:
 * A string with a list of named database columns, for example ``%(id)d``
   or ``%(uuid)s`` or ``%(hostname)s``.
 """),
+    cfg.IntOpt('instance_flavor_update_interval',
+        default=300,
+        help="""
+Interval for updating flavor-info of instances.
+
+Possible values:
+
+* 0: Will run at the default periodic interval.
+* Any value < 0: Disables the option.
+* Any positive integer in seconds.
+"""),
 ]
 
 


### PR DESCRIPTION
Periodic task that detects changes in the extra_specs of the
flavor and updates the instance.flavor in the database.

The interval can be configured with the property

instance_flavor_update_interval = 120