### PR TITLE
vmware: Fix update_cluster_das_vm_override

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -411,7 +411,7 @@ def update_cluster_das_vm_override(session, cluster, vm_ref, operation='add',
 
     client_factory = session.vim.client.factory
 
-    das_vm_spec = client_factory.create('ns0:ClusterDasVmConfigInfo')
+    das_vm_spec = client_factory.create('ns0:ClusterDasVmConfigSpec')
     das_vm_spec.operation = operation
 
     if operation == 'add':


### PR DESCRIPTION
Introduced in 'vmware: Restart BigVMs with "high" priority', the function "update_cluster_das_vm_override()" did not work, because it created a "ClusterDasVmConfigInfo" instead of a "ClusterDasVmConfigSpec" object. This lead to us not being able to spawn BigVMs with the following error:

    Exception in ReconfigureComputeResource_Task.
    Cause: Type not found: 'operation'

Change-Id: If9acf9ee07e373b7b24c14c642d0d99fe2a41db1