### PR TITLE
bigvm: Fix allocations dict access during cleanup

### DIFF
--- a/nova/bigvm/manager.py
+++ b/nova/bigvm/manager.py
@@ -591,8 +591,8 @@ class BigVmManager(manager.Manager):
         client = self.placement_client
 
         # find the consumer
-        allocations = client.get_allocations_for_resource_provider(context,
-                                                                   rp_uuid)
+        allocations = client.get_allocations_for_resource_provider(
+                                                context, rp_uuid).allocations
         # we might have already deleted them and got killed or the VM got
         # deleted in the mean time
         failures = 0


### PR DESCRIPTION
In
      f534495 Make get_allocations_for_resource_provider raise

`get_allocations_for_resource_provider()` was changed to return a named
tuple with one key "allocations" instead of a dict directly. Unpack
this before iterating over the allocations during cleanup of consumed
providers in the bigvm manager.

Change-Id: I71f0324395e0135d8facdbf45c74c9682093104d
