### PR TITLE
vmware: Fix missing image_cache conf group usage

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -3633,7 +3633,8 @@ class VMwareVMOps(object):
 
                 vm_moref_value = vutil.get_moref_value(obj.obj)
                 if not timeutils.is_older_than(vm_props['config.createDate'],
-                        CONF.remove_unused_original_minimum_age_seconds):
+                        CONF.image_cache.
+                            remove_unused_original_minimum_age_seconds):
                     expired_templ_vms.pop(vm_moref_value)
                     continue
 


### PR DESCRIPTION
`remove_unused_original_minimum_age_seconds` along with several other config options related to image cache management were moved to their own config group `image_cache` in Ussuri (nova 21), but the cherry-pick in

    9de18bd "vmware: Update expired image-template-VM handling"

failed to account for this.
