### PR TITLE
limits: Fix per-flavor limit API value type

### DIFF
--- a/nova/api/openstack/compute/views/limits.py
+++ b/nova/api/openstack/compute/views/limits.py
@@ -99,6 +99,9 @@ class ViewBuilder(object):
         for name, value in quotas.items():
             if name.startswith('instances_'):
                 flavorname = name[10:]
-                limits[flavorname] = {'maxTotalInstances': value}
+                limits[flavorname] = {
+                    'maxTotalInstances': value['limit'],
+                    'totalInstancesUsed': value['in_use'],
+                }
 
         return limits


### PR DESCRIPTION
In

daeeafd "baremetal quota handling"

the `_build_per_flavor_limits()` method is incorrectly rewritten to match surrounding code, esp. `_build_absolute_limits()`, and uses not only the limit, but limit and in_use as value for the resulting limit dict.

The original commit,

16857ed "reintroduce baremetal quota handling"

used `absolute_limits` directly as method parameter.
