### PR TITLE
vmware: Allow offline migration with too big root disk

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -115,7 +115,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                  self._context, **self._instance_values)
         self._flavor = objects.Flavor(name='m1.small', memory_mb=512, vcpus=1,
                                       root_gb=10, ephemeral_gb=0, swap=0,
-                                      extra_specs={})
+                                      extra_specs={}, id=3)
         self._instance.flavor = self._flavor
         self._volumeops = volumeops.VMwareVolumeOps(self._session)
         self._vmops = vmops.VMwareVMOps(self._session, self._virtapi,
@@ -1534,6 +1534,14 @@ class VMwareVMOpsTestCase(test.TestCase):
                           self._test_migrate_disk_and_power_off,
                           flavor_root_gb=self._instance.flavor.root_gb - 1)
 
+    def test_migrate_disk_and_power_off_disk_shrink_no_resize(self):
+        """If the flavor id doesn't change, this is an offline migration and we
+        should not fail if the disk is too large
+        """
+        self._test_migrate_disk_and_power_off(
+            flavor_root_gb=self._instance.flavor.root_gb - 1,
+            flavor_id=self._instance.flavor.id)
+
     @ddt.data((129, False, True), (128, False, False),
               (129, True, False), (128, True, False))
     @ddt.unpack
@@ -1576,7 +1584,8 @@ class VMwareVMOpsTestCase(test.TestCase):
                                          fake_rename_vm, fake_vm_device_change,
                                          fake_image_meta, fake_finish_revert,
                                          flavor_root_gb, flavor_vcpus=None,
-                                         is_efi=True, migrate_fails=False):
+                                         is_efi=True, migrate_fails=False,
+                                         flavor_id=None):
         if flavor_vcpus is None:
             flavor_vcpus = self._instance.flavor.vcpus + 1
 
@@ -1593,7 +1602,10 @@ class VMwareVMOpsTestCase(test.TestCase):
         fake_get_vmdk_info.return_value = vmdk
         fake_get_remove_network_device_change.return_value = ['fake-device']
         fake_get_object_property.return_value = 'efi' if is_efi else 'bios'
+        if flavor_id is None:
+            flavor_id = self._instance.flavor.id + 1
         flavor = fake_flavor.fake_flavor_obj(self._context,
+                                             id=flavor_id,
                                              root_gb=flavor_root_gb,
                                              vcpus=flavor_vcpus)
         if migrate_fails:

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2384,8 +2384,12 @@ class VMwareVMOps(object):
         boot_from_volume = compute_utils.is_volume_backed_instance(context,
                                                                    instance)
 
-        # Checks if the migration needs a disk resize down.
-        if (not boot_from_volume and (
+        # Checks if the migration needs a disk resize down,
+        # but only errors out if this is a requested resize. If this is an
+        # offline migration, we need to keep our mouths shut and just copy the
+        # disk over.
+        is_resize = flavor.id != instance.flavor.id
+        if (is_resize and not boot_from_volume and (
                 flavor.root_gb < instance.flavor.root_gb or
                 (flavor.root_gb != 0 and
                 flavor.root_gb < vmdk.capacity_in_bytes / units.Gi))):


### PR DESCRIPTION
There can be VMs where the image inflated to more than the flavor's root disk. Since VMware doesn't allow shrinking a disk, these VMs cannot be resized - and can also not be offline migrated, as that's the same code path.

Since an offline migration can only be triggered by admins and is done e.g. during decommissioning a host, we now allow offline migration with too big root disks. Otherwise, such a VM would always require customer interaction to get it removed or special care by booting into BIOS and live-migrating it.

We have to change `migrate_disk_and_power_off()` and not `finish_migration()`, because the latter does not check disk size differences but rather relies on the `resize_instance` argument passed in from `nova.compute.manager`. `resize_instance` can only be `True` if the flavor ids differ. We implement the same check in `migrate_disk_and_power_off()` now, too, to distinguish a resize from an offline migration.

Change-Id: I9592b1c490aa81bd06f5ce3f658ba59e5f702c85