### PR TITLE
vmware: Fix rescue for efi-booted VMs

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -1973,11 +1973,17 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         mock_reconfigure.assert_called_once_with(session, 'fake-ref', mock.ANY)
 
     def test_get_vm_boot_spec(self):
+        self._test_get_vm_boot_spec(efi=False)
+
+    def test_get_vm_boot_spec_efi(self):
+        self._test_get_vm_boot_spec(efi=True)
+
+    def _test_get_vm_boot_spec(self, efi):
         disk = fake.VirtualDisk()
         disk.key = 7
         fake_factory = fake.FakeFactory()
         result = vm_util.get_vm_boot_spec(fake_factory,
-                                          disk)
+                                          disk, efi)
         expected = fake_factory.create('ns0:VirtualMachineConfigSpec')
         boot_disk = fake_factory.create(
             'ns0:VirtualMachineBootOptionsBootableDiskDevice')
@@ -1985,6 +1991,12 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         boot_options = fake_factory.create('ns0:VirtualMachineBootOptions')
         boot_options.bootOrder = [boot_disk]
         expected.bootOptions = boot_options
+
+        if efi:
+            opt = fake_factory.create('ns0:OptionValue')
+            opt.key = 'efi.quickBoot.enabled'
+            opt.value = 'FALSE'
+            expected.extraConfig = [opt]
         self.assertEqual(expected, result)
 
     def _get_devices(self, filename):

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -416,6 +416,12 @@ class VMwareVMOpsTestCase(test.TestCase):
     def test_get_datacenter_ref_and_name_with_no_datastore(self):
         self._test_get_datacenter_ref_and_name()
 
+    def test_rescue(self):
+        self._test_rescue()
+
+    def test_rescue_efi(self):
+        self._test_rescue(efi=True)
+
     @mock.patch('nova.image.glance.API.get')
     @mock.patch.object(vm_util, 'power_off_instance')
     @mock.patch.object(ds_util, 'disk_copy')
@@ -429,13 +435,13 @@ class VMwareVMOpsTestCase(test.TestCase):
                        return_value=None)
     @mock.patch.object(vmops.VMwareVMOps, '_fetch_image_from_other_datastores',
                        return_value=None)
-    def test_rescue(self,
-                    mock_fetch_image_from_other_datastores,
-                    mock_find_image_template_vm,
-                    mock_get_ds_by_ref, mock_power_on, mock_reconfigure,
-                    mock_get_boot_spec, mock_find_rescue,
-                    mock_get_vm_ref, mock_disk_copy,
-                    mock_power_off, mock_glance):
+    def _test_rescue(self,
+                     mock_fetch_image_from_other_datastores,
+                     mock_find_image_template_vm,
+                     mock_get_ds_by_ref, mock_power_on, mock_reconfigure,
+                     mock_get_boot_spec, mock_find_rescue,
+                     mock_get_vm_ref, mock_disk_copy,
+                     mock_power_off, mock_glance, efi=False):
         _volumeops = mock.Mock()
         self._vmops._volumeops = _volumeops
         ds_ref = vmwareapi_fake.ManagedObjectReference(value='fake-ref')
@@ -458,6 +464,8 @@ class VMwareVMOpsTestCase(test.TestCase):
         vmx_path = ds_obj.DatastorePath.parse(
             '[vmx-ds] test (uuid)/test (uuid).vmdk')
 
+        gop_return = 'efi' if efi else 'bios'
+
         with test.nested(
             mock.patch.object(self._vmops, 'get_datacenter_ref_and_name'),
             mock.patch.object(vm_util, 'get_vmdk_info',
@@ -465,9 +473,11 @@ class VMwareVMOpsTestCase(test.TestCase):
             mock.patch.object(vm_util, 'get_datastore_ref_by_name',
                               return_value=ds_ref),
             mock.patch.object(vm_util, 'get_vmx_path',
-                              return_value=vmx_path)
+                              return_value=vmx_path),
+            mock.patch.object(vm_util, 'get_object_property',
+                              return_value=gop_return)
         ) as (_get_dc_ref_and_name, fake_vmdk_info, fake_ds_ref_by_name,
-                fake_get_vmx_path):
+                fake_get_vmx_path, fake_get_object_property):
             dc_info = mock.Mock()
             _get_dc_ref_and_name.return_value = dc_info
             self._vmops.rescue(
@@ -487,8 +497,9 @@ class VMwareVMOpsTestCase(test.TestCase):
                              cache_path, rescue_path)
             _volumeops.attach_disk_to_vm.assert_called_once_with(vm_ref,
                              self._instance, mock.ANY, mock.ANY, rescue_path)
-            mock_get_boot_spec.assert_called_once_with(mock.ANY,
-                                                       'fake-rescue-device')
+
+            get_boot_spec_args = [mock.ANY, 'fake-rescue-device', efi]
+            mock_get_boot_spec.assert_called_once_with(*get_boot_spec_args)
             mock_reconfigure.assert_called_once_with(self._session,
                                                      vm_ref,
                                                      'fake-boot-spec')
@@ -502,15 +513,25 @@ class VMwareVMOpsTestCase(test.TestCase):
     def test_unrescue_power_off(self):
         self._test_unrescue(False)
 
-    def _test_unrescue(self, power_on):
+    def test_unrescue_efi(self):
+        self._test_unrescue(False, efi=True)
+
+    def _test_unrescue(self, power_on, efi=False):
         _volumeops = mock.Mock()
         self._vmops._volumeops = _volumeops
         vm_ref = mock.Mock()
 
+        get_object_property_args = iter(((vm_ref, 'config.hardware.device'),
+                                         (vm_ref, 'config.firmware')))
+
         def fake_call_method(module, method, *args, **kwargs):
-            expected_args = (vm_ref, 'config.hardware.device')
+            expected_args = next(get_object_property_args)
             self.assertEqual('get_object_property', method)
             self.assertEqual(expected_args, args)
+            if expected_args[1] == 'config.firmware':
+                return 'efi'
+            else:
+                return 'bios'
 
         with test.nested(
                 mock.patch.object(vm_util, 'power_on_instance'),
@@ -518,9 +539,10 @@ class VMwareVMOpsTestCase(test.TestCase):
                 mock.patch.object(vm_util, 'get_vm_ref', return_value=vm_ref),
                 mock.patch.object(self._session, '_call_method',
                                   fake_call_method),
-                mock.patch.object(vm_util, 'power_off_instance')
+                mock.patch.object(vm_util, 'power_off_instance'),
+                mock.patch.object(vm_util, 'reconfigure_vm', autospec=True)
         ) as (_power_on_instance, _find_rescue, _get_vm_ref,
-              _call_method, _power_off):
+              _call_method, _power_off, _reconfigure_vm):
             self._vmops.unrescue(self._instance, power_on=power_on)
 
             if power_on:
@@ -534,6 +556,16 @@ class VMwareVMOpsTestCase(test.TestCase):
                                                vm_ref)
             _volumeops.detach_disk_from_vm.assert_called_once_with(
                 vm_ref, self._instance, mock.ANY, destroy_disk=True)
+
+            if efi:
+                fake_factory = vmwareapi_fake.FakeFactory()
+                expected = fake_factory.create('ns0:VirtualMachineConfigSpec')
+                opt = fake_factory.create('ns0:OptionValue')
+                opt.key = 'efi.quickBoot.enabled'
+                opt.value = ''
+                expected.extraConfig = [opt]
+                _reconfigure_vm.assert_called_once_with(self._session, vm_ref,
+                    expected)
 
     @mock.patch.object(time, 'sleep')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cached_instances')

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -526,11 +526,14 @@ def create_serial_port_spec(client_factory):
     return dev_spec
 
 
-def get_vm_boot_spec(client_factory, device):
+def get_vm_boot_spec(client_factory, device, is_efi=False):
     """Returns updated boot settings for the instance.
 
     The boot order for the instance will be changed to have the
     input device as the boot disk.
+
+    If "is_efi" is True, "quickBoot" will be disabled for the VM so it can
+    actually see the rescue disk during the boot decision.
     """
     config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
     boot_disk = client_factory.create(
@@ -539,6 +542,13 @@ def get_vm_boot_spec(client_factory, device):
     boot_options = client_factory.create('ns0:VirtualMachineBootOptions')
     boot_options.bootOrder = [boot_disk]
     config_spec.bootOptions = boot_options
+
+    if is_efi:
+        opt = client_factory.create('ns0:OptionValue')
+        opt.key = 'efi.quickBoot.enabled'
+        opt.value = 'FALSE'
+        config_spec.extraConfig = [opt]
+
     return config_spec
 
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2059,7 +2059,10 @@ class VMwareVMOps(object):
         # boot from this device
         rescue_device = self._get_rescue_device(instance, vm_ref)
         factory = self._session.vim.client.factory
-        boot_spec = vm_util.get_vm_boot_spec(factory, rescue_device)
+        firmware = vm_util.get_object_property(self._session, vm_ref,
+                                               'config.firmware')
+        boot_spec = vm_util.get_vm_boot_spec(factory, rescue_device,
+                                             firmware == 'efi')
         # Update the VM with the new boot order and power on
         vm_util.reconfigure_vm(self._session, vm_ref, boot_spec)
         vm_util.power_on_instance(self._session, instance, vm_ref=vm_ref)
@@ -2078,6 +2081,19 @@ class VMwareVMOps(object):
         vm_util.power_off_instance(self._session, instance, vm_ref)
         self._volumeops.detach_disk_from_vm(vm_ref, instance, rescue_device,
                                             destroy_disk=True)
+
+        firmware = vm_util.get_object_property(self._session, vm_ref,
+                                               'config.firmware')
+        if firmware == 'efi':
+            # Enable quickBoot again, since we only needed it to find the
+            # rescue disk
+            factory = self._session.vim.client.factory
+            config_spec = factory.create('ns0:VirtualMachineConfigSpec')
+            opt = factory.create('ns0:OptionValue')
+            opt.key = 'efi.quickBoot.enabled'
+            opt.value = ''  # an empty value deletes the option
+            config_spec.extraConfig = [opt]
+            vm_util.reconfigure_vm(self._session, vm_ref, config_spec)
         if power_on:
             vm_util.power_on_instance(self._session, instance, vm_ref=vm_ref)
 


### PR DESCRIPTION
VMware by default enables a "quickBoot" feature for efi-booted VMs, which exposes only the first disk of the VM when finding out which disk to boot from. This leads to the VM not booting the rescue disk and thus ignoring the explicitly set "bootOptions.bootOrder" property.

There's an advanced setting called "efi.quickBoot.enabled" to disable the default behavior by providing a value of "FALSE". We set this property on rescue and unset it on unrescue, as it might have an adverse effect on the boot time when the underlying disks are slow.

Change-Id: I64cf1cd4478a9c48a4cce723d224dac31edf85c6

---

I haven't run the tests, yet, as I want the PR to do that.