### PR TITLE
Fix _cleanup_after_special_spawning()

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1533,8 +1533,7 @@ class VMwareVMOps(object):
                 inv_data = rp.inventory
                 inv_data[special_spawning.BIGVM_RESOURCE]['reserved'] = 1
                 placement_client.set_inventory_for_provider(context,
-                                        rp.uuid, rp_name, inv_data,
-                                        parent_provider_uuid=parent_rp_uuid)
+                                        rp.uuid, rp_name, inv_data)
 
     def _is_bdm_valid(self, block_device_mapping):
         """Checks if the block device mapping is valid."""


### PR DESCRIPTION
With moving to Xena, we overlooked a change in
`SchedulerReportClient.set_inventory_for_provider()` which removed the `parent_provider_uuid` argument to the function. Therefore, any call to this function fails and big VMs cannot spawn anymore in regions having nova-bigvm enabled.

Change-Id: I43fe1c4dc40caf5781457a0d4de83c6cb53ebc8f