### PR TITLE
vmware: Fix AttrError when setting restart-priority

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -416,7 +416,9 @@ def update_cluster_das_vm_override(session, cluster, vm_ref, operation='add',
     if operation == 'add':
         das_vm_info = client_factory.create('ns0:ClusterDasVmConfigInfo')
         das_vm_info.key = vm_ref
-        das_vm_info.dasSettings.restartPriority = restart_priority
+        settings = client_factory.create('ns0:ClusterDasVmSettings')
+        settings.restartPriority = restart_priority
+        das_vm_info.dasSettings = settings
 
         das_vm_spec.info = das_vm_info
 


### PR DESCRIPTION
Nested `ClusterDasVmSettings` inside new `ClusterDasVmConfigInfo` objects don't get created properly. This seems to have worked on Rocky but fails on Xena.
