### PR TITLE
K8s shard affinity

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -1733,6 +1733,15 @@ class ComputeManager(manager.Manager):
 
         _do_validation(context, instance, group)
 
+    def _validate_driver_instance_group_policy(self, context, instance):
+        lock_id = "driver-instance-group-validation-%s" % instance.uuid
+
+        @utils.synchronized(lock_id)
+        def _do_validation(context, instance):
+            self.driver.validate_instance_group_policy(context, instance)
+
+        _do_validation(context, instance)
+
     def _log_original_error(self, exc_info, instance_uuid):
         LOG.error('Error: %s', exc_info[1], instance_uuid=instance_uuid,
                   exc_info=exc_info)
@@ -2407,6 +2416,8 @@ class ComputeManager(manager.Manager):
                 # the host is set on the instance.
                 self._validate_instance_group_policy(context, instance,
                                                      scheduler_hints)
+                self._validate_driver_instance_group_policy(context,
+                                                            instance)
                 image_meta = objects.ImageMeta.from_dict(image)
 
                 with self._build_resources(context, instance,

--- a/nova/db/main/api.py
+++ b/nova/db/main/api.py
@@ -2159,6 +2159,11 @@ def _handle_k8s_hosts_query_filters(query, filters=None):
         query = query.filter(
             models.Instance.availability_zone == availability_zone)
 
+    skip_instance_uuid = filters.get('skip_instance_uuid')
+    if skip_instance_uuid:
+        query.filter(
+            models.Instance.uuid != skip_instance_uuid)
+
     return query
 
 

--- a/nova/objects/compute_node.py
+++ b/nova/objects/compute_node.py
@@ -506,6 +506,17 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
         return base.obj_make_list(context, cls(context), objects.ComputeNode,
                                   db_computes)
 
+    @base.remotable_classmethod
+    def get_k8s_hosts_by_instances_metadata(cls, context, meta_key, meta_value,
+                                            filters=None):
+        return db.get_k8s_hosts_by_instances_metadata(
+            context, meta_key, meta_value, filters=filters)
+
+    @base.remotable_classmethod
+    def get_k8s_hosts_by_instances_tag(cls, context, tag, filters=None):
+        return db.get_k8s_hosts_by_instances_tag(
+            context, tag, filters=filters)
+
 
 def _get_node_empty_ratio(context, max_count):
     """Query the DB for non-deleted compute_nodes with 0.0/None alloc ratios

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1055,7 +1055,7 @@ object_data = {
     'CellMapping': '1.1-5d652928000a5bc369d79d5bde7e497d',
     'CellMappingList': '1.1-496ef79bb2ab41041fff8bcb57996352',
     'ComputeNode': '1.19-af6bd29a6c3b225da436a0d8487096f2',
-    'ComputeNodeList': '1.17-52f3b0962b1c86b98590144463ebb192',
+    'ComputeNodeList': '1.17-bb54e3fd5415be274c5515577acafe3d',
     'ConsoleAuthToken': '1.1-8da320fb065080eb4d3c2e5c59f8bf52',
     'CpuDiagnostics': '1.0-d256f2e442d1b837735fd17dfe8e3d47',
     'Destination': '1.4-3b440d29459e2c98987ad5b25ad1cb2c',

--- a/nova/tests/unit/scheduler/filters/test_shard_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_shard_filter.py
@@ -16,7 +16,6 @@ import time
 
 import mock
 
-from nova.db.main import api as main_db_api
 from nova import objects
 from nova.scheduler.filters import shard_filter
 from nova import test
@@ -84,6 +83,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs'],
                 extra_specs=extra_specs))
@@ -102,6 +102,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='bar',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
         self._assert_passes(host, spec_obj, False)
@@ -116,6 +117,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
 
@@ -130,6 +132,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
 
@@ -144,6 +147,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
 
@@ -158,6 +162,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
 
@@ -172,6 +177,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
 
@@ -186,6 +192,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
 
@@ -205,6 +212,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']),
             scheduler_hints=dict(_nova_check_type=['resize'],
@@ -227,6 +235,7 @@ class TestShardFilter(test.NoDBTestCase):
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']),
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             scheduler_hints=dict(_nova_check_type=['resize'],
                                  source_host=['host2']))
 
@@ -245,6 +254,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='baz',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
         self._assert_passes(host, spec_obj, True)
@@ -261,6 +271,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='baz',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
         self._assert_passes(host, spec_obj, True)
@@ -287,7 +298,7 @@ class TestShardFilter(test.NoDBTestCase):
 
         gather_host.assert_called_once_with(
             get_context.return_value,
-            main_db_api.get_k8s_hosts_by_instances_tag,
+            objects.ComputeNodeList.get_k8s_hosts_by_instances_tag,
             'kubernikus:kluster-example',
             filters={'hv_type': 'VMware vCenter Server',
                      'availability_zone': 'az-2'})
@@ -321,7 +332,7 @@ class TestShardFilter(test.NoDBTestCase):
 
         gather_host.assert_called_once_with(
             get_context.return_value,
-            main_db_api.get_k8s_hosts_by_instances_metadata,
+            objects.ComputeNodeList.get_k8s_hosts_by_instances_metadata,
             gardener_cluster, '1',
             filters={'hv_type': 'VMware vCenter Server',
                      'availability_zone': 'az-2'})
@@ -351,7 +362,7 @@ class TestShardFilter(test.NoDBTestCase):
 
         gather_host.assert_called_once_with(
             get_context.return_value,
-            main_db_api.get_k8s_hosts_by_instances_metadata,
+            objects.ComputeNodeList.get_k8s_hosts_by_instances_metadata,
             gardener_cluster, '1',
             filters={'hv_type': 'VMware vCenter Server',
                      'availability_zone': 'az-2'})
@@ -467,6 +478,7 @@ class TestShardFilter(test.NoDBTestCase):
         spec_obj = objects.RequestSpec(
             context=mock.sentinel.ctx, project_id='foo',
             instance_uuid=self.fake_build_req.instance_uuid,
+            availability_zone=None,
             flavor=fake_flavor.fake_flavor_obj(
                 mock.sentinel.ctx, expected_attrs=['extra_specs']))
 

--- a/nova/virt/driver.py
+++ b/nova/virt/driver.py
@@ -1807,6 +1807,14 @@ class ComputeDriver(object):
         """
         raise NotImplementedError()
 
+    def validate_instance_group_policy(self, context, instance):
+        """Validates that the instance meets driver-specific grouping policy
+
+        The driver can raise exception.RescheduledException to reject and
+        trigger rescheduling of the instance to a different host.
+        """
+        pass
+
 
 def load_compute_driver(virtapi, compute_driver=None):
     """Load a compute driver module.

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -1319,3 +1319,6 @@ class VMwareVCDriver(driver.ComputeDriver):
                   vim_util.get_moref_value(current_host_ref),
                   vim_util.get_moref_value(host_ref),
                   instance=instance)
+
+    def validate_instance_group_policy(self, context, instance):
+        self._vmops._check_k8s_shard(instance)

--- a/nova/virt/vmwareapi/shard_util.py
+++ b/nova/virt/vmwareapi/shard_util.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2023 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from collections import defaultdict
+
+from nova import context as nova_context
+from nova import exception
+from nova.objects.aggregate import AggregateList
+from nova.objects.compute_node import ComputeNodeList
+
+GARDENER_PREFIX = "kubernetes.io-cluster-"
+KKS_PREFIX = "kubernikus:kluster"
+VMWARE_HV_TYPE = 'VMware vCenter Server'
+SHARD_PREFIX = 'vc-'
+
+
+def get_sorted_k8s_shard_aggregates(context, metadata, tags, availability_zone,
+                                    skip_instance_uuid=None):
+    """Returns the shards of a K8S cluster sorted by the instances count.
+
+    The K8S cluster is determined by Instance's metadata or tags.
+    Returns None if the cluster is new (first instance is being spawned there)
+    or if the K8S metadata/tags are not set.
+    """
+    kks_tag = None
+    gardener_meta = None
+    no_ret = None
+    if tags:
+        kks_tag = next((t.tag for t in tags
+                        if t.tag.startswith(KKS_PREFIX)), None)
+    if not kks_tag and metadata:
+        gardener_meta = \
+            {k: v for k, v in metadata.items()
+             if k.startswith(GARDENER_PREFIX)}
+
+    if not kks_tag and not gardener_meta:
+        return no_ret
+
+    q_filters = {'hv_type': VMWARE_HV_TYPE}
+    if availability_zone:
+        q_filters['availability_zone'] = availability_zone
+    if skip_instance_uuid:
+        q_filters['skip_instance_uuid'] = skip_instance_uuid
+
+    results = None
+    if kks_tag:
+        results = nova_context.scatter_gather_skip_cell0(
+            context, ComputeNodeList.get_k8s_hosts_by_instances_tag,
+            kks_tag, filters=q_filters)
+    elif gardener_meta:
+        (meta_key, meta_value) = next(iter(gardener_meta.items()))
+        results = nova_context.scatter_gather_skip_cell0(
+            context, ComputeNodeList.get_k8s_hosts_by_instances_metadata,
+            meta_key, meta_value, filters=q_filters)
+
+    if not results:
+        return no_ret
+
+    # hosts with count of instances from this K8S cluster
+    # {host: <count>}
+    k8s_hosts = defaultdict(lambda: 0)
+
+    for cell_uuid, cell_result in results.items():
+        if nova_context.is_cell_failure_sentinel(cell_result):
+            raise exception.NovaException(
+                "Unable to schedule the K8S instance because "
+                "cell %s is not responding." % cell_uuid)
+        cell_hosts = dict(cell_result)
+        for h, c in cell_hosts.items():
+            k8s_hosts[h] += c
+
+    if not k8s_hosts:
+        return no_ret
+
+    all_shard_aggrs = [agg for agg in AggregateList.get_all(context)
+                       if agg.name.startswith(SHARD_PREFIX)]
+
+    return sorted(
+        all_shard_aggrs,
+        reverse=True,
+        key=lambda aggr: sum(i for h, i in k8s_hosts.items()
+                             if h in aggr.hosts))


### PR DESCRIPTION
Instances created by K8S orchestrators (Kubernikus or Gardener) which are part of the same K8S cluster should be scheduled in the same shard, because Kubernetes is heavily using volumes and we want to avoid slow attachments due to cross-shard migration of volumes.

(check also the commit message)