### PR TITLE
mks-proxy: Add compat --verbose flag

### DIFF
--- a/nova/conf/mks.py
+++ b/nova/conf/mks.py
@@ -57,7 +57,8 @@ mks_cli_opts = [
                help='MKS web location, takes precedence over --web'),
     cfg.IPOpt('host', default='0.0.0.0', help='MKS proxy host'),
     cfg.PortOpt('port', default=6090, help='MKS proxy port'),
-    cfg.BoolOpt('verbose', default=False, help='Verbose logging'),
+    cfg.BoolOpt('verbose', default=False, help='Verbose logging',
+                deprecated_name='verbose'),
 ]
 
 


### PR DESCRIPTION
The old script had a `--verbose` flag that we are using in the k8s deployment definition for all regions. This will include both Xena and older Rocky deployments. The new name of this flag is `--mks-verbose`.

I had previously thought that there still was a global `--verbose` flag I could use, but there was not. This failed the deployment because of the invalid usage of `--verbose`.

Instead of adding an image version check in the helm-chart, create this compatibility flag instead for the duration of the update, and revert this after the Xena upgrade is through everywhere.
