### PR TITLE
Drop unused mitmproxy

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,7 +1,6 @@
 dumb-init
 python-memcached
 pymemcache
-mitmproxy
 python-ironicclient
 
 -e git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven


### PR DESCRIPTION
We used it in the shellinaboxproxy, which was dropped with the change I4bb869932ee458120931868bfbceaa99a9ee641d So, we might as well drop the dependency as well.

Change-Id: Ia56516909fccea6bd228a3e1040c1e730704ab21