### PR TITLE
vmareapi: Fix jsonutils.load() needing bytes in Python3

### DIFF
--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1546,7 +1546,7 @@ def _get_host_reservations_map(groups=None):
     if not CONF.vmware.hostgroup_reservations_json_file:
         return {}
 
-    with open(CONF.vmware.hostgroup_reservations_json_file) as f:
+    with open(CONF.vmware.hostgroup_reservations_json_file, 'rb') as f:
         reservations = jsonutils.load(f)
 
     hrm = {}


### PR DESCRIPTION
This is a fixup for commit 072b15f54b4 [vmware] Add configurable reservations per hostgroup

Change-Id: I191aedb0e3bba7698825771089cf134f320368ec