### PR TITLE
Fix BigVM xena issues

### DIFF
--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -122,7 +122,7 @@ class BigVmManager(manager.Manager):
         candidates = {}
         for hv_size in set(_flatten(missing_hv_sizes_per_vc.values())):
             resources = ResourceRequest()
-            resources._add_resource(None, MEMORY_MB, hv_size)
+            resources._add_resource(MEMORY_MB, hv_size)
             res = client.get_allocation_candidates(context, resources)
             if res is None:
                 continue

--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -384,7 +384,7 @@ class BigVmManager(manager.Manager):
 
                 # retrieve traits so we can find disabled and hana exclusive
                 # hosts
-                traits = client._get_provider_traits(context, rp['uuid'])
+                traits = client.get_provider_traits(context, rp['uuid'])
                 vmware_providers[rp['uuid']] = {
                     'hv_size': hv_size,
                     'host': host,

--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -403,7 +403,7 @@ class BigVmManager(manager.Manager):
         # retrieve all bigvm provider's inventories
         for rp_uuid, rp in bigvm_providers.items():
             inventory = client._get_inventory(context, rp_uuid)
-            rp['inventory'] = inventory['inventories']
+            rp['inventory'] = inventory['inventories'] if inventory else {}
 
         # make sure grouping by hv_size works properly later on, even if there
         # are marginal differences in the reported hv_size. we need to have all

--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -699,9 +699,7 @@ class BigVmManager(manager.Manager):
             context, rp_uuid, rp['rp']['name'])
         try:
             client.set_inventory_for_provider(context, rp_uuid, inv_data)
-        except (exception.ResourceProviderUpdateConflict,
-                exception.ResourceProviderUpdateFailed,
-                exception.InventoryInUse) as err:
+        except Exception as err:
             LOG.error('Adding inventory to the resource-provider for '
                       'spawning on %(host)s failed: %(err)s',
                       {'host': rp['host'], 'err': err})

--- a/nova/objects/compute_node.py
+++ b/nova/objects/compute_node.py
@@ -496,7 +496,8 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     @db.select_db_reader_mode
     def _db_compute_node_get_by_hv_type(context, hv_type):
         db_computes = context.session.query(models.ComputeNode).filter(
-            models.ComputeNode.hypervisor_type == hv_type).all()
+            models.ComputeNode.hypervisor_type == hv_type,
+            models.ComputeNode.deleted == 0).all()
         return db_computes
 
     @classmethod


### PR DESCRIPTION
- bigvm: Fix ResourceRequest._add_resource() usage
- bigvm/ComputeNodeList: Only get non-deleted nodes
- bigvm: Use public SchedulerReportClient.get_provider_traits
- bigvm: Catch possible KeyError from get_inventory
- bigvm: Replace removed _update_inventory() call
