### PR TITLE
copy request IDs from the current context

### DIFF
--- a/nova/context.py
+++ b/nova/context.py
@@ -112,6 +112,11 @@ class RequestContext(context.RequestContext):
                           "nova.context.RequestContext is no longer used and "
                           "will be removed in a future version.")
 
+        current = context.get_current()
+        if current:
+            kwargs.setdefault('request_id', current.request_id)
+            kwargs.setdefault('global_request_id', current.global_request_id)
+
         super(RequestContext, self).__init__(is_admin=is_admin, **kwargs)
 
         self.read_deleted = read_deleted

--- a/nova/tests/unit/test_context.py
+++ b/nova/tests/unit/test_context.py
@@ -459,3 +459,13 @@ class ContextTestCase(test.NoDBTestCase):
         mock_scatter.assert_called_once_with(
             ctxt, [mapping1], 60, objects.InstanceList.get_by_filters, filters,
             sort_dir='foo')
+
+    def test_inherits_req_ids(self):
+        ctx1 = context.get_admin_context()
+        ctx1.global_request_id = 'grec'
+        ctx2 = context.get_admin_context()
+        ctx3 = context.RequestContext.from_dict(ctx2.to_dict())
+
+        self.assertEqual(ctx1.request_id, ctx2.request_id)
+        self.assertEqual(ctx2.request_id, ctx3.request_id)
+        self.assertEqual(ctx1.global_request_id, ctx3.global_request_id)


### PR DESCRIPTION
If a RequestContext has already been created in the current
threadlocal, we should copy the request_id and global_request_id
from it when creating a new one.

Currently, creating a new context with context.get_admin_context()
will end up generating new request IDs for it.