### PR TITLE
[ironic] IPA imports VMDKs via qemu-img just fine

### DIFF
--- a/nova/virt/ironic/driver.py
+++ b/nova/virt/ironic/driver.py
@@ -175,7 +175,7 @@ class IronicDriver(virt_driver.ComputeDriver):
         "supports_image_type_vdi": False,
         "supports_image_type_vhd": False,
         "supports_image_type_vhdx": False,
-        "supports_image_type_vmdk": False,
+        "supports_image_type_vmdk": True,
         "supports_image_type_ploop": False,
     }
 


### PR DESCRIPTION
The ironic-python-agent uses qemu-img to convert
various image formats to the raw disk format.
QCow2 is already correctly marked accordingly,
but vmdk was missing

Change-Id: Ifd868e6951452b291184bd848d4244d37649f1ed