### PR TITLE
[scheduler] Only fetch instances when weighers/filters request any

### DIFF
--- a/nova/scheduler/filters/__init__.py
+++ b/nova/scheduler/filters/__init__.py
@@ -49,10 +49,21 @@ class BaseHostFilter(filters.BaseFilter):
         """
         raise NotImplementedError()
 
+    def host_info_requiring_instance_ids(self, spec_obj):
+        return set()
+
 
 class HostFilterHandler(filters.BaseFilterHandler):
     def __init__(self):
         super(HostFilterHandler, self).__init__(BaseHostFilter)
+
+    @staticmethod
+    def host_info_requiring_instance_ids(filters, spec_obj):
+        instance_ids = set()
+        for filter_ in filters:
+            instance_ids.update(filter_.host_info_requiring_instance_ids(
+                spec_obj))
+        return instance_ids
 
 
 def all_filters():

--- a/nova/scheduler/filters/affinity_filter.py
+++ b/nova/scheduler/filters/affinity_filter.py
@@ -39,6 +39,9 @@ class DifferentHostFilter(filters.BaseHostFilter):
         # With no different_host key
         return True
 
+    def host_info_for_instance_ids(self, spec_obj):
+        return set(spec_obj.get_scheduler_hint('different_host'))
+
 
 class SameHostFilter(filters.BaseHostFilter):
     """Schedule the instance on the same host as another instance in a set of
@@ -56,6 +59,9 @@ class SameHostFilter(filters.BaseHostFilter):
             return overlap
         # With no same_host key
         return True
+
+    def host_info_for_instance_ids(self, spec_obj):
+        return set(spec_obj.get_scheduler_hint('same_host'))
 
 
 class SimpleCIDRAffinityFilter(filters.BaseHostFilter):
@@ -127,6 +133,14 @@ class _GroupAntiAffinityFilter(filters.BaseHostFilter):
         # will accept the given host if there are 0 servers from the group
         # already on this host.
         return len(servers_on_host) < max_server_per_host
+
+    def host_info_for_instance_ids(self, spec_obj):
+        instance_group = spec_obj.instance_group
+        policy = instance_group.policy if instance_group else None
+        if self.policy_name != policy:
+            return set()
+
+        return set(spec_obj.instance_group.members)
 
 
 class ServerGroupAntiAffinityFilter(_GroupAntiAffinityFilter):

--- a/nova/scheduler/weights/__init__.py
+++ b/nova/scheduler/weights/__init__.py
@@ -35,12 +35,23 @@ class BaseHostWeigher(weights.BaseWeigher):
     """Base class for host weights."""
     pass
 
+    def host_info_requiring_instance_ids(self, request_spec):
+        return set()
+
 
 class HostWeightHandler(weights.BaseWeightHandler):
     object_class = WeighedHost
 
     def __init__(self):
         super(HostWeightHandler, self).__init__(BaseHostWeigher)
+
+    @staticmethod
+    def host_info_requiring_instance_ids(weights, request_spec):
+        instance_ids = set()
+        for weight in weights:
+            instance_ids.update(
+                weight.host_info_requiring_instance_ids(request_spec))
+        return instance_ids
 
 
 def all_weighers():

--- a/nova/scheduler/weights/affinity.py
+++ b/nova/scheduler/weights/affinity.py
@@ -51,6 +51,17 @@ class _SoftAffinityWeigherBase(weights.BaseHostWeigher):
 
         return len(member_on_host)
 
+    def host_info_requiring_instance_ids(self, request_spec):
+        if not request_spec.instance_group:
+            return set()
+
+        policy = request_spec.instance_group.policy
+
+        if self.policy_name != policy:
+            return set()
+
+        return set(request_spec.instance_group.members)
+
 
 class ServerGroupSoftAffinityWeigher(_SoftAffinityWeigherBase):
     policy_name = 'soft-affinity'

--- a/nova/tests/unit/scheduler/test_host_filters.py
+++ b/nova/tests/unit/scheduler/test_host_filters.py
@@ -14,6 +14,8 @@
 """
 Tests For Scheduler Host Filters.
 """
+import mock
+
 from nova.scheduler import filters
 from nova.scheduler.filters import all_hosts_filter
 from nova.scheduler.filters import compute_filter
@@ -30,6 +32,20 @@ class HostFiltersTestCase(test.NoDBTestCase):
                 ['nova.scheduler.filters.all_filters'])
         self.assertIn(all_hosts_filter.AllHostsFilter, classes)
         self.assertIn(compute_filter.ComputeFilter, classes)
+
+    def test_host_info_requiring_instance_ids(self):
+        filter_handler = filters.HostFilterHandler()
+        filter_a = mock.Mock()
+        filter_b = mock.Mock()
+
+        filter_a.host_info_requiring_instance_ids.return_value = {'a'}
+        filter_b.host_info_requiring_instance_ids.return_value = {'b'}
+
+        mock_filter = [filter_a, filter_b]
+        spec_obj = mock.sentinel.spec_obj
+        result = filter_handler.host_info_requiring_instance_ids(mock_filter,
+                                                                 spec_obj)
+        self.assertEqual({'a', 'b'}, result)
 
     def test_all_host_filter(self):
         filt_cls = all_hosts_filter.AllHostsFilter()


### PR DESCRIPTION
Only in a subset of the situations the filters or weighers
are interested in the placement of very specific instances
for the scheduling decision.

But the host-manager fetches/holds all the instances for all
the hosts, which at a sufficient scale occupies the scheduler
fully with book-keeping of the instances.

As a first step, return the instance-ids each filter/weigher
is interested in, and skip on updating that information,
if none is required.

At a later step, the update can be limited to those instances.

Change-Id: I3ea05f98e300bbf0e4b0b42ad334e86d34b21ab6