### PR TITLE
[vmwareapi] Look up vmdk volume by uuid directly first

### DIFF
--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -541,10 +541,16 @@ class VMwareVolumeOps(object):
     def _get_vmdk_backed_disk_device(self, vm_ref, connection_info_data):
         # Get the vmdk file name that the VM is pointing to
         hardware_devices = vm_util.get_hardware_devices(self._session, vm_ref)
+        volume_uuid = connection_info_data['volume_id']
 
-        # Get disk uuid
-        disk_uuid = self._get_volume_uuid(vm_ref,
-                                          connection_info_data['volume_id'])
+        # Try first the direct mapping
+        device = vm_util.get_vmdk_backed_disk_device(hardware_devices,
+                                                     volume_uuid)
+        if device:
+            return device
+
+        # Fall back to the indirect mapping
+        disk_uuid = self._get_volume_uuid(vm_ref, volume_uuid)
         device = vm_util.get_vmdk_backed_disk_device(hardware_devices,
                                                      disk_uuid)
         if not device:


### PR DESCRIPTION
For historic reasons, there is a mapping between
the volume-uuid and the device[].backing.uuid in vmware through extraConfig.
In most cases they are the same, but sometimes they are not.
And apparently, the extraProperties can even hold
wrong information.

Since the risk of a collision of uuids is quite low, and lookup is the iteration over a small list of volumes we first try it that way, avoiding possibly incorrect information in the extraConfig.
Failing that, we still do the additional api call
to get the mapping, and try that.

Change-Id: Ifcdf96cfc6d00473299c1f2a7cb9d23d03294027