### PR TITLE
vmware: Clear MOref cache on source after migration

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -1230,9 +1230,12 @@ class VMwareVCDriver(driver.ComputeDriver):
             self._vmops.sync_instance_server_group(context, instance)
 
     def post_live_migration_at_source(self, context, instance, network_info):
-        # This is mostly for network related cleanup tasks at the source
-        # There is nothing to do for us
-        pass
+        # We have to clean up our VM-moref cache, so that when a VM with
+        # volume attachments comes back to this compute node after being moved
+        # away, the moref is not incorrect/stale and the VMware API, on volume
+        # attachment creation, doesn't complain that the VM
+        # "has already been deleted or has not been completely created".
+        vm_util.vm_ref_cache_delete(instance.uuid)
 
     def post_live_migration_at_destination(self, context, instance,
                                            network_info,


### PR DESCRIPTION
When a VM moves away from a compute node, the MOref cache in
nova.virt.vmwareapi.vm_util._VM_REFS_CACHE is not cleaned up.
If the VM is then migrated back to the same node it once came from,
_and_ it has volumes attached, the attachment creation fails in the
VCenter API, because the MOref used is the stale one.

Clean up the cache after moving away, so that if the VM comes back,
the new MOref value is fetched and volume attachments work.

Change-Id: Ib1f4b7cdd8c28924b674032a9ea92171b796bdb9
