### PR TITLE
Vmware: Consolidate getting properties for instances

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -758,7 +758,7 @@ class VMwareVCDriver(driver.ComputeDriver):
 
     def get_info(self, instance, use_cache=True):
         """Return info about the VM instance."""
-        return self._vmops.get_info(instance)
+        return self._vmops.get_info(instance, use_cache=use_cache)
 
     def get_diagnostics(self, instance):
         """Return data about VM diagnostics."""


### PR DESCRIPTION
Each caller to get properties for an instance goes through either _get_instance_props or _get_instance_properties That ensures, that everywhere the ManagedObjectNotFound exception is handled and raising an InstanceNotFound instead, which is understood by the compute manager

Change-Id: If5c62a7257eab99ea7f4ed5638261948aed85455