### PR TITLE
cinder: Define minimum migration timeout

### DIFF
--- a/nova/conf/cinder.py
+++ b/nova/conf/cinder.py
@@ -116,6 +116,24 @@ Possible values:
 
   * Positive floating point value
 """),
+    cfg.IntOpt('migration_overhead',
+               default=600,
+               min=0,
+               help="""
+Additional time to give Cinder to migrate a volume in seconds
+
+When Nova is waiting for a volume-migration to finish, the time is expected to
+rise with the size of the volume. Therefore, we employ a simple computation
+using min_migration_speed_mib_per_second to get an upper bound for the waiting
+time. With really small volumes, the overhead of migration is longer than the
+overhead of copying the data and thus the computed migration time is too low.
+To handle these cases, we add migration_overhead to increase the lower bound
+for the time Nova waits.
+
+Possible values:
+
+  * Positive Integer value
+"""),
 ]
 
 

--- a/nova/volume/cinder.py
+++ b/nova/volume/cinder.py
@@ -1078,6 +1078,9 @@ class API(object):
         except cinder_exception.ClientException:
             # assume a big volume for computing the default timeout
             migration_timeout = int(2 * 1024 * 1024 // assumed_speed_mib)
+        # we add some overhead of processing the request in Cinder, too
+        migration_timeout += CONF.cinder.migration_overhead
+
         # an external dictionary so the looping function can keep state between
         # runs
         loop_state = {}


### PR DESCRIPTION
When Nova computes the wait time for volume-migration, it uses the
volume size. For really small volumes (e.g. 1 GiB) the computed time is
lower than the overhead added by the API and RPC calls inside Cinder.
Therefore, Nova times out to wait for the migration, even though the
migration happens as expected.

To fix this, we add an additional static overhead for the migration
timeout, defaulting to 10min.

Change-Id: I1532054524653bc9dfaf5010f3250ea6bff03701