### PR TITLE
bigvm: Refresh RP inventory after spawning

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1528,6 +1528,10 @@ class VMwareVMOps(object):
                             'reserving resources after (re)starting a big VM.',
                             {'rp': rp_name})
             else:
+                # we need to update the inventory of the bigvm provider in our
+                # cache, because the generation might be too old after the
+                # allocations of our currently spawning big vm
+                placement_client._refresh_and_get_inventory(context, rp.uuid)
                 # reserve the bigvm resource. this prohibits any further
                 # deployment needing a free host on that compute-node.
                 inv_data = rp.inventory


### PR DESCRIPTION
We encountered inventory generation conflicts during bigvm spawning, and now do an additional inventory refresh after completing initial spawning.

Change-Id: I65c2be9781b60e31d9a6c6dd84a02c7fe4aa1e72
