### PR TITLE
Conditionally disable hypervisor uptime in details API

### DIFF
--- a/nova/conf/api.py
+++ b/nova/conf/api.py
@@ -363,6 +363,17 @@ option will be ignored. See "Handling Down Cells" section of the Compute API
 guide (https://docs.openstack.org/api-guide/compute/down_cells.html) for
 more information.
 """),
+    cfg.BoolOpt("disable_hypervisor_uptime_detail",
+                default=False,
+                help="""
+If enabled, return None in the "uptime" field from hypervisors' detailed
+properties. This speeds up the API for these requests. Consider enabling this
+if you have a lot of hypervisors, since it scales with their number.
+
+In the VMware driver in particular a nova hypervisor is actually a cluster of
+nodes, and reporting uptime is not meaningful. Ironic also doesn't implement
+this field.
+"""),
 ]
 
 os_network_opts = [


### PR DESCRIPTION
The "uptime" field in the hypervisor-details API is
- costly
- not supported for every hypervisor (notably not ironic & vmware)
- noisy in error tracing tools

Introduce a "disable_hypervisor_uptime_detail" setting (default off)
to always return None without asking the compute services.

Change-Id: I544c62af23c98da8cab198d3be1c951645c19ce9
