### PR TITLE
vmware: Report DISK_GB as integers

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -544,10 +544,10 @@ class VMwareVCDriver(driver.ComputeDriver):
             reserved_disk_gb = compute_utils.convert_mb_to_ceil_gb(
                 CONF.reserved_host_disk_mb)
             result[orc.DISK_GB] = {
-                'total': local_gb,
+                'total': int(local_gb),
                 'reserved': reserved_disk_gb,
                 'min_unit': 1,
-                'max_unit': local_gb_max_free,
+                'max_unit': int(local_gb_max_free),
                 'step_size': 1,
             }
 


### PR DESCRIPTION
With upgrading to Xena and thus Nova using newer microversions to talk to Placement, we cannot report floating point numbers for the resources anymore. This came up in DISK_GB, which is computed from MB and thus not always a round number.

We fix this by converting the numbers to int and thus cutting off the values after the comma. With that, we under-report resources, which seems better than over-reporting them, because we could not fit everything in when over-reporting.

Change-Id: I0d364f347afa235ed2b7e8ae90f5851275b7738e