### PR TITLE
vmware: Fix double restartPriority override

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1075,10 +1075,8 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'get_vm_ref',
                        return_value=mock.sentinel.vm_ref)
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
-    @mock.patch.object(cluster_util, 'update_cluster_das_vm_override')
-    def test_resize_vm_bigvm_upsize(self, fake_das_override, fake_drs_override,
-                                    fake_get_vm_ref, fake_resize_spec,
-                                    fake_reconfigure,
+    def test_resize_vm_bigvm_upsize(self, fake_drs_override, fake_get_vm_ref,
+                                    fake_resize_spec, fake_reconfigure,
                                     fake_cleanup_after_special_spawning,
                                     fake_get_extra_specs, fake_get_metadata):
         vm_ref = fake_get_vm_ref.return_value
@@ -1098,12 +1096,6 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                   vm_ref,
                                                   operation='add',
                                                   behavior=behavior)
-        priority = constants.DAS_RESTART_PRIORITY_HIGH
-        fake_das_override.assert_called_once_with(self._session,
-                                                  self._cluster.obj,
-                                                  vm_ref,
-                                                  operation='add',
-                                                  restart_priority=priority)
         expected = (self._context, int(flavor.memory_mb), flavor)
         fake_cleanup_after_special_spawning.assert_called_once_with(*expected)
 
@@ -1116,9 +1108,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'get_vm_ref',
                        return_value=mock.sentinel.vm_ref)
     @mock.patch.object(cluster_util, 'update_cluster_drs_vm_override')
-    @mock.patch.object(cluster_util, 'update_cluster_das_vm_override')
-    def test_resize_vm_bigvm_downsize(self, fake_das_override,
-                                      fake_drs_override, fake_get_vm_ref,
+    def test_resize_vm_bigvm_downsize(self, fake_drs_override, fake_get_vm_ref,
                                       fake_resize_spec, fake_reconfigure,
                                       fake_cleanup_after_special_spawning,
                                       fake_get_extra_specs, fake_get_metadata):
@@ -1135,10 +1125,6 @@ class VMwareVMOpsTestCase(test.TestCase):
         instance.old_flavor.memory_mb = CONF.bigvm_mb
         self._vmops._resize_vm(self._context, instance, vm_ref, flavor, None)
         fake_drs_override.assert_called_once_with(self._session,
-                                                  self._cluster.obj,
-                                                  vm_ref,
-                                                  operation='remove')
-        fake_das_override.assert_called_once_with(self._session,
                                                   self._cluster.obj,
                                                   vm_ref,
                                                   operation='remove')

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2269,13 +2269,6 @@ class VMwareVMOps(object):
                                                         vm_ref,
                                                         operation='add',
                                                         behavior=behavior)
-            # Make sure BigVMs get restarted first
-            restart_priority = constants.DAS_RESTART_PRIORITY_HIGH
-            LOG.debug("Adding restart priority override '%s' for big VM.",
-                      restart_priority, instance=instance)
-            cluster_util.update_cluster_das_vm_override(
-                self._session, self._cluster, vm_ref, operation='add',
-                restart_priority=restart_priority)
         elif old_needs_override and not new_needs_override:
             # remove the old overrides, if we had one before. make sure we
             # don't error out if they were already deleted another way
@@ -2288,14 +2281,6 @@ class VMwareVMOps(object):
                                                             operation='remove')
             except Exception:
                 LOG.warning('Could not remove DRS override.',
-                            instance=instance)
-            try:
-                cluster_util.update_cluster_das_vm_override(self._session,
-                                                            self._cluster,
-                                                            vm_ref,
-                                                            operation='remove')
-            except Exception:
-                LOG.warning('Could not remove DAS override.',
                             instance=instance)
         self._clean_up_after_special_spawning(context, flavor.memory_mb,
                                               flavor)


### PR DESCRIPTION
Adding an override for restartPriority when one alrady exists is an error in the VMware API. We do the override twice when running `finish_migration()` during resize toward HANA flavors, once in `_resize()` and once again explicitly. Remove the explicit `set_restart_priority_if_needed()` call.

Fixes f157f63707 'vmware: Restart BigVMs with "high" priority'.
