### PR TITLE
vmware: Optionally limit max_unit for DISK_GB resource

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -489,6 +489,23 @@ that are stored in Swift will be downloaded by VMWare from the `direct_url`,
 instead of the nova-compute service having to proxy the image between glance
 and VMware.
 """),
+    cfg.IntOpt('resource_disk_gb_max_unit_limit',
+               min=-1,
+               default=-1,
+               help="""
+Limit reporting DISK_GB "max_unit" to Placement to this value
+
+A VMware hypervisor managing multiple datastores reports "max_unit" for DISK_GB
+as the most free space on any of these datastores. Since this can lead to a lot
+of changes in Placement with VMs spawning and getting deleted, users can limit
+the reported "max_unit" value with this config option.
+
+Possible values:
+ * integer > 0: limit of the "max_unit" for DISK_GB in GB
+ * integer = 0: disable reporting DISK_GB resources i.e. disallow non-volume
+                root disks
+ * integer = -1: no limit
+"""),
 ]
 
 ALL_VMWARE_OPTS = (vmwareapi_vif_opts +

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -549,6 +549,9 @@ class VMwareVCDriver(driver.ComputeDriver):
 
         local_gb = stats["local_gb"]
         local_gb_max_free = stats.get("local_gb_max_free", "local_gb")
+        local_gb_max_unit_limit = CONF.vmware.resource_disk_gb_max_unit_limit
+        if local_gb_max_unit_limit != -1:
+            local_gb_max_free = min(local_gb_max_free, local_gb_max_unit_limit)
         if local_gb > 0 and local_gb_max_free > 0:
             reserved_disk_gb = compute_utils.convert_mb_to_ceil_gb(
                 CONF.reserved_host_disk_mb)


### PR DESCRIPTION
Since the VMware driver manages multiple datastores in its cluster, it reports the DISK_GB resource "total" as the sum of free space of all of these datastores. The "max_unit" for DISK_GB is computed as the maximum of free space on any of these datastores.

Since the free space on the datastores changes every time a VM gets deployed and deleted and when sDRS moves a disk from one datastore to another, there are a lot of updates happening against Placement - some of which failing, as they are happening in parallel during updating the resource when deleting VMs in parallel.

We try to work around this problem by reducing the necessary updates through limiting the reported "max_unit" to a static value. The limit can be set via config option "resource_disk_gb_max_unit_limit", which is by default turned off. An operator should set the value to the maximum of root-disk they allow(ed) in any of their flavors to make sure VMs can still target the hypervisor.

Change-Id: I27ca9285b8d52afd0f1ca2a413dbf8c01e4db0b1