### PR TITLE
nova-manage: Fix max_count break condition

### DIFF
--- a/nova/cmd/manage.py
+++ b/nova/cmd/manage.py
@@ -3347,9 +3347,10 @@ class SAPCommands(object):
                 if cb(ctxt, instance, dry_run=dry_run):
                     num_processed += 1
 
-            # Make sure we don't go over the max count.
-            if (not unlimited and num_processed == max_count) or instance_uuid:
-                return num_processed
+                # Make sure we don't go over the max count.
+                if (not unlimited and num_processed == max_count) \
+                        or instance_uuid:
+                    return num_processed
 
             # Use a marker to get the next page of instances in this cell.
             marker = instances[-1].uuid


### PR DESCRIPTION
We only checked the number of processed instances after each batch fully handled. Since we checked for the number of processed instances being equal to the `max_count`, passing `max_count` in a batch would lead to processing all instances instead of only `mac_count`.

To fix this, we now check if we're at `max_count` after every instance.

his is a fixup for commit d314bd137dec74d67bdb1a0651d3340b4148543d "nova-manage: add sync_instances_flavor command"

Change-Id: Ieb2bbbce1f450b1655a44bbe0732a87288f3291c