### PR TITLE
SAP: Rewrite ShellInaBoxProxy as MiTM script

### DIFF
--- a/nova/cmd/shellinaboxproxy.py
+++ b/nova/cmd/shellinaboxproxy.py
@@ -15,7 +15,7 @@
 import sys
 
 from os import path
-from subprocess import check_output
+from subprocess import call
 
 import nova.conf
 from nova.conf import shellinabox
@@ -36,7 +36,7 @@ def main():
 
     config.parse_args(sys.argv)
     # Run mitmproxy with shellinaboxproxy.py as an inline script
-    check_output("mitmdump -R %s --port %s --bind-address %s --script %s" % (
+    return call("mitmdump -R %s --port %s --bind-address %s --script %s" % (
                  CONF.shellinabox.proxyclient_url,
                  CONF.shellinabox.port,
                  CONF.shellinabox.host,

--- a/nova/console/shellinaboxproxy.py
+++ b/nova/console/shellinaboxproxy.py
@@ -13,66 +13,111 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from nova.compute import rpcapi as compute_rpcapi
-from nova import config
-from nova.console.websocketproxy import NovaProxyRequestHandlerBase
-from nova import context
-from nova import exception
 
-STATIC_FILES_EXT = ('.js', '.css', '.html', '.ico', '.png', '.gif')
+import hashlib
+
+import configparser
+from mitmproxy.models import http
+from mitmproxy.script import concurrent
+from netlib import http as netlib_http
+from netlib import version
+from sqlalchemy import create_engine
+from sqlalchemy.sql import text
+
+STATIC_FILES_EXT = (".js", ".css", ".html", ".ico", ".png", ".gif")
 
 
-class NovaShellInaBoxProxy(NovaProxyRequestHandlerBase):
-    """Class that injects token validation routine into proxy logic."""
+def _load_dbs():
+    config = configparser.ConfigParser()
+    config.read("/etc/nova/nova.conf")
+    api_db_url = config["api_database"]["connection"]
+    api_db_engine = create_engine(api_db_url)
+    with api_db_engine.connect() as api_db:
+        for (db_url,) in api_db.execute(
+            text("SELECT database_connection FROM cell_mappings WHERE id > 1")
+        ):
+            yield create_engine(db_url)
 
-    def __init__(self):
-        self._compute_rpcapi = None
 
-    @property
-    def compute_rpcapi(self):
-        # This is copied from NovaProxyRequestHandler, just to avoid
-        # extending that class (because it inherits
-        # websockify.ProxyRequestHandler in addition and we don't need that).
-        # For upgrades we should have a look again if anything changed there,
-        # that we might need to also include here.
-        if not self._compute_rpcapi:
-            self._compute_rpcapi = compute_rpcapi.ComputeAPI()
-        return self._compute_rpcapi
+_DBS = list(_load_dbs())
 
-    def path_includes_static_files(self):
-        """Returns True if requested path includes static files."""
-        for extension in STATIC_FILES_EXT:
-            if extension in self.path:
+
+@concurrent
+def request(flow):
+    if flow.error or not flow.live:
+        return
+    request = flow.request
+
+    # We only have to validate the "initial" GET
+    # on the console path, as that one returns a session-id
+    # which is validated by the backend
+
+    if request.method == "POST":  # POST gets validated by the backend
+        return
+
+    path = request.path
+    if _path_includes_static_files(path):  # Not secret
+        return
+
+    if path in [None, "", "/"]:  # The liveness probe
+        _root_response(flow)
+        return
+
+    token = flow.request.query.pop("token", None)
+
+    if not token:
+        _access_denied(flow, b"No token provided.")
+        return
+
+    token_hash = _get_sha256_str(token)
+
+    for db in _DBS:
+        if _validate_token(db, token_hash):
+            return
+
+    _access_denied(flow, b"The token has expired or is invalid.")
+
+
+def _path_includes_static_files(path):
+    """Returns True if requested path includes static files."""
+    for extension in STATIC_FILES_EXT:
+        if path.endswith(extension):
+            return True
+
+
+def _root_response(flow):
+    http_version = flow.request.data.http_version
+    headers = netlib_http.Headers(
+        Server=version.MITMPROXY,
+        Connection="close",
+        Content_Length="0",
+    )
+
+    flow.response = http.HTTPResponse(
+        http_version, 204, b"No content", headers, b""
+    )
+
+
+def _validate_token(db_engine, token_hash):
+    with db_engine.connect() as con:
+        for (exists,) in con.execute(
+            text(
+                "SELECT EXISTS("
+                "  SELECT 1 FROM console_auth_tokens "
+                "    WHERE token_hash=:token_hash"
+                "    AND expires > UNIX_TIMESTAMP()"
+                ")"
+            ),
+            token_hash=token_hash,
+        ):
+            if exists > 0:
                 return True
-
-    def response(self, flow):
-        """Validate the token and give 403 if not found or not valid."""
-        if self.method == "GET" and not self.path_includes_static_files():
-
-            if not self.token:
-                # No token found
-                flow.response.status_code = 403
-                flow.response.content = b"No token provided."
-            else:
-                # Validate the token
-                ctxt = context.get_admin_context()
-                try:
-                    super(NovaShellInaBoxProxy, self)._get_connect_info(
-                        ctxt, self.token)
-                except exception.InvalidToken:
-                    # Token not valid
-                    flow.response.status_code = 403
-                    flow.response.content = ("The token has expired "
-                                             "or invalid.")
-
-    def request(self, flow):
-        """Save the token, method and path that came with request."""
-        self.token = flow.request.query.get("token", "")
-        self.method = flow.request.method
-        self.path = flow.request.path
+    return False
 
 
-def start():
-    """Entrypoint. Configures rpc first, otherwise cannot validate token."""
-    config.parse_args([])  # we need this to configure rpc
-    return NovaShellInaBoxProxy()
+def _get_sha256_str(base_str):
+    return hashlib.sha256(base_str.encode("utf-8")).hexdigest()
+
+
+def _access_denied(flow, reason):
+    flow.response = http.make_error_response(403, reason)


### PR DESCRIPTION
The old script was
- running check_output and therefore
  - not printing the mitmproxy logs
  - capturing the output in RAM
- only querying the first cell for tokens
- validating the request after having received a response from the backend, i.e. after having forwarded the unauthenticated request
- and probably having some strange interaction between eventlet and mitmproxy mixing up the validation with the requests (i.e. requests would be send through without validation despite the code clearly stating they should)

Change-Id: I2d1cd9a3f440705a8c8a075c8df62e5627facd90