### PR TITLE
[scheduler] Refactored PreferSameHostOnResizeWeigher

### DIFF
--- a/nova/scheduler/weights/resize_same_host.py
+++ b/nova/scheduler/weights/resize_same_host.py
@@ -22,11 +22,9 @@ This weigher ignores any instances which are:
  * baremetal
 """
 import nova.conf
-from nova.exception import ObjectActionError
 from nova.scheduler import utils
 from nova.scheduler import weights
-from nova.utils import is_baremetal_flavor
-import six
+from nova import utils as nova_utils
 
 CONF = nova.conf.CONF
 
@@ -38,33 +36,19 @@ class PreferSameHostOnResizeWeigher(weights.BaseHostWeigher):
         """Override the weight multiplier."""
         return CONF.filter_scheduler.prefer_same_host_resize_weight_multiplier
 
-    def _is_resize(self, cur_flavor, dest_flavor):
-        """Return True if `cur_flavor` is different from `dest_flavor`.
-        Return False otherwise.
-        """
-        try:
-            return cur_flavor.id != dest_flavor.id
-        except ObjectActionError as e:
-            if 'obj_load_attr' in six.text_type(e):
-                # Note(jakob): If for some weird reason, id cannot be found,
-                # assume it's a resize. There is not much to break by
-                # preferring the same host.
-                return True
-            raise e
-
     def _weigh_object(self, host_state, request_spec):
         """Return 1 for about-to-be-resized instances where the host is the
         instance's current host. Return 0 otherwise.
         """
-        if (request_spec.instance_uuid not in host_state.instances
-                or utils.request_is_rebuild(request_spec)):
+        if not utils.request_is_resize(request_spec):
             return 0.0
 
-        instance = host_state.instances[request_spec.instance_uuid]
-        if (is_baremetal_flavor(instance.flavor)
-                or is_baremetal_flavor(request_spec.flavor)):
+        if nova_utils.is_baremetal_flavor(request_spec.flavor):
             return 0.0
 
-        if self._is_resize(instance.flavor, request_spec.flavor):
-            return 1.0
-        return 0.0
+        instance_host = request_spec.get_scheduler_hint('source_host')
+
+        if instance_host != host_state.host:
+            return 0.0
+
+        return 1.0

--- a/nova/tests/unit/scheduler/weights/test_weights_resize_same_host.py
+++ b/nova/tests/unit/scheduler/weights/test_weights_resize_same_host.py
@@ -56,17 +56,27 @@ class PreferSameHostOnResizeWeigherTestCase(test.NoDBTestCase):
         ]
         self.request_specs = {
             'to-big': objects.RequestSpec(instance_uuid=old_instance.uuid,
-                                          flavor=flavor_big),
-            'to-small': objects.RequestSpec(instance_uuid=old_instance.uuid,
-                                            flavor=flavor_small),
+                                          flavor=flavor_big,
+                                          scheduler_hints={
+                                            '_nova_check_type': ['resize'],
+                                            'source_host': ['same_host'],
+                                          }),
+            'unchanged': objects.RequestSpec(instance_uuid=old_instance.uuid,
+                                            flavor=flavor_small,
+                                           ),
             'rebuild': objects.RequestSpec(instance_uuid=old_instance.uuid,
                                            flavor=flavor_big,
                                            scheduler_hints={
-                                               '_nova_check_type': ['rebuild']
+                                            '_nova_check_type': ['rebuild'],
+                                            'source_host': ['same_host'],
                                            }),
             'new': objects.RequestSpec(instance_uuid=new_instance.uuid),
             'resize-bm': objects.RequestSpec(instance_uuid=bm_instance.uuid,
-                                             flavor=flavor_bm_big)
+                                             flavor=flavor_bm_big,
+                                             scheduler_hints={
+                                                '_nova_check_type': ['resize'],
+                                                'source_host': ['same_host'],
+                                             }),
         }
 
     def test_prefer_resize_to_same_host(self):
@@ -91,7 +101,7 @@ class PreferSameHostOnResizeWeigherTestCase(test.NoDBTestCase):
         self.flags(prefer_same_host_resize_weight_multiplier=1.0,
                    group='filter_scheduler')
         weighed_hosts = self.weight_handler.get_weighed_objects(
-            self.weighers, self.hosts, self.request_specs['to-small'])
+            self.weighers, self.hosts, self.request_specs['unchanged'])
         self.assertEqual(0.0, weighed_hosts[0].weight)
         self.assertEqual(0.0, weighed_hosts[1].weight)
 


### PR DESCRIPTION
We can make use of the changes to the scheduler to simplify the internal logic.

If it is a resize is now stored in the request_spec, as well as the source host, so we do not have
to reconstruct it from instance data anymore.

Change-Id: I4b016448a5a905a5d9833aa821daed186d7f1f8a