### PR TITLE
Rewrite ShellInaBoxProxy as MiTM script (Xena)

### DIFF
--- a/nova/cmd/shellinaboxproxy.py
+++ b/nova/cmd/shellinaboxproxy.py
@@ -15,7 +15,7 @@
 import sys
 
 from os import path
-from subprocess import check_output
+from subprocess import call
 
 import nova.conf
 from nova.conf import shellinabox
@@ -37,9 +37,8 @@ def main():
 
     config.parse_args(sys.argv)
     # Run mitmproxy with shellinaboxproxy.py as an inline script
-    cmd = ['mitmdump',
-           '--mode', f"reverse:{CONF.shellinabox.proxyclient_url}",
-           '--listen-port', str(CONF.shellinabox.port),
-           '--listen-host', CONF.shellinabox.host,
-           '--script', path.abspath(script)]
-    check_output(cmd)
+    return call("mitmdump -R %s --port %s --bind-address %s --script %s" % (
+                 CONF.shellinabox.proxyclient_url,
+                 CONF.shellinabox.port,
+                 CONF.shellinabox.host,
+                 path.abspath(script)), shell=True)

--- a/nova/console/shellinaboxproxy.py
+++ b/nova/console/shellinaboxproxy.py
@@ -55,7 +55,7 @@ def request(flow):
         return
 
     path = request.path
-    if _path_includes_static_files(path):  # Not secret
+    if path.endswith(STATIC_FILES_EXT):  # Not secret
         return
 
     if path in [None, "", "/"]:  # The liveness probe
@@ -75,13 +75,6 @@ def request(flow):
             return
 
     _access_denied(flow, b"The token has expired or is invalid.")
-
-
-def _path_includes_static_files(path):
-    """Returns True if requested path includes static files."""
-    for extension in STATIC_FILES_EXT:
-        if path.endswith(extension):
-            return True
 
 
 def _root_response(flow):


### PR DESCRIPTION
The old script was
- running check_output and therefore
  - not printing the mitmproxy logs
  - capturing the output in RAM
- only querying the first cell for tokens
- validating the request after having received
  a response from the backend, i.e. after having
  forwarded the unauthenticated request
- and probably having some strange interaction
  between eventlet and mitmproxy mixing up
  the validation with the requests
  (i.e. requests would be send through without validation
  despite the code clearly stating they should)

Change-Id: I2d1cd9a3f440705a8c8a075c8df62e5627facd90
