### PR TITLE
[vmwareapi] Limit free space of datastore to capacity 2

### DIFF
--- a/nova/virt/vmwareapi/ds_util.py
+++ b/nova/virt/vmwareapi/ds_util.py
@@ -79,11 +79,13 @@ def _select_datastore(session, datastores, best_match, datastore_regex=None,
         propdict = vm_util.propset_dict(obj_content.propSet)
         if _is_datastore_valid(propdict, datastore_regex, allowed_ds_types,
                                datastore_hagroup_regex, datastore_hagroup):
+            capacity = propdict['summary.capacity']
+            freespace = propdict['summary.freeSpace']
             new_ds = ds_obj.Datastore(
                     ref=obj_content.obj,
                     name=propdict['summary.name'],
-                    capacity=propdict['summary.capacity'],
-                    freespace=propdict['summary.freeSpace'])
+                    capacity=capacity,
+                    freespace=min(freespace, capacity))
             # favor datastores with more free space
             if (best_match is None or
                     new_ds.freespace > best_match.freespace):


### PR DESCRIPTION
Apparently, the vmware api can report datastores with more free space than capacity, which causes an exception in the olso_vmware api. Therefore, we limit the free space to the capacity.

Change-Id: If6013022a8a32029d43f9074eaaeea5b55855104