### PR TITLE
scheduler: Move project tag caching to mixin

### DIFF
--- a/nova/scheduler/filters/shard_filter.py
+++ b/nova/scheduler/filters/shard_filter.py
@@ -12,14 +12,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import time
-
-from keystoneauth1 import exceptions as kse
-from keystoneauth1 import loading as ks_loading
 from oslo_log import log as logging
 
 import nova.conf
 from nova.scheduler import filters
+from nova.scheduler.mixins import ProjectTagMixin
 from nova.scheduler import utils
 from nova import utils as nova_utils
 
@@ -27,10 +24,8 @@ LOG = logging.getLogger(__name__)
 
 CONF = nova.conf.CONF
 
-_SERVICE_AUTH = None
 
-
-class ShardFilter(filters.BaseHostFilter):
+class ShardFilter(filters.BaseHostFilter, ProjectTagMixin):
     """Filter hosts based on the vcenter-shard configured in their aggregate
     and the vcenter-shards configured in the project's tags in keystone. They
     have to overlap for a host to pass this filter.
@@ -39,80 +34,16 @@ class ShardFilter(filters.BaseHostFilter):
     enables the project for hosts in all shards.
     """
 
-    _PROJECT_SHARD_CACHE = {}
-    _PROJECT_SHARD_CACHE_RETENTION_TIME = 10 * 60
-    _SHARD_PREFIX = 'vc-'
     _ALL_SHARDS = "sharding_enabled"
+    _SHARD_PREFIX = 'vc-'
+    _PROJECT_TAG_TAGS = [_ALL_SHARDS]
+    _PROJECT_TAG_PREFIX = _SHARD_PREFIX
 
-    def _update_cache(self):
-        """Ask keystone for the list of projects to save the interesting tags
-        of each project in the cache
-        """
-        global _SERVICE_AUTH
-
-        if _SERVICE_AUTH is None:
-            _SERVICE_AUTH = ks_loading.load_auth_from_conf_options(
-                                CONF,
-                                group=
-                                nova.conf.service_token.SERVICE_USER_GROUP)
-            if _SERVICE_AUTH is None:
-                # This indicates a misconfiguration so log a warning and
-                # return the user_auth.
-                LOG.error('Unable to load auth from [service_user] '
-                          'configuration. Ensure "auth_type" is set.')
-                return
-
-        adap = nova_utils.get_ksa_adapter(
-            'identity', ksa_auth=_SERVICE_AUTH,
-            min_version=(3, 0), max_version=(3, 'latest'))
-
-        url = '/projects'
-        while url:
-            try:
-                resp = adap.get(url, raise_exc=False)
-            except kse.EndpointNotFound:
-                LOG.error(
-                    "Keystone identity service version 3.0 was not found. "
-                    "This might be because your endpoint points to the v2.0 "
-                    "versioned endpoint which is not supported. Please fix "
-                    "this.")
-                return
-            except kse.ClientException:
-                LOG.error("Unable to contact keystone to update project tags "
-                          "cache")
-                return
-
-            resp.raise_for_status()
-
-            data = resp.json()
-            for project in data['projects']:
-                project_id = project['id']
-                shards = [t for t in project['tags']
-                          if t.startswith(self._SHARD_PREFIX) or
-                          t == self._ALL_SHARDS]
-                self._PROJECT_SHARD_CACHE[project_id] = shards
-
-            url = data['links']['next']
-
-        self._PROJECT_SHARD_CACHE['last_modified'] = time.time()
-
-    @nova_utils.synchronized('update-shard-cache')
     def _get_shards(self, project_id):
-        """Return a set of shards for a project or None
-
-        This should be quite fast except if we update the cache. Since we only
-        need one thread updating the cache, we let the other threads wait here.
-        """
-        # expire the cache 10min after last write
-        last_modified = self._PROJECT_SHARD_CACHE.get('last_modified', 0)
-        time_diff = time.time() - last_modified
-        if time_diff > self._PROJECT_SHARD_CACHE_RETENTION_TIME:
-            self._PROJECT_SHARD_CACHE = {}
-
-        if project_id not in self._PROJECT_SHARD_CACHE:
-            self._update_cache()
-
-        return self._PROJECT_SHARD_CACHE.get(project_id)
+        """Return a set of shards for a project or None"""
+        # NOTE(jkulik): We wrap _get_tags() here to change the name to
+        # _get_shards() so it's clear what we return
+        return self._get_tags(project_id)
 
     def host_passes(self, host_state, spec_obj):
         # Only VMware

--- a/nova/scheduler/mixins.py
+++ b/nova/scheduler/mixins.py
@@ -12,14 +12,24 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import time
+
+from keystoneauth1 import exceptions as kse
+from keystoneauth1 import loading as ks_loading
 from oslo_cache.backends.dictionary import DictCacheBackend
 from oslo_cache import core as cache_core
 from oslo_log import log as logging
 
+import nova.conf
 from nova import context
 from nova.scheduler.client import report
+from nova import utils as nova_utils
 
 LOG = logging.getLogger(__name__)
+
+CONF = nova.conf.CONF
+
+_SERVICE_AUTH = None
 
 
 class HypervisorSizeMixin(object):
@@ -41,3 +51,96 @@ class HypervisorSizeMixin(object):
         self._HV_SIZE_CACHE.set(host_state.uuid, hv_size_mb)
 
         return hv_size_mb
+
+
+class ProjectTagMixin:
+
+    _PROJECT_TAG_CACHE = {}
+    _PROJECT_TAG_CACHE_RETENTION_TIME = 10 * 60
+    # Optional prefix to filter for in tags to cache. Works in addition to
+    # _PROJECT_TAG_TAGS i.e. as an OR
+    _PROJECT_TAG_PREFIX = None
+    # Optional explicit list of tags to cache. Works in addition to
+    # _PROJECT_TAG_PREFIX i.e. as an OR
+    _PROJECT_TAG_TAGS = None
+
+    def _update_cache(self):
+        """Ask keystone for the list of projects to save the interesting tags
+        of each project in the cache
+        """
+        global _SERVICE_AUTH
+
+        if _SERVICE_AUTH is None:
+            _SERVICE_AUTH = ks_loading.load_auth_from_conf_options(
+                                CONF,
+                                group=
+                                nova.conf.service_token.SERVICE_USER_GROUP)
+            if _SERVICE_AUTH is None:
+                # This indicates a misconfiguration so log a warning and
+                # return the user_auth.
+                LOG.error('Unable to load auth from [service_user] '
+                          'configuration. Ensure "auth_type" is set.')
+                return
+
+        adap = nova_utils.get_ksa_adapter(
+            'identity', ksa_auth=_SERVICE_AUTH,
+            min_version=(3, 0), max_version=(3, 'latest'))
+
+        url = '/projects'
+        while url:
+            try:
+                resp = adap.get(url, raise_exc=False)
+            except kse.EndpointNotFound:
+                LOG.error(
+                    "Keystone identity service version 3.0 was not found. "
+                    "This might be because your endpoint points to the v2.0 "
+                    "versioned endpoint which is not supported. Please fix "
+                    "this.")
+                return
+            except kse.ClientException:
+                LOG.error("Unable to contact keystone to update project tags "
+                          "cache")
+                return
+
+            resp.raise_for_status()
+
+            data = resp.json()
+            for project in data['projects']:
+                project_id = project['id']
+                tags = []
+                for t in project['tags']:
+                    if self._PROJECT_TAG_TAGS and t in self._PROJECT_TAG_TAGS:
+                        tags.append(t)
+                    if (self._PROJECT_TAG_PREFIX and
+                            t.startswith(self._PROJECT_TAG_PREFIX)):
+                        tags.append(t)
+                self._PROJECT_TAG_CACHE[project_id] = tags
+
+            url = data['links']['next']
+
+        self._PROJECT_TAG_CACHE['last_modified'] = time.time()
+
+    def _get_tags(self, project_id):
+        """Return a list of tags for a project or None
+
+        This should be quite fast except if we update the cache. Since we only
+        need one thread updating the cache, we let the other threads wait here.
+        """
+        # we inline the function to customize the key with the name of the
+        # class we're used as mixin in
+        key = f"update-project-tag-cache-{self.__class__.__name__}"
+
+        @nova_utils.synchronized(key)
+        def _synchronized_get_tags(project_id):
+            # expire the cache 10min after last write
+            last_modified = self._PROJECT_TAG_CACHE.get('last_modified', 0)
+            time_diff = time.time() - last_modified
+            if time_diff > self._PROJECT_TAG_CACHE_RETENTION_TIME:
+                self._PROJECT_TAG_CACHE = {}
+
+            if project_id not in self._PROJECT_TAG_CACHE:
+                self._update_cache()
+
+            return self._PROJECT_TAG_CACHE.get(project_id)
+
+        return _synchronized_get_tags(project_id)

--- a/nova/tests/unit/scheduler/filters/test_shard_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_shard_filter.py
@@ -27,7 +27,7 @@ class TestShardFilter(test.NoDBTestCase):
     def setUp(self):
         super(TestShardFilter, self).setUp()
         self.filt_cls = shard_filter.ShardFilter()
-        self.filt_cls._PROJECT_SHARD_CACHE = {
+        self.filt_cls._PROJECT_TAG_CACHE = {
             'foo': ['vc-a-0', 'vc-b-0'],
             'last_modified': time.time()
         }
@@ -36,25 +36,25 @@ class TestShardFilter(test.NoDBTestCase):
                 'ShardFilter._update_cache')
     def test_get_shards_cache_timeout(self, mock_update_cache):
         def set_cache():
-            self.filt_cls._PROJECT_SHARD_CACHE = {
+            self.filt_cls._PROJECT_TAG_CACHE = {
                 'foo': ['vc-a-1']
             }
         mock_update_cache.side_effect = set_cache
 
         project_id = 'foo'
-        mod = time.time() - self.filt_cls._PROJECT_SHARD_CACHE_RETENTION_TIME
+        mod = time.time() - self.filt_cls._PROJECT_TAG_CACHE_RETENTION_TIME
 
         self.assertEqual(self.filt_cls._get_shards(project_id),
                                                    ['vc-a-0', 'vc-b-0'])
 
-        self.filt_cls._PROJECT_SHARD_CACHE['last_modified'] = mod
+        self.filt_cls._PROJECT_TAG_CACHE['last_modified'] = mod
         self.assertEqual(self.filt_cls._get_shards(project_id), ['vc-a-1'])
 
     @mock.patch('nova.scheduler.filters.shard_filter.'
                 'ShardFilter._update_cache')
     def test_get_shards_project_not_included(self, mock_update_cache):
         def set_cache():
-            self.filt_cls._PROJECT_SHARD_CACHE = {
+            self.filt_cls._PROJECT_TAG_CACHE = {
                 'bar': ['vc-a-1', 'vc-b-0']
             }
         mock_update_cache.side_effect = set_cache
@@ -95,7 +95,7 @@ class TestShardFilter(test.NoDBTestCase):
             context=mock.sentinel.ctx, project_id='foo',
             flavor=objects.Flavor(extra_specs={}))
 
-        self.filt_cls._PROJECT_SHARD_CACHE['foo'] = []
+        self.filt_cls._PROJECT_TAG_CACHE['foo'] = []
         self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
 
     @mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
@@ -145,7 +145,7 @@ class TestShardFilter(test.NoDBTestCase):
             context=mock.sentinel.ctx, project_id='foo',
             flavor=objects.Flavor(extra_specs={}))
 
-        self.filt_cls._PROJECT_SHARD_CACHE['foo'] = ['vc-a-0', 'vc-a-1',
+        self.filt_cls._PROJECT_TAG_CACHE['foo'] = ['vc-a-0', 'vc-a-1',
                                                      'vc-b-0']
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
@@ -161,7 +161,7 @@ class TestShardFilter(test.NoDBTestCase):
             scheduler_hints=dict(_nova_check_type=['resize'],
                                  source_host=['host2']))
 
-        self.filt_cls._PROJECT_SHARD_CACHE['foo'] = ['vc-a-0', 'vc-a-1',
+        self.filt_cls._PROJECT_TAG_CACHE['foo'] = ['vc-a-0', 'vc-a-1',
                                                      'vc-b-0']
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
@@ -176,12 +176,12 @@ class TestShardFilter(test.NoDBTestCase):
             scheduler_hints=dict(_nova_check_type=['resize'],
                                  source_host=['host2']))
 
-        self.filt_cls._PROJECT_SHARD_CACHE['foo'] = ['vc-a-0', 'vc-a-1',
+        self.filt_cls._PROJECT_TAG_CACHE['foo'] = ['vc-a-0', 'vc-a-1',
                                                      'vc-b-0']
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
     def test_shard_project_has_sharding_enabled_any_host_passes(self):
-        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled']
+        self.filt_cls._PROJECT_TAG_CACHE['baz'] = ['sharding_enabled']
         aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1']),
                  objects.Aggregate(id=1, name='vc-a-0', hosts=['host1'])]
         host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
@@ -191,7 +191,7 @@ class TestShardFilter(test.NoDBTestCase):
         self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
 
     def test_shard_project_has_sharding_enabled_and_single_shards(self):
-        self.filt_cls._PROJECT_SHARD_CACHE['baz'] = ['sharding_enabled',
+        self.filt_cls._PROJECT_TAG_CACHE['baz'] = ['sharding_enabled',
                                                      'vc-a-1']
         aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1']),
                  objects.Aggregate(id=1, name='vc-a-0', hosts=['host1'])]


### PR DESCRIPTION
We have an implementation caching certain tags for projects in the `ShardFilter`. In the future, we want to add another filter to the scheduler that will also react to project tags. Therefore, we move the code handling the caching out into a Mixin class.

The Mixin supports prefix and exact matching, configured via class attribute.

Change-Id: I3ad865ec4dbbf097fc4718b0753b86a8e64775fa