### PR TITLE
Fix UnboundLocalError in _wait_for_import_task()

### DIFF
--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -454,6 +454,7 @@ def _wait_for_import_task(session, vm_ref):
     task_filter_spec.state = ["queued", "running"]
 
     waited = False
+    task_collector = None
 
     try:
         task_collector = session._call_method(


### PR DESCRIPTION
The `finally` clause tries to destroy the `task_collector` instance, which might not have been created at all of the `_call_method()` call raised an exception.

This is a fixup for commit 54c437984ba032ad9cc65b7b066a96afaed195fa "Merge clone vm and glance parallel image import".

Change-Id: I5e4bee5f0326185a9b85f361695c941a7d813419