### PR TITLE
Add more password generation options

### DIFF
--- a/nova/conf/base.py
+++ b/nova/conf/base.py
@@ -17,12 +17,51 @@
 
 from oslo_config import cfg
 
+_DEFAULT_PASSWORD_SYMBOLS = ['23456789',  # Removed: 0,1
+                             'ABCDEFGHJKLMNPQRSTUVWXYZ',   # Removed: I, O
+                             'abcdefghijkmnopqrstuvwxyz',  # Removed: l
+                            ]
+
 base_options = [
     cfg.IntOpt(
         'password_length',
         default=12,
         min=0,
         help='Length of generated instance admin passwords.'),
+    cfg.IntOpt(
+        'password_all_group_samples',
+        default=1,
+        min=0,
+        help='''
+How often should the symbols be sampled from all groups
+to ensure the presence of all of them
+* Zero: Purely random, so least predictable, but possibly not confirming to
+  some password policies
+* Any positive number: At least that many symbols will be from each of the
+  classes. By default: lower-case, upper-case and numbers.
+
+Interdependencies to other options:
+
+* If ``password_length`` is smaller than ``password_all_group_samples`` times
+  three (or more in case more groups are added to ``password_symbol_groups``),
+  then the password will be cut off after ``password_length``, thereby possibly
+  reducing the number of symbol classes in the generated password.
+'''),
+    cfg.MultiStrOpt(
+        'password_symbol_groups',
+        default=_DEFAULT_PASSWORD_SYMBOLS,
+        help='''
+List of symbols to use for passwords.
+Default avoids visually confusing characters. (~6 bits per symbol)
+
+The items in the list represents symbol groups, and from each of those groups
+at least ``password_all_group_samples`` symbols are taken randomly.
+
+Interdependencies to other options:
+See ``password_additional_symbols`` for the interaction of the three values
+``password_length``,  ``password_additional_symbols`` and
+``password_symbol_groups``
+'''),
     cfg.StrOpt(
         'instance_usage_audit_period',
         default='month',

--- a/nova/tests/unit/test_utils.py
+++ b/nova/tests/unit/test_utils.py
@@ -15,6 +15,7 @@
 import datetime
 import os
 import os.path
+import string
 import tempfile
 
 import eventlet
@@ -32,6 +33,7 @@ from oslo_utils import encodeutils
 from oslo_utils import fixture as utils_fixture
 from oslo_utils.secretutils import md5
 
+from nova.conf import base as conf_base
 from nova import context
 from nova import exception
 from nova.objects import base as obj_base
@@ -141,11 +143,40 @@ class GenericUtilsTestCase(test.NoDBTestCase):
 
     def test_generate_password(self):
         password = utils.generate_password()
-        self.assertTrue([c for c in password if c in '0123456789'])
-        self.assertTrue([c for c in password
-                         if c in 'abcdefghijklmnopqrstuvwxyz'])
-        self.assertTrue([c for c in password
-                         if c in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'])
+        for group in conf_base._DEFAULT_PASSWORD_SYMBOLS:
+            if group:
+                self.assertTrue([c for c in password if c in group])
+
+    @mock.patch.object(CONF, "password_all_group_samples", 0)
+    def test_generate_password_zero_groups(self):
+        password = utils.generate_password()
+        self.assertEqual(len(password), CONF.password_length)
+
+    @mock.patch.object(CONF, "password_all_group_samples", 2)
+    def test_generate_password_two_groups(self):
+        password = utils.generate_password()
+        self.assertEqual(len(password), CONF.password_length)
+        for group in conf_base._DEFAULT_PASSWORD_SYMBOLS:
+            if group:
+                self.assertGreaterEqual(
+                    len([c for c in password if c in group]),
+                    CONF.password_all_group_samples)
+
+    @mock.patch.object(CONF, "password_all_group_samples", 7)
+    @mock.patch.object(CONF, "password_length", 13)
+    def test_generate_password_too_many_groups(self):
+        password = utils.generate_password()
+        self.assertEqual(len(password), CONF.password_length)
+
+    @mock.patch.object(CONF, "password_symbol_groups", [string.ascii_lowercase,
+            string.ascii_uppercase, string.punctuation])
+    def test_generate_password_custom_groups(self):
+        password = utils.generate_password()
+        self.assertEqual(len(password), CONF.password_length)
+        self.assertGreaterEqual(
+            len([c for c in password if c in string.punctuation]),
+            CONF.password_all_group_samples)
+        self.assertFalse([c for c in password if c in string.digits])
 
     @mock.patch('nova.privsep.path.chown')
     def test_temporary_chown(self, mock_chown):

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -116,13 +116,6 @@ def generate_random_string(size=8):
     return ''.join([random.choice(characters) for _x in range(size)])
 
 
-# Default symbols to use for passwords. Avoids visually confusing characters.
-# ~6 bits per symbol
-DEFAULT_PASSWORD_SYMBOLS = ('23456789',  # Removed: 0,1
-                            'ABCDEFGHJKLMNPQRSTUVWXYZ',   # Removed: I, O
-                            'abcdefghijkmnopqrstuvwxyz')  # Removed: l
-
-
 def last_completed_audit_period(unit=None, before=None):
     """This method gives you the most recently *completed* audit period.
 
@@ -213,7 +206,7 @@ def last_completed_audit_period(unit=None, before=None):
     return (begin, end)
 
 
-def generate_password(length=None, symbolgroups=DEFAULT_PASSWORD_SYMBOLS):
+def generate_password(length=None, symbolgroups=None):
     """Generate a random password from the supplied symbol groups.
 
     At least one symbol from each group will be included. Unpredictable
@@ -225,12 +218,19 @@ def generate_password(length=None, symbolgroups=DEFAULT_PASSWORD_SYMBOLS):
     if length is None:
         length = CONF.password_length
 
+    if symbolgroups is None:
+        symbolgroups = CONF.password_symbol_groups
+
     r = random.SystemRandom()
 
     # NOTE(jerdfelt): Some password policies require at least one character
     # from each group of symbols, so start off with one random character
     # from each symbol group
-    password = [r.choice(s) for s in symbolgroups]
+    # NOTE(fwiesel): And some policies require even more of them, so
+    # do it as often as configured in DEFAULT.password_all_group_samples
+    password = [r.choice(s)
+                for s in symbolgroups * CONF.password_all_group_samples
+                if s]
     # If length < len(symbolgroups), the leading characters will only
     # be from the first length groups. Try our best to not be predictable
     # by shuffling and then truncating.


### PR DESCRIPTION
Some password policies require more than one occurence of symbols of one kind, or make restrictions about their occurence effectively requiring them to occure more often.

By providing the configuration value 'password_all_group_samples' the administrator can increase the rounds to sample from all groups to adhere to such policies

Often, password policies require not only ascii letters (upper/lower-case) and numbers, but also other printable characters in the password as a fourth symbol group.

By makeing the symbol-classes the multi-string list 'password_symbol_groups', the administrator can add those and also override the other classes, if desired.

Change-Id: I5b995883a41f65296de86f3effa0102ecb12c1fa