### PR TITLE
Add oslo.vmware stable/xena-m3 as custom requirement

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -2,7 +2,8 @@ dumb-init
 python-memcached
 pymemcache
 
-git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven
-git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
-git+https://github.com/sapcc/openstack-audit-middleware.git#egg=audit-middleware
+-e git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven
+-e git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
+-e git+https://github.com/sapcc/openstack-audit-middleware.git#egg=audit-middleware
 -e git+https://github.com/sapcc/python-agentliveness.git#egg=agentliveness
+-e git+https://github.com/sapcc/oslo.vmware.git@stable/xena-m3#egg=oslo.vmware

--- a/nova/db/api/legacy_migrations/versions/061_rocky.py
+++ b/nova/db/api/legacy_migrations/versions/061_rocky.py
@@ -28,7 +28,7 @@ from sqlalchemy import Text
 from sqlalchemy import text
 from sqlalchemy import Unicode
 
-from nova.db.sqlalchemy.api_models import MediumText
+from nova.db import types
 from nova.objects import keypair
 
 
@@ -153,7 +153,7 @@ def upgrade(migrate_engine):
         Column('updated_at', DateTime),
         Column('id', Integer, primary_key=True, nullable=False),
         Column('instance_uuid', String(36), nullable=False),
-        Column('spec', MediumText(), nullable=False),
+        Column('spec', types.MediumText(), nullable=False),
         UniqueConstraint(
             'instance_uuid', name='uniq_request_specs0instance_uuid'),
         Index('request_spec_instance_uuid_idx', 'instance_uuid'),
@@ -184,8 +184,8 @@ def upgrade(migrate_engine):
             'locked_by',
             Enum('owner', 'admin', name='build_requests0locked_by')),
         Column('instance_uuid', String(length=36)),
-        Column('instance', MediumText()),
-        Column('block_device_mappings', MediumText()),
+        Column('instance', types.MediumText()),
+        Column('block_device_mappings', types.MediumText()),
         Column('tags', Text()),
         UniqueConstraint(
             'instance_uuid', name='uniq_build_requests0instance_uuid'),

--- a/nova/db/main/legacy_migrations/versions/390_rocky.py
+++ b/nova/db/main/legacy_migrations/versions/390_rocky.py
@@ -22,7 +22,7 @@ from sqlalchemy import Text
 from sqlalchemy.types import NullType
 from sqlalchemy import Unicode
 
-from nova.db.sqlalchemy import types
+from nova.db import types
 from nova.objects import keypair
 
 LOG = logging.getLogger(__name__)

--- a/nova/db/main/migrations/versions/8f2f1571d55b_initial_version.py
+++ b/nova/db/main/migrations/versions/8f2f1571d55b_initial_version.py
@@ -519,7 +519,7 @@ def upgrade():
         sa.Column('console_type', sa.String(255), nullable=False),
         sa.Column('host', sa.String(255), nullable=False),
         sa.Column('port', sa.Integer, nullable=False),
-        sa.Column('internal_access_path', sa.String(255)),
+        sa.Column('internal_access_path', sa.Text()),
         sa.Column('instance_uuid', sa.String(36), nullable=False),
         sa.Column('expires', sa.Integer, nullable=False),
         sa.Column('access_url_base', sa.String(255), nullable=True),

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -87,6 +87,8 @@ fake_host_list = [mock.sentinel.host1]
 @ddt.ddt
 class ComputeManagerUnitTestCase(test.NoDBTestCase,
                                  fake_resource_tracker.RTMockMixin):
+    REQUIRES_LOCKING = True
+
     def setUp(self):
         super(ComputeManagerUnitTestCase, self).setUp()
         self.compute = manager.ComputeManager()

--- a/nova/tests/unit/virt/test_block_device.py
+++ b/nova/tests/unit/virt/test_block_device.py
@@ -36,6 +36,8 @@ ATTACHMENT_ID = uuids.attachment_id
 
 
 class TestDriverBlockDevice(test.NoDBTestCase):
+    REQUIRES_LOCKING = True
+
     # This is used to signal if we're dealing with a new style volume
     # attachment (Cinder v3.44 flow).
     attachment_id = None

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,4 +25,4 @@ gabbi>=1.35.0 # Apache-2.0
 wsgi-intercept>=1.7.0 # MIT License
 
 # vmwareapi driver specific dependencies
-oslo.vmware>=3.6.0 # Apache-2.0
+git+https://github.com/sapcc/oslo.vmware.git@stable/xena-m3#egg=oslo.vmware

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
   OS_TEST_TIMEOUT=160
   PYTHONDONTWRITEBYTECODE=1
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/xena}
+  -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/xena-m3/upper-constraints.txt}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
 passenv =


### PR DESCRIPTION
We cannot use the upper-contraints.txt with URLs anymorme, because newer
pip doesn't like that. Additionally, we want our repositories with full
git history around for easier debugging - the other services are doing
it like that, too.

Change-Id: Ia5d8fe096e15b9b244573d662ea73613b3c68744