### PR TITLE
Log disabled/forced_down changes on services

### DIFF
--- a/nova/objects/service.py
+++ b/nova/objects/service.py
@@ -406,6 +406,10 @@ class Service(base.NovaPersistentObject, base.NovaObject,
         if set(updates.keys()).intersection(
                 {'disabled', 'disabled_reason', 'forced_down'}):
             self._send_notification(fields.NotificationAction.UPDATE)
+            LOG.info("ServiceStatusNotification for service on host %s: "
+                     "disabled: %s, forced_down: %s, reason: %s",
+                     self.host, self.disabled, self.forced_down,
+                     self.disabled_reason)
 
     def _send_notification(self, action):
         payload = service_notification.ServiceStatusPayload(self)


### PR DESCRIPTION
We want to know when a service was first activated and last deactivated. For this, we log a line every time a service is enabled/disabled. The log line can then be saved in long-term storage and looked up again.

Change-Id: Ia904ac8108dd384d1675eba5250a38b77a5a8184