### PR TITLE
vmware: Delete duplicate DRS rules

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -4332,8 +4332,23 @@ class VMwareVMOps(object):
             LOG.debug('Sync for server-group %s done', sg_uuid)
 
         def _update_rule(rule_name, expected_members, sg):
-            rule = cluster_util.get_rule(
-                self._session, self._cluster, rule_name)
+            # we need to get by "prefix", to get all rules matching our name,
+            # as there can be duplication happening with automatically
+            # vSphere-created rules during vMotion
+            rules = [r for r in cluster_util.get_rules_by_prefix(
+                        self._session, self._cluster, rule_name)
+                     if r.name == rule_name]
+
+            rule = rules[0] if rules else None
+
+            # if we have duplicates (with the same name), delete them
+            for dupl_rule in rules[1:]:
+                LOG.debug('Deleting DRS rule %s with key %s as duplicate',
+                          dupl_rule.name, dupl_rule.key)
+                cluster_util.delete_rule(
+                    self._session, self._cluster, dupl_rule)
+                LOG.info('Deleted rule %s with key %s as duplicate',
+                         dupl_rule.name, dupl_rule.key)
 
             if not rule:
                 if len(expected_members) < 2 or sg.policy == 'soft-affinity':


### PR DESCRIPTION
Cross-cluster vMotion creates DRS rules in the target cluster, if the VM was part of them in the source cluster. This can create duplicate DRS rules (by name), as it seems VMware looks at the UUID of the rule not the name.

Since multiple rules for the same VM cannot be enabled at the same time and `cluster_util.get_rule()` only returns the first matching rule, Nova might update the wrong rule and the anti-affinity might not actually work.

To fix this, we get all the rules with the same name during `_update_rule()` to check for duplicates. We keep the first rule we find and delete all others. If the rule is disabled, Nova will enable it already.

Change-Id: Ie5958a1645e8133f303e386353526ec83e646882