### PR TITLE
bigvm: Fix call to set_inventory_for_provider()

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1532,8 +1532,8 @@ class VMwareVMOps(object):
                 # deployment needing a free host on that compute-node.
                 inv_data = rp.inventory
                 inv_data[special_spawning.BIGVM_RESOURCE]['reserved'] = 1
-                placement_client.set_inventory_for_provider(context,
-                                        rp.uuid, rp_name, inv_data)
+                placement_client.set_inventory_for_provider(context, rp.uuid,
+                                                            inv_data)
 
     def _is_bdm_valid(self, block_device_mapping):
         """Checks if the block device mapping is valid."""


### PR DESCRIPTION
The method was refactored and doesn't take resource provider name anymore.

Change-Id: I840e5d671c3df24cd01952b522288982ddfde80e
