### PR TITLE
vmware: soft-anti-affinity can use multiple DRS rules - xena

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -117,7 +117,7 @@ class VMwareVMOpsTestCase(test.TestCase):
         self._instance.flavor = self._flavor
         self._volumeops = volumeops.VMwareVolumeOps(self._session)
         self._vmops = vmops.VMwareVMOps(self._session, self._virtapi,
-                                        self._volumeops,
+                                        self._volumeops, mock.Mock(),
                                         cluster=cluster.obj,
                                         vcenter_uuid=uuids.vcenter)
         self._cluster = cluster
@@ -203,7 +203,8 @@ class VMwareVMOpsTestCase(test.TestCase):
         self.assertEqual('DE:AD:BE:EF:00:00;;;;;#', result)
 
     def _setup_create_folder_mocks(self):
-        ops = vmops.VMwareVMOps(mock.Mock(), mock.Mock(), mock.Mock())
+        ops = vmops.VMwareVMOps(mock.Mock(), mock.Mock(), mock.Mock(),
+                                mock.Mock())
         base_name = 'folder'
         ds_name = "datastore"
         ds_ref = vmwareapi_fake.ManagedObjectReference(value=1)
@@ -232,7 +233,7 @@ class VMwareVMOpsTestCase(test.TestCase):
 
     def test_get_valid_vms_from_retrieve_result(self):
         ops = vmops.VMwareVMOps(self._session, mock.Mock(), mock.Mock(),
-                                cluster=self._cluster.obj)
+                                mock.Mock(), cluster=self._cluster.obj)
         fake_objects = vmwareapi_fake.FakeRetrieveResult()
         for x in range(0, 3):
             vm = vmwareapi_fake.VirtualMachine()
@@ -245,7 +246,7 @@ class VMwareVMOpsTestCase(test.TestCase):
 
     def test_get_valid_vms_from_retrieve_result_with_invalid(self):
         ops = vmops.VMwareVMOps(self._session, mock.Mock(), mock.Mock(),
-                                cluster=self._cluster.obj)
+                                mock.Mock(), cluster=self._cluster.obj)
         fake_objects = vmwareapi_fake.FakeRetrieveResult()
         valid_vm = vmwareapi_fake.VirtualMachine()
         valid_vm.set('config.extraConfig["nvp.vm-uuid"]',
@@ -386,7 +387,7 @@ class VMwareVMOpsTestCase(test.TestCase):
 
     def _test_get_datacenter_ref_and_name(self, ds_ref_exists=False):
         instance_ds_ref = vmwareapi_fake.ManagedObjectReference(value='ds-1')
-        _vcvmops = vmops.VMwareVMOps(self._session, None, None,
+        _vcvmops = vmops.VMwareVMOps(self._session, None, None, None,
                                      cluster=self._cluster.obj)
         result = vmwareapi_fake.FakeRetrieveResult()
         if ds_ref_exists:

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -166,18 +166,19 @@ class VMwareVCDriver(driver.ComputeDriver):
             self._create_nodename(vim_util.get_moref_value(self._cluster_ref))
         self._volumeops = volumeops.VMwareVolumeOps(self._session,
                                                     self._cluster_ref)
+        self._vc_state = host.VCState(self._session,
+                                      self._nodename,
+                                      self._cluster_ref,
+                                      self._datastore_regex)
         self._vmops = vmops.VMwareVMOps(self._session,
                                         virtapi,
                                         self._volumeops,
+                                        self._vc_state,
                                         self._cluster_ref,
                                         self._vcenter_uuid,
                                         datastore_regex=self._datastore_regex,
                                         datastore_hagroup_regex=
                                             self._datastore_hagroup_regex)
-        self._vc_state = host.VCState(self._session,
-                                      self._nodename,
-                                      self._cluster_ref,
-                                      self._datastore_regex)
         self.capabilities['resource_scheduling'] = \
             cluster_util.is_drs_enabled(self._session, self._cluster_ref)
         # Register the OpenStack extension

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -168,7 +168,7 @@ class VMwareVMOps(object):
     """
     MIGRATION_VERSION = "1.0"
 
-    def __init__(self, session, virtapi, volumeops, cluster=None,
+    def __init__(self, session, virtapi, volumeops, vc_state, cluster=None,
                  vcenter_uuid=None, datastore_regex=None,
                  datastore_hagroup_regex=None):
         """Initializer."""
@@ -176,6 +176,7 @@ class VMwareVMOps(object):
         self._session = session
         self._virtapi = virtapi
         self._volumeops = volumeops
+        self._vc_state = vc_state
         self._cluster = cluster
         self._vcenter_uuid = vcenter_uuid
         self._property_collector = None

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -4231,13 +4231,57 @@ class VMwareVMOps(object):
                     continue
                 expected_members[instance.uuid] = moref
 
-            rule_name = '{}-{}'.format(rule_prefix, sg.policy)
+            rule_members_by_name = {}
+            if sg.policy == 'soft-anti-affinity':
+                # we chunk by available hosts, because we can spawn only as
+                # many VMs as there are hosts as VMware doesn't provide any
+                # "soft" anti-affinity except for VM-Host relations
+                # Only hosts have an 'available' field - the cluster doesn't.
+                # Therefore, we don't have to filter out the aggregated cluster
+                # stats explicitly.
+                member_chunk_size = len(
+                    [stat for stat in self._vc_state.get_host_stats().values()
+                     if stat.get('available', False)])
+
+                # to generate stable chunks we have to sort the expected
+                # members. we also need a list to be able to access parts of
+                # them.
+                expected_members = sorted(expected_members.items())
+
+                # generate chunks of the expected members with rules having a
+                # postfix counting up for the soft-anti-affinity policy
+                for i, j in enumerate(range(0, len(expected_members),
+                                            member_chunk_size)):
+                    rule_name = '{}-{}-{}'.format(rule_prefix, sg.policy, i)
+                    rule_members = expected_members[j:j + member_chunk_size]
+                    rule_members_by_name[rule_name] = rule_members
+
+                # we need to add in the existing rules with the same prefix,
+                # because there might be 1) old rules from before the chunking
+                # and 2) rules we don't reach anymore because the number of
+                # members of the sg is much lower now
+                existing_rule_names = [
+                    rule['name'] for rule in cluster_util.get_rules_by_prefix(
+                        self._session, self._cluster, rule_prefix)]
+
+                rule_names = \
+                    set(existing_rule_names) | set(rule_members_by_name)
+                for rule_name in rule_names:
+                    rule_members = rule_members_by_name.get(rule_name, [])
+                    _update_rule(rule_name, dict(rule_members), sg)
+            else:
+                # no chunking necessary - just update the rule
+                rule_name = '{}-{}'.format(rule_prefix, sg.policy)
+                _update_rule(rule_name, expected_members, sg)
+
+            LOG.debug('Sync for server-group %s done', sg_uuid)
+
+        def _update_rule(rule_name, expected_members, sg):
             rule = cluster_util.get_rule(
                 self._session, self._cluster, rule_name)
 
             if not rule:
                 if len(expected_members) < 2 or sg.policy == 'soft-affinity':
-                    LOG.debug('Sync for server-group %s done', sg_uuid)
                     return
                 # we have to create a new rule
                 LOG.debug('Creating missing DRS rule %s with members %s',
@@ -4250,7 +4294,6 @@ class VMwareVMOps(object):
                     self._session, self._cluster, rule)
                 LOG.info('Created missing DRS rule %s with members %s',
                          rule_name, ', '.join(expected_members))
-                LOG.debug('Sync for server-group %s done', sg_uuid)
                 return
 
             if sg.policy == 'soft-affinity':
@@ -4260,7 +4303,6 @@ class VMwareVMOps(object):
                     self._session, self._cluster, rule)
                 LOG.info('Deleted DRS rule %s with policy soft-affinity.',
                           rule_name)
-                LOG.debug('Sync for server-group %s done', sg_uuid)
                 return
 
             if len(expected_members) < 2:
@@ -4269,7 +4311,6 @@ class VMwareVMOps(object):
                 cluster_util.delete_rule(
                     self._session, self._cluster, rule)
                 LOG.info('Deleted DRS rule %s with < 2 members.', rule_name)
-                LOG.debug('Sync for server-group %s done', sg_uuid)
                 return
 
             if not rule.enabled:
@@ -4284,7 +4325,6 @@ class VMwareVMOps(object):
             existing_moref_values = set(vutil.get_moref_value(m)
                                         for m in rule.vm)
             if expected_moref_values == existing_moref_values:
-                LOG.debug('Sync for server-group %s done', sg_uuid)
                 return
 
             # we have to update the DRS rule to contain the right members
@@ -4294,7 +4334,6 @@ class VMwareVMOps(object):
             cluster_util.update_rule(self._session, self._cluster, rule)
             LOG.info('Updated DRS rule %s with members %s',
                      rule_name, ', '.join(expected_members))
-            LOG.debug('Sync for server-group %s done', sg_uuid)
 
         _sync_sync_server_group(context, sg_uuid)
 


### PR DESCRIPTION
Since VMware doesn't support the "mandatory" setting on VM-VM DRS rules, all rules we create are mandatory. This leads to VMs being unable to spawn in a cluster, if there are already as many VMs in the same soft-anti-affinity server-group as there are hosts in the cluster. Customers expect soft-anti-affinity to work also in this case.

To accommodate for that, we now split members of soft-anti-affinity server-groups into multiple chunks. Each chunk has the size of available hosts in the cluster. For each chunk, we create an anti-affinity DRS rule.

We try to make the members of each chunk stable by sorting the members in the server-group, but this commit probably still leads to more updates of DRS rules in those bigger server-groups.

Since there can be rules in a no-longer-used chunk and since there are currently already rules with a different naming scheme (i.e. without the trailing number), we also fetch all rules of the same prefix and "update" them. Updating a rule without members leads to deletion of this rule.

Change-Id: Id28fcc71193b491a1ac57e5c4f28c3b4862eeee5