### PR TITLE
vmware: Set restart-priority only if not present

### DIFF
--- a/nova/virt/vmwareapi/cluster_util.py
+++ b/nova/virt/vmwareapi/cluster_util.py
@@ -429,3 +429,22 @@ def update_cluster_das_vm_override(session, cluster, vm_ref, operation='add',
     config_spec.dasVmConfigSpec = [das_vm_spec]
 
     reconfigure_cluster(session, cluster, config_spec)
+
+
+def fetch_cluster_das_vm_restart_priority(session, cluster_ref, vm_ref):
+    """Fetch restartPriority DAS override for the VM on the cluster
+
+    The cluster is identified by a cluster_ref and we fetch the cluster_config.
+
+    Returns the restartPriority of one VM as a
+    `ClusterDasVmSettingsRestartPriority` string or None if no overrides
+    configured.
+    """
+    cluster_config = session._call_method(vutil, "get_object_property",
+                                          cluster_ref, "configurationEx")
+
+    overrides = getattr(cluster_config, 'dasVmConfig', [])
+    for o in overrides:
+        if vutil.get_moref_value(o.key) == vutil.get_moref_value(vm_ref):
+            return o.dasSettings.restartPriority
+    return None

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1503,9 +1503,13 @@ class VMwareVMOps(object):
             LOG.debug("Adding restart priority '%s' for big VM.",
                       restart_priority, instance=instance)
             vm_ref = vm_util.get_vm_ref(self._session, instance)
-            cluster_util.update_cluster_das_vm_override(
-                self._session, self._cluster, vm_ref, operation='add',
-                restart_priority=restart_priority)
+            prev_restart_priority = \
+                cluster_util.fetch_cluster_das_vm_restart_priority(
+                    self._session, self._cluster, vm_ref)
+            if prev_restart_priority is None:
+                cluster_util.update_cluster_das_vm_override(
+                    self._session, self._cluster, vm_ref, operation='add',
+                    restart_priority=restart_priority)
 
     def _clean_up_after_special_spawning(self, context, instance_memory_mb,
                                          instance_flavor):


### PR DESCRIPTION
The restart-priority migrates with the VM. Re-setting it raises the error

    InvalidDasConfigArgument: "The setting of vmConfig is invalid for cluster ..."

So check if the setting is present before setting it.

fixup: 89c95963f551 vmware: Restart BigVMs with "high" priority
Change-Id: Ibccec024af231a69ffcfa87f9575830f176e6a8c
