### PR TITLE
[scheduler] Recent Patches for Xena (selective instance fetch, uuids None, unified host_info/passes/weigh)

### DIFF
--- a/nova/scheduler/filters/__init__.py
+++ b/nova/scheduler/filters/__init__.py
@@ -49,10 +49,21 @@ class BaseHostFilter(filters.BaseFilter):
         """
         raise NotImplementedError()
 
+    def host_info_requiring_instance_ids(self, spec_obj):
+        return set()
+
 
 class HostFilterHandler(filters.BaseFilterHandler):
     def __init__(self):
         super(HostFilterHandler, self).__init__(BaseHostFilter)
+
+    @staticmethod
+    def host_info_requiring_instance_ids(filters, spec_obj):
+        instance_ids = set()
+        for filter_ in filters:
+            instance_ids.update(filter_.host_info_requiring_instance_ids(
+                spec_obj))
+        return instance_ids
 
 
 def all_filters():

--- a/nova/scheduler/filters/affinity_filter.py
+++ b/nova/scheduler/filters/affinity_filter.py
@@ -32,7 +32,7 @@ class DifferentHostFilter(filters.BaseHostFilter):
     RUN_ON_REBUILD = False
 
     def host_passes(self, host_state, spec_obj):
-        affinity_uuids = spec_obj.get_scheduler_hint('different_host')
+        affinity_uuids = self.host_info_requiring_instance_ids(spec_obj)
         if affinity_uuids:
             overlap = utils.instance_uuids_overlap(host_state, affinity_uuids)
             return not overlap
@@ -40,7 +40,14 @@ class DifferentHostFilter(filters.BaseHostFilter):
         return True
 
     def host_info_requiring_instance_ids(self, spec_obj):
-        return set(spec_obj.get_scheduler_hint('different_host'))
+        different_host = spec_obj.get_scheduler_hint('different_host')
+        if not different_host:
+            return different_host
+
+        if isinstance(different_host, str):
+            return set([different_host])
+
+        return set(different_host)
 
 
 class SameHostFilter(filters.BaseHostFilter):
@@ -53,7 +60,7 @@ class SameHostFilter(filters.BaseHostFilter):
     RUN_ON_REBUILD = False
 
     def host_passes(self, host_state, spec_obj):
-        affinity_uuids = spec_obj.get_scheduler_hint('same_host')
+        affinity_uuids = self.host_info_requiring_instance_ids(spec_obj)
         if affinity_uuids:
             overlap = utils.instance_uuids_overlap(host_state, affinity_uuids)
             return overlap
@@ -61,7 +68,14 @@ class SameHostFilter(filters.BaseHostFilter):
         return True
 
     def host_info_requiring_instance_ids(self, spec_obj):
-        return set(spec_obj.get_scheduler_hint('same_host'))
+        same_host = spec_obj.get_scheduler_hint('same_host')
+        if not same_host:
+            return same_host
+
+        if isinstance(same_host, str):
+            return set([same_host])
+
+        return set(same_host)
 
 
 class SimpleCIDRAffinityFilter(filters.BaseHostFilter):
@@ -93,10 +107,10 @@ class _GroupAntiAffinityFilter(filters.BaseHostFilter):
     RUN_ON_REBUILD = False
 
     def host_passes(self, host_state, spec_obj):
-        # Only invoke the filter if 'anti-affinity' is configured
-        instance_group = spec_obj.instance_group
-        policy = instance_group.policy if instance_group else None
-        if self.policy_name != policy:
+        members = self.host_info_requiring_instance_ids(spec_obj)
+        # Only invoke the filter if 'anti-affinity' is configured,
+        # and there are any instances to consider
+        if not members:
             return True
 
         # NOTE(hanrong): Move operations like resize can check the same source
@@ -104,12 +118,13 @@ class _GroupAntiAffinityFilter(filters.BaseHostFilter):
         # must not return the source as a non-possible destination.
         if spec_obj.instance_uuid in host_state.instances.keys():
             return True
+
         # The list of instances UUIDs on the given host
         instances = set(host_state.instances.keys())
-        # The list of instances UUIDs which are members of this group
-        members = set(spec_obj.instance_group.members)
         # The set of instances on the host that are also members of this group
         servers_on_host = instances.intersection(members)
+
+        instance_group = spec_obj.instance_group
 
         rules = instance_group.rules
         if rules and 'max_server_per_host' in rules:
@@ -137,9 +152,11 @@ class _GroupAntiAffinityFilter(filters.BaseHostFilter):
     def host_info_requiring_instance_ids(self, spec_obj):
         instance_group = spec_obj.instance_group
         policy = instance_group.policy if instance_group else None
+
         if self.policy_name != policy:
             return set()
 
+        # The list of instances UUIDs which are members of this group
         return set(spec_obj.instance_group.members)
 
 

--- a/nova/scheduler/filters/affinity_filter.py
+++ b/nova/scheduler/filters/affinity_filter.py
@@ -39,7 +39,7 @@ class DifferentHostFilter(filters.BaseHostFilter):
         # With no different_host key
         return True
 
-    def host_info_for_instance_ids(self, spec_obj):
+    def host_info_requiring_instance_ids(self, spec_obj):
         return set(spec_obj.get_scheduler_hint('different_host'))
 
 
@@ -60,7 +60,7 @@ class SameHostFilter(filters.BaseHostFilter):
         # With no same_host key
         return True
 
-    def host_info_for_instance_ids(self, spec_obj):
+    def host_info_requiring_instance_ids(self, spec_obj):
         return set(spec_obj.get_scheduler_hint('same_host'))
 
 
@@ -134,7 +134,7 @@ class _GroupAntiAffinityFilter(filters.BaseHostFilter):
         # already on this host.
         return len(servers_on_host) < max_server_per_host
 
-    def host_info_for_instance_ids(self, spec_obj):
+    def host_info_requiring_instance_ids(self, spec_obj):
         instance_group = spec_obj.instance_group
         policy = instance_group.policy if instance_group else None
         if self.policy_name != policy:

--- a/nova/scheduler/filters/affinity_filter.py
+++ b/nova/scheduler/filters/affinity_filter.py
@@ -39,6 +39,9 @@ class DifferentHostFilter(filters.BaseHostFilter):
         # With no different_host key
         return True
 
+    def host_info_for_instance_ids(self, spec_obj):
+        return set(spec_obj.get_scheduler_hint('different_host'))
+
 
 class SameHostFilter(filters.BaseHostFilter):
     """Schedule the instance on the same host as another instance in a set of
@@ -56,6 +59,9 @@ class SameHostFilter(filters.BaseHostFilter):
             return overlap
         # With no same_host key
         return True
+
+    def host_info_for_instance_ids(self, spec_obj):
+        return set(spec_obj.get_scheduler_hint('same_host'))
 
 
 class SimpleCIDRAffinityFilter(filters.BaseHostFilter):
@@ -127,6 +133,14 @@ class _GroupAntiAffinityFilter(filters.BaseHostFilter):
         # will accept the given host if there are 0 servers from the group
         # already on this host.
         return len(servers_on_host) < max_server_per_host
+
+    def host_info_for_instance_ids(self, spec_obj):
+        instance_group = spec_obj.instance_group
+        policy = instance_group.policy if instance_group else None
+        if self.policy_name != policy:
+            return set()
+
+        return set(spec_obj.instance_group.members)
 
 
 class ServerGroupAntiAffinityFilter(_GroupAntiAffinityFilter):

--- a/nova/scheduler/host_manager.py
+++ b/nova/scheduler/host_manager.py
@@ -817,7 +817,7 @@ class HostManager(object):
                 # aggregates could have been happening after setting
                 # this field for the first time
 
-                if not instance_uuids:
+                if instance_uuids is not None and not instance_uuids:
                     # If no filter requires any instance information
                     # on the host, we can skip the db query
                     instances = {}

--- a/nova/scheduler/host_manager.py
+++ b/nova/scheduler/host_manager.py
@@ -752,6 +752,12 @@ class HostManager(object):
         # cell a particular host is in (used with self.cells).
         self.host_to_cell_uuid = {}
 
+    def _get_required_instance_uuids_for_spec(self, spec_obj):
+        return (self.filter_handler.host_info_requiring_instance_ids(
+                    self.enabled_filters, spec_obj)
+                | self.weight_handler.host_info_requiring_instance_ids(
+                    self.weighers, spec_obj))
+
     def get_host_states_by_uuids(self, context, compute_uuids, spec_obj):
 
         if not self.cells:
@@ -773,9 +779,14 @@ class HostManager(object):
 
         compute_nodes, services = self._get_computes_for_cells(
             context, cells, compute_uuids=compute_uuids)
-        return self._get_host_states(context, compute_nodes, services)
 
-    def _get_host_states(self, context, compute_nodes, services):
+        instance_uuids = self._get_required_instance_uuids_for_spec(spec_obj)
+
+        return self._get_host_states(context, compute_nodes, services,
+                    instance_uuids=instance_uuids)
+
+    def _get_host_states(self, context, compute_nodes, services,
+                         instance_uuids=None):
         """Returns a generator over HostStates given a list of computes.
 
         Also updates the HostStates internal mapping for the HostManager.
@@ -805,10 +816,19 @@ class HostManager(object):
                 # new request comes in, because some changes on the
                 # aggregates could have been happening after setting
                 # this field for the first time
+
+                if not instance_uuids:
+                    # If no filter requires any instance information
+                    # on the host, we can skip the db query
+                    instances = {}
+                else:
+                    instances = self._get_instance_info(context, compute)
+
                 host_state.update(compute,
                                   dict(service),
                                   self._get_aggregates_info(host),
-                                  self._get_instance_info(context, compute))
+                                  instances
+                                  )
 
                 seen_nodes.add(state_key)
 

--- a/nova/scheduler/weights/__init__.py
+++ b/nova/scheduler/weights/__init__.py
@@ -35,12 +35,23 @@ class BaseHostWeigher(weights.BaseWeigher):
     """Base class for host weights."""
     pass
 
+    def host_info_requiring_instance_ids(self, request_spec):
+        return set()
+
 
 class HostWeightHandler(weights.BaseWeightHandler):
     object_class = WeighedHost
 
     def __init__(self):
         super(HostWeightHandler, self).__init__(BaseHostWeigher)
+
+    @staticmethod
+    def host_info_requiring_instance_ids(weights, request_spec):
+        instance_ids = set()
+        for weight in weights:
+            instance_ids.update(
+                weight.host_info_requiring_instance_ids(request_spec))
+        return instance_ids
 
 
 def all_weighers():

--- a/nova/scheduler/weights/affinity.py
+++ b/nova/scheduler/weights/affinity.py
@@ -52,6 +52,17 @@ class _SoftAffinityWeigherBase(weights.BaseHostWeigher):
 
         return len(member_on_host)
 
+    def host_info_requiring_instance_ids(self, request_spec):
+        if not request_spec.instance_group:
+            return set()
+
+        policy = request_spec.instance_group.policy
+
+        if self.policy_name != policy:
+            return set()
+
+        return set(request_spec.instance_group.members)
+
 
 class ServerGroupSoftAffinityWeigher(_SoftAffinityWeigherBase):
     policy_name = 'soft-affinity'

--- a/nova/scheduler/weights/affinity.py
+++ b/nova/scheduler/weights/affinity.py
@@ -38,16 +38,11 @@ class _SoftAffinityWeigherBase(weights.BaseHostWeigher):
 
     def _weigh_object(self, host_state, request_spec):
         """Higher weights win."""
-        if not request_spec.instance_group:
-            return 0
-
-        policy = request_spec.instance_group.policy
-
-        if self.policy_name != policy:
+        members = self.host_info_requiring_instance_ids(request_spec)
+        if not members:
             return 0
 
         instances = set(host_state.instances.keys())
-        members = set(request_spec.instance_group.members)
         member_on_host = instances.intersection(members)
 
         return len(member_on_host)

--- a/nova/tests/unit/scheduler/test_host_filters.py
+++ b/nova/tests/unit/scheduler/test_host_filters.py
@@ -14,6 +14,8 @@
 """
 Tests For Scheduler Host Filters.
 """
+import mock
+
 from nova.scheduler import filters
 from nova.scheduler.filters import all_hosts_filter
 from nova.scheduler.filters import compute_filter
@@ -30,6 +32,20 @@ class HostFiltersTestCase(test.NoDBTestCase):
                 ['nova.scheduler.filters.all_filters'])
         self.assertIn(all_hosts_filter.AllHostsFilter, classes)
         self.assertIn(compute_filter.ComputeFilter, classes)
+
+    def test_host_info_requiring_instance_ids(self):
+        filter_handler = filters.HostFilterHandler()
+        filter_a = mock.Mock()
+        filter_b = mock.Mock()
+
+        filter_a.host_info_requiring_instance_ids.return_value = {'a'}
+        filter_b.host_info_requiring_instance_ids.return_value = {'b'}
+
+        mock_filter = [filter_a, filter_b]
+        spec_obj = mock.sentinel.spec_obj
+        result = filter_handler.host_info_requiring_instance_ids(mock_filter,
+                                                                 spec_obj)
+        self.assertEqual({'a', 'b'}, result)
 
     def test_all_host_filter(self):
         filt_cls = all_hosts_filter.AllHostsFilter()

--- a/nova/tests/unit/scheduler/test_host_manager.py
+++ b/nova/tests/unit/scheduler/test_host_manager.py
@@ -1360,20 +1360,25 @@ class HostManagerChangedNodesTestCase(test.NoDBTestCase):
     @mock.patch('nova.objects.InstanceList.get_uuids_by_host')
     def test_get_host_states_by_uuids(self, mock_get_by_host, mock_get_all,
                                       mock_get_by_binary):
-        mock_get_by_host.return_value = []
         mock_get_all.side_effect = [fakes.COMPUTE_NODES, []]
         mock_get_by_binary.side_effect = [fakes.SERVICES, fakes.SERVICES]
 
         # Request 1: all nodes can satisfy the request
         hosts1 = self.host_manager.get_host_states_by_uuids(
-            mock.sentinel.ctxt1, mock.sentinel.uuids1, objects.RequestSpec())
+            mock.sentinel.ctxt1, mock.sentinel.uuids1, objects.RequestSpec(
+                instance_group=None
+            ))
+        mock_get_by_host.assert_not_called()
         # get_host_states_by_uuids returns a generator so convert the values
         # into an iterator
         host_states1 = iter(hosts1)
 
         # Request 2: no nodes can satisfy the request
         hosts2 = self.host_manager.get_host_states_by_uuids(
-            mock.sentinel.ctxt2, mock.sentinel.uuids2, objects.RequestSpec())
+            mock.sentinel.ctxt2, mock.sentinel.uuids2, objects.RequestSpec(
+                instance_group=None
+            ))
+        mock_get_by_host.assert_not_called()
         host_states2 = iter(hosts2)
 
         # Fake a concurrent request that is still processing the first result
@@ -1384,6 +1389,29 @@ class HostManagerChangedNodesTestCase(test.NoDBTestCase):
         # Verify that no nodes are available to Request 2.
         num_hosts2 = len(list(host_states2))
         self.assertEqual(0, num_hosts2)
+
+    @mock.patch('nova.objects.ServiceList.get_by_binary')
+    @mock.patch('nova.objects.ComputeNodeList.get_all_by_uuids')
+    @mock.patch('nova.objects.InstanceList.get_uuids_by_host')
+    def test_get_host_states_by_uuids_with_instances(self, mock_get_by_host,
+                                                     mock_get_all,
+                                                     mock_get_by_binary):
+        mock_get_by_host.return_value = []
+        mock_get_all.side_effect = [fakes.COMPUTE_NODES, []]
+        mock_get_by_binary.side_effect = [fakes.SERVICES, fakes.SERVICES]
+
+        with mock.patch.object(self.host_manager,
+                '_get_required_instance_uuids_for_spec') as (
+                    mock_instance_uuids):
+            mock_instance_uuids.return_value = mock.sentinel.uuids2
+
+            spec_obj = objects.RequestSpec()
+            self.host_manager.get_host_states_by_uuids(mock.sentinel.ctxt1,
+                mock.sentinel.uuids1, spec_obj)
+
+            mock_instance_uuids.assert_called_with(spec_obj)
+
+        mock_get_by_host.assert_called()
 
     @mock.patch('nova.scheduler.host_manager.HostManager.'
                 '_get_computes_for_cells',
@@ -1398,6 +1426,7 @@ class HostManagerChangedNodesTestCase(test.NoDBTestCase):
         ctxt = nova_context.get_admin_context()
         compute_uuids = [uuids.compute_node_uuid]
         spec_obj = objects.RequestSpec(
+            instance_group=None,
             requested_destination=objects.Destination(
                 cell=objects.CellMapping(uuid=uuids.cell1),
                 allow_cross_cell_move=True))
@@ -1406,7 +1435,8 @@ class HostManagerChangedNodesTestCase(test.NoDBTestCase):
         mock_get_computes.assert_called_once_with(
             ctxt, self.host_manager.enabled_cells, compute_uuids=compute_uuids)
         mock_get_host_states.assert_called_once_with(
-            ctxt, mock.sentinel.compute_nodes, mock.sentinel.services)
+            ctxt, mock.sentinel.compute_nodes, mock.sentinel.services,
+            instance_uuids=set())
 
 
 class HostStateTestCase(test.NoDBTestCase):


### PR DESCRIPTION
Only in a subset of the situations the filters or weighers
are interested in the placement of very specific instances
for the scheduling decision.

But the host-manager fetches/holds all the instances for all
the hosts, which at a sufficient scale occupies the scheduler
fully with book-keeping of the instances.

As a first step, return the instance-ids each filter/weigher
is interested in, and skip on updating that information,
if none is required.

At a later step, the update can be limited to those instances.

Change-Id: I3ea05f98e300bbf0e4b0b42ad334e86d34b21ab6