### PR TITLE
scheduler: Add VolumeSizeSameShardResizeFilter

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -870,6 +870,20 @@ Possible values:
 Related options:
 
 * vm_size_threshold_vm_size_mb
+"""),
+    cfg.IntOpt("volume_size_same_shard_resize_filter_sum",
+        default=1024,
+        help="""
+Sum of volume sizes in GiB >= the VolumeSizeSameShardResizeFilter starts acting
+
+When using the volume_size_same_shard_resize filter, any VM having in sum equal
+or more than the given amount of volume sizes attached will be prohibited from
+resizing outside of its current shard - if the project has the appropriate tag
+set (see _TAG class attribute).
+
+Possible values:
+
+* Any positive integer
 """)]
 
 metrics_group = cfg.OptGroup(

--- a/nova/scheduler/filters/volume_size_same_shard_resize_filter.py
+++ b/nova/scheduler/filters/volume_size_same_shard_resize_filter.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2023 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from oslo_log import log as logging
+
+import nova.conf
+from nova.scheduler import filters
+from nova.scheduler.mixins import ProjectTagMixin
+from nova.scheduler import utils
+from nova import utils as nova_utils
+
+LOG = logging.getLogger(__name__)
+
+CONF = nova.conf.CONF
+
+
+class VolumeSizeSameShardResizeFilter(filters.BaseHostFilter, ProjectTagMixin):
+    """Filter out other shards on resize with too big volumes
+
+    A project can opt in to this by setting the appropriate tag (see
+    _TAG below).
+    The sum of the sizes of the volumes attached to the VM trigger the
+    behavior. It's configured below in _VOLUME_SIZE_SUM.
+    """
+    _TAG = 'restrict-resize-by-volume-size'
+    _PROJECT_TAG_TAGS = [_TAG]
+    # sum of the volumes size >= we do not allow a host as resize target
+    _VOLUME_SIZE_SUM = \
+        CONF.filter_scheduler.volume_size_same_shard_resize_filter_sum
+    # prefix of the aggregate names that make them a shard
+    _SHARD_PREFIX = 'vc-'
+
+    def _has_tag(self, project_id):
+        """Return boolean if the project has our tag set"""
+        return self._TAG in self._get_tags(project_id)
+
+    def host_passes(self, host_state, request_spec):
+        # Only VMware
+        if utils.is_non_vmware_spec(request_spec):
+            return True
+
+        if not utils.request_is_resize(request_spec):
+            return True
+
+        project_id = request_spec.project_id
+        if not self._has_tag(project_id):
+            LOG.debug('%(host_state)s allowed, because project %(project_id)s '
+                      'did not set %(tag)s',
+                      {'host_state': host_state, 'project_id': project_id,
+                       'tag': self._TAG})
+            return True
+
+        if ('scheduler_hints' not in request_spec or
+                'volume_sizes' not in request_spec.scheduler_hints):
+            LOG.error('Resize without "volume_sizes" scheduler-hint')
+            return False
+
+        volume_sizes = request_spec.scheduler_hints['volume_sizes']
+        if not volume_sizes:
+            LOG.debug('%(host_state)s allowed, because the instance has no '
+                      'volumes', {'host_state': host_state})
+            return True
+
+        # NOTE(jkulik): scheduler_hints are of type DictOfListOfStringsField
+        # so we need to convert them to int to sum them up
+        volume_size_sum = 0
+        for s in volume_sizes:
+            if not s:
+                continue
+            try:
+                volume_size_sum += int(s)
+            except ValueError:
+                pass
+        if volume_size_sum < self._VOLUME_SIZE_SUM:
+            LOG.debug('%(host_state)s allowed, because the instances has a '
+                      'sum of %(sum)s GiB of volumes and we allow '
+                      '%(configured_sum)s GiB',
+                      {'host_state': host_state, 'sum': volume_size_sum,
+                       'configured_sum': self._VOLUME_SIZE_SUM})
+            return True
+
+        host_shard_aggrs = [aggr for aggr in host_state.aggregates
+                            if aggr.name.startswith(self._SHARD_PREFIX)]
+        if not host_shard_aggrs:
+            log_method = (LOG.debug if nova_utils.is_baremetal_host(host_state)
+                          else LOG.error)
+            log_method('%(host_state)s is not in an aggregate starting with '
+                       '%(shard_prefix)s',
+                       {'host_state': host_state,
+                        'shard_prefix': self._SHARD_PREFIX})
+            return False
+
+        if len(host_shard_aggrs) > 1:
+            LOG.error('More than one host aggregates found for '
+                      'host %(host)s: %(aggrs)s',
+                      {'host': host_state.host,
+                       'aggrs': ', '.join([a.name for a in host_shard_aggrs])})
+        host_shard_aggr = host_shard_aggrs[0]
+
+        instance_host = request_spec.get_scheduler_hint('source_host')
+        if instance_host in host_shard_aggr.hosts:
+            LOG.debug('%(host_state)s allowed, as it has the same shard '
+                      '%(shard_name)s as the source host %(source_host)s',
+                      {'host_state': host_state,
+                       'shard_name': host_shard_aggr.name,
+                       'source_host': instance_host})
+            return True
+
+        LOG.debug('%(host_state)s not allowed, as it has another shard '
+                  '%(shard_name)s as the source host %(source_host)s and the '
+                  'instance has %(sum)s GiB of volumes which is >= the '
+                  'configured %(configured_sum)s',
+                  {'host_state': host_state,
+                   'shard_name': host_shard_aggr.name,
+                   'source_host': instance_host,
+                   'sum': volume_size_sum,
+                   'configured_sum': self._VOLUME_SIZE_SUM
+                   })
+        return False

--- a/nova/tests/unit/scheduler/filters/test_volume_size_same_shard_resize_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_volume_size_same_shard_resize_filter.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import time
+
+import mock
+from oslo_utils.fixture import uuidsentinel as uuids
+
+from nova import objects
+from nova.scheduler.filters import volume_size_same_shard_resize_filter
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+class TestVolumeSizeSameShardResizeFilter(test.NoDBTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.filt_cls = (volume_size_same_shard_resize_filter
+                         .VolumeSizeSameShardResizeFilter())
+        self.filt_cls._PROJECT_TAG_CACHE = {
+            uuids.project_with: [self.filt_cls._TAG],
+            uuids.project_without: [],
+            'last_modified': time.time()
+        }
+        self.flavor = objects.Flavor(extra_specs={})
+        self.spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id=uuids.project_with,
+            flavor=self.flavor,
+            scheduler_hints=dict(_nova_check_type=['resize'],
+                                 source_host=['host2']))
+
+    def test_non_vmware_passes(self):
+        """We only need sharding for VMware hypervisors"""
+        host = fakes.FakeHostState('host1', 'compute', {})
+        extra_specs = {'capabilities:cpu_arch': 'x86_64'}
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id=uuids.project_without,
+            flavor=objects.Flavor(extra_specs=extra_specs))
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_non_resize_passes(self):
+        """The filter should only check resizes"""
+        host = fakes.FakeHostState('host1', 'compute', {})
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id=uuids.project_without,
+            flavor=self.flavor)
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_projects_without_tag_pass(self):
+        """we only need to check volumes if the tag is present"""
+        host = fakes.FakeHostState('host1', 'compute', {})
+        self.spec_obj.project_id = uuids.project_without
+        self.assertTrue(self.filt_cls.host_passes(host, self.spec_obj))
+
+    def test_host_without_shard_fails(self):
+        """if the host doesn't have an aggregate, we cannot accept it as it
+        might be in another shard
+        """
+        aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1'])]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
+        self.assertFalse(self.filt_cls.host_passes(host, self.spec_obj))
+
+    def test_host_with_multiple_shards_fails(self):
+        """we cannot decide whether this will work, so we rather not pass"""
+        aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1']),
+                objects.Aggregate(id=2, name='vc-a-1', hosts=['host1']),
+                objects.Aggregate(id=3, name='vc-a-2', hosts=['host2'])]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
+        self.assertFalse(self.filt_cls.host_passes(host, self.spec_obj))
+
+    def test_scheduler_hints_without_volume_sizes_fails(self):
+        """if we did not get the "volume_sizes" key for a resize, we run
+        outdated code somewhere and need to bail
+        """
+        aggs = [objects.Aggregate(id=1, name='some-az-a', hosts=['host1']),
+                objects.Aggregate(id=2, name='vc-a-1', hosts=['host1'])]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
+        self.assertFalse(self.filt_cls.host_passes(host, self.spec_obj))
+
+    def test_volumes_sum_below_threshold_passes(self):
+        """if the sum of volume sizes does not reach the threshold, we don't
+        have to check shards and can pass
+        """
+        host = fakes.FakeHostState('host1', 'compute', {})
+        self.spec_obj.scheduler_hints['volume_sizes'] = [
+            10, self.filt_cls._VOLUME_SIZE_SUM - 11]
+        self.assertTrue(self.filt_cls.host_passes(host, self.spec_obj))
+
+    def test_source_host_in_aggregate_passes(self):
+        """the host is in the same shard as our source host, which does not
+        create any volume migrations
+        """
+        aggs = [objects.Aggregate(id=1, name='some-az-a',
+                                  hosts=['host1', 'host2']),
+                objects.Aggregate(id=2, name='vc-a-1',
+                                  hosts=['host1', 'host2'])]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
+        self.spec_obj.scheduler_hints['volume_sizes'] = [
+            10, 5, self.filt_cls._VOLUME_SIZE_SUM - 15]
+        self.assertTrue(self.filt_cls.host_passes(host, self.spec_obj))
+
+    def test_source_host_not_in_aggregate_fails(self):
+        """the host is in another shard than our source host, which would
+        create volume migrations
+        """
+        aggs = [objects.Aggregate(id=1, name='some-az-a',
+                                  hosts=['host1', 'host2']),
+                objects.Aggregate(id=2, name='vc-a-1',
+                                  hosts=['host1'])]
+        host = fakes.FakeHostState('host1', 'compute', {'aggregates': aggs})
+        self.spec_obj.scheduler_hints['volume_sizes'] = [
+            10, 5, self.filt_cls._VOLUME_SIZE_SUM - 15]
+        self.assertFalse(self.filt_cls.host_passes(host, self.spec_obj))


### PR DESCRIPTION
We want to allow customers to optionally disable resizes of VMs across shards if the sum of the volume sizes reach a certain threshold. With this, we want customers to have more reliable resize times that might fit in their downtime windows as resizing across shards can create volume migrations which can take a long time.

The threshold is not configurable by the user and set to 1 TiB by default.  It can be changed with the
`volume_size_same_shard_resize_filter_sum` config setting.

Change-Id: I13a0e16713b90954cb48ea7f0a7c6db870d60bdc