### PR TITLE
[scheduler] _get_host_states instance_uuids may be None

### DIFF
--- a/nova/scheduler/host_manager.py
+++ b/nova/scheduler/host_manager.py
@@ -743,7 +743,7 @@ class HostManager(object):
                 # aggregates could have been happening after setting
                 # this field for the first time
 
-                if not instance_uuids:
+                if instance_uuids is not None and not instance_uuids:
                     # If no filter requires any instance information
                     # on the host, we can skip the db query
                     instances = {}


### PR DESCRIPTION
The function is called from other code-paths as well, and we need to preserve the old semantics for use-cases besides the FilteringScheduler (such as the CachingScheduler)

Change-Id: Id99e08fa5e833b197324ccf525a5fbcdfcce318a