### PR TITLE
Add MKS VNC proxy for VMware

### DIFF
--- a/nova/cmd/mksproxy.py
+++ b/nova/cmd/mksproxy.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2016 VMware Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import sys
+
+from oslo_log import log as logging
+
+from nova.cmd import baseproxy
+import nova.conf
+from nova.conf import mks
+from nova import config
+from nova.console.securityproxy.mks import MksSecurityProxy
+
+
+CONF = nova.conf.CONF
+LOG = logging.getLogger(__name__)
+mks.register_cli_opts(CONF)
+
+
+def main():
+    config.parse_args(sys.argv)
+
+    if CONF.mks.verbose:
+        LOG.setLevel(logging.DEBUG)
+    if CONF.mks.web:
+        CONF.web = CONF.mks.web
+
+    baseproxy.proxy(
+        host=CONF.mks.host,
+        port=CONF.mks.port,
+        security_proxy=MksSecurityProxy())

--- a/nova/conf/mks.py
+++ b/nova/conf/mks.py
@@ -13,7 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-
 from oslo_config import cfg
 
 mks_group = cfg.OptGroup('mks',
@@ -53,9 +52,23 @@ Enables graphical console access for virtual machines.
 ]
 
 
+mks_cli_opts = [
+    cfg.StrOpt('web', required=False,
+               help='MKS web location, takes precedence over --web'),
+    cfg.IPOpt('host', default='0.0.0.0', help='MKS proxy host'),
+    cfg.PortOpt('port', default=6090, help='MKS proxy port'),
+    cfg.BoolOpt('verbose', default=False, help='Verbose logging'),
+]
+
+
 def register_opts(conf):
     conf.register_group(mks_group)
     conf.register_opts(mks_opts, group=mks_group)
+
+
+def register_cli_opts(conf):
+    conf.register_group(mks_group)
+    conf.register_cli_opts(mks_cli_opts, mks_group)
 
 
 def list_opts():

--- a/nova/console/mksproxy.py
+++ b/nova/console/mksproxy.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2016 VMware Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import base64
+import hashlib
+import os
+import socket
+import ssl
+
+from nova.console.websocketproxy import NovaProxyRequestHandler
+from nova import exception
+from oslo_serialization import jsonutils
+
+
+class NovaMksProxyRequestHandler(NovaProxyRequestHandler):
+    VMAD_OK = 200
+    VMAD_WELCOME = 220
+    VMAD_LOGINOK = 230
+    VMAD_NEEDPASSWD = 331
+    VMAD_USER_CMD = "USER"
+    VMAD_PASS_CMD = "PASS"
+    VMAD_THUMB_CMD = "THUMBPRINT"
+    VMAD_CONNECT_CMD = "CONNECT"
+
+    @staticmethod
+    def expect(sock, code):
+        """Receive and extract the next message and raise if the reply doesn't
+           match the expected `code`.
+        """
+        line = sock.recv(1024).decode('ascii')
+        recv_code, msg = line.split()[0:2]
+        recv_code = int(recv_code)
+        if code != recv_code:
+            raise exception.ValidationError('Expected %d but received %d'
+                                            % (code, recv_code))
+        return msg
+
+    @classmethod
+    def handshake_and_connect(cls, connect_info):
+        host = connect_info.host
+        port = connect_info.port
+        mks_auth = jsonutils.loads(connect_info.internal_access_path)
+        ticket = mks_auth['ticket']
+        cfg_file = mks_auth['cfgFile']
+        thumbprint = mks_auth['thumbprint']
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((host, port))
+        cls.expect(sock, cls.VMAD_WELCOME)
+        sock = ssl.wrap_socket(sock)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        cert = sock.getpeercert(binary_form=True) or bytes()
+        h = hashlib.sha1()
+        h.update(cert)
+        if thumbprint != h.hexdigest():
+            raise exception.ValidationError("Server thumbprint doesn't match")
+        sock.sendall(
+            ("%s %s\r\n" % (cls.VMAD_USER_CMD, ticket)).encode('ascii'))
+        cls.expect(sock, cls.VMAD_NEEDPASSWD)
+        sock.sendall(
+            ("%s %s\r\n" % (cls.VMAD_PASS_CMD, ticket)).encode('ascii'))
+        cls.expect(sock, cls.VMAD_LOGINOK)
+        rand = os.urandom(12)
+        rand_b = base64.b64encode(rand)
+        rand_s = rand_b.decode('ascii')
+        sock.sendall(
+            ("%s %s\r\n" % (cls.VMAD_THUMB_CMD, rand_s)).encode('ascii'))
+        thumbprint2 = cls.expect(sock, cls.VMAD_OK)
+        thumbprint2 = thumbprint2.replace(':', '').lower()
+        sock.sendall(
+            ("%s %s mks\r\n" % (cls.VMAD_CONNECT_CMD, cfg_file))
+            .encode('ascii'))
+        cls.expect(sock, cls.VMAD_OK)
+        sock2 = ssl.wrap_socket(sock)
+        cert2 = sock2.getpeercert(binary_form=True) or bytes()
+        h = hashlib.sha1()
+        h.update(cert2)
+        if thumbprint2 != h.hexdigest():
+            raise exception.ValidationError("Second thumbprint doesn't match")
+        sock2.sendall(rand_b)
+        return sock2

--- a/nova/console/securityproxy/mks.py
+++ b/nova/console/securityproxy/mks.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2016 VMware Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import base64
+import hashlib
+import os
+import socket
+import ssl
+
+from nova.console.securityproxy import base
+from nova import exception
+
+
+class MksSecurityProxy(base.SecurityProxy):
+    VMAD_OK = 200
+    VMAD_WELCOME = 220
+    VMAD_LOGINOK = 230
+    VMAD_NEEDPASSWD = 331
+    VMAD_USER_CMD = "USER"
+    VMAD_PASS_CMD = "PASS"
+    VMAD_THUMB_CMD = "THUMBPRINT"
+    VMAD_CONNECT_CMD = "CONNECT"
+
+    def connect(self, tenant_sock, compute_sock):
+        mks_auth = tenant_sock.reqhandler.internal_access_path_data
+        ticket = mks_auth['ticket']
+        cfg_file = mks_auth['cfgFile']
+        thumbprint = mks_auth['thumbprint']
+
+        def expect(sock, code):
+            """Receive and extract the next message and raise if the reply
+               doesn't match the expected `code`.
+            """
+            line = sock.recv(1024).decode('ascii')
+            recv_code, msg = line.split()[0:2]
+            recv_code = int(recv_code)
+            if code != recv_code:
+                raise exception.ValidationError('Expected %d but received %d'
+                                                % (code, recv_code))
+            return msg
+
+        sock = compute_sock
+        expect(sock, self.VMAD_WELCOME)
+        sock = ssl.wrap_socket(sock)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        cert = sock.getpeercert(binary_form=True) or bytes()
+        h = hashlib.sha1()
+        h.update(cert)
+        if thumbprint != h.hexdigest():
+            raise exception.ValidationError("Server thumbprint doesn't match")
+        sock.sendall(
+            ("%s %s\r\n" % (self.VMAD_USER_CMD, ticket)).encode('ascii'))
+        expect(sock, self.VMAD_NEEDPASSWD)
+        sock.sendall(
+            ("%s %s\r\n" % (self.VMAD_PASS_CMD, ticket)).encode('ascii'))
+        expect(sock, self.VMAD_LOGINOK)
+        rand = os.urandom(12)
+        rand_b = base64.b64encode(rand)
+        rand_s = rand_b.decode('ascii')
+        sock.sendall(
+            ("%s %s\r\n" % (self.VMAD_THUMB_CMD, rand_s)).encode('ascii'))
+        thumbprint2 = expect(sock, self.VMAD_OK)
+        thumbprint2 = thumbprint2.replace(':', '').lower()
+        sock.sendall(
+            ("%s %s mks\r\n" % (self.VMAD_CONNECT_CMD, cfg_file))
+            .encode('ascii'))
+        expect(sock, self.VMAD_OK)
+        sock2 = ssl.wrap_socket(sock)
+        cert2 = sock2.getpeercert(binary_form=True) or bytes()
+        h = hashlib.sha1()
+        h.update(cert2)
+        if thumbprint2 != h.hexdigest():
+            raise exception.ValidationError("Second thumbprint doesn't match")
+        sock2.sendall(rand_b)
+        return sock2


### PR DESCRIPTION
Original code can be found at: https://opendev.org/x/nova-mksproxy

Integrate the code into nova as a builtin command.

Subclass `NovaProxyRequestHandler` for the `WebSocketProxy` by overriding just the handshake part. This made it necessary to refactor the handshake & connection code out of `new_websocket_client()` into a new `handshake_and_connect()` method in `NovaProxyRequestHandler`.
