### PR TITLE
vmwareapi: Limit reported free space by capacity

### DIFF
--- a/nova/virt/vmwareapi/host.py
+++ b/nova/virt/vmwareapi/host.py
@@ -52,11 +52,13 @@ def _get_ds_capacity_and_freespace(session, cluster=None,
     except exception.DatastoreNotFound:
         pass
 
-    return capacity, freespace, max_freespace
+    # Avoid ValueError("Capacity is smaller than free space")
+    return capacity, min(freespace, capacity), min(max_freespace, capacity)
 
 
 class VCState(object):
     """Manages information about the vCenter cluster"""
+
     def __init__(self, session, cluster_node_name, cluster, datastore_regex):
         super(VCState, self).__init__()
         self._session = session


### PR DESCRIPTION
Other parts of the code expect the capacity to be bigger or equal to the free space, and validate that.

Since the vmwareapi reports sometimes more free space than capacity, we need to limit it

Change-Id: I8b3b39c456596f96718088e7478ff5264a1789cf