### PR TITLE
Reserve the CUSTOM_BIGVM resource after live-migrations

### DIFF
--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -1260,6 +1260,9 @@ class VMwareVCDriver(driver.ComputeDriver):
             LOG.debug("Fixing shadow vms %s", volumes, instance=instance)
             self._volumeops.fixup_shadow_vms(instance, volumes)
 
+        self._vmops._clean_up_after_special_spawning(
+            context, instance.memory_mb, instance.flavor)
+
     def in_cluster_vmotion(self, context, instance, host_moref_value):
         """vMotion the instance onto host_moref, if possible
 


### PR DESCRIPTION
When spawning a big VM in nova-bigvm-enabled regions, the CUSTOM_BIGVM resource gets updated to have reserved=1 to indicate that this resource is done being used and nova-bigvm is supposed to clean it up.
This does not happen during live-migrations, which leads to a used and no longer usable CUSTOM_BIGVM resource that nova-bigvm does not clean up.

We're now calling _clean_up_after_special_spawning() in post_live_migration_at_destination() which will set the reserved CUSTOM_BIGVM on the resource provider.

Change-Id: I192209d90603c43cb0c1bb4cb32e55c6638d9a3e