### PR TITLE
Fix passing scheduler_hints on resize

### DIFF
--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -307,10 +307,10 @@ class ComputeTaskManager:
         # NOTE(jkulik): We need the instance's current host in at least one
         # filter to make sure we don't pass vCenter boundaries, i.e. shards
         if instance.obj_attr_is_set('host'):
-            scheduler_hints = {'source_host': [instance.host],
-                               'source_node': [instance.node]}
+            new_scheduler_hints = {'source_host': [instance.host],
+                                   'source_node': [instance.node]}
             sh = filter_properties.setdefault('scheduler_hints', {})
-            sh.update(scheduler_hints)
+            sh.update(new_scheduler_hints)
 
         # NOTE(sbauza): If a reschedule occurs when prep_resize(), then
         # it only provides filter_properties legacy dict back to the
@@ -346,7 +346,8 @@ class ComputeTaskManager:
             # original RequestSpec object for make sure the scheduler verifies
             # the right one and not the original flavor
             request_spec.flavor = flavor
-            request_spec.update_scheduler_hints(scheduler_hints)
+            request_spec.update_scheduler_hints(
+                filter_properties.get('scheduler_hints', {}))
         return request_spec
 
     def _cold_migrate(self, context, instance, flavor, filter_properties,


### PR DESCRIPTION
We used the wrong variable and thus did not pass on the scheduler_hints set by `nova-compute.api` during the preparation of a resize in `nova-conductor`.

We rename the local variable `scheduler_hints` to `new_scheduler_hints` to make sure we don't make the same mistake again.

This is a fixup for Id80bfd2f3e4771856cc0d85bc1b85a7d14f3b136

Change-Id: I8274ba6b2a4fb0e32b0880939ce50096672bbd3b