### PR TITLE
vmware-monitor: remove _LE from forward port

### DIFF
--- a/nova/compute/monitors/compute_node/vmware_monitor.py
+++ b/nova/compute/monitors/compute_node/vmware_monitor.py
@@ -17,7 +17,6 @@ from oslo_utils import timeutils
 from nova.compute.monitors import base
 import nova.conf
 from nova import exception
-from nova.i18n import _LE
 from nova import objects
 
 CONF = nova.conf.CONF
@@ -63,7 +62,7 @@ class Monitor(base.VmwareMonitorBase):
             LOG.info("Cluster metrics: %s", self._data)
 
         except (NotImplementedError, TypeError, KeyError):
-            LOG.exception(_LE("Not all properties needed are implemented "
-                              "in the compute driver"))
+            LOG.exception("Not all properties needed are implemented "
+                          "in the compute driver")
             raise exception.ResourceMonitorError(
                 monitor=self.__class__.__name__)


### PR DESCRIPTION
Removed in
    eee57f2380 trivial: Remove remaining '_LE' instances

Change-Id: Iea5356d42934f855449d300654771792d07a41fb
