### PR TITLE
[scheduler] Fix HvRamClassWeigher config loading

### DIFF
--- a/nova/scheduler/weights/hv_ram_class.py
+++ b/nova/scheduler/weights/hv_ram_class.py
@@ -39,7 +39,7 @@ class HvRamClassWeigher(weights.BaseHostWeigher, HypervisorSizeMixin):
     def _load_classes(self):
         """Split out from __init__() to be able to unit-test better"""
         config_weights = CONF.filter_scheduler.hv_ram_class_weights_gib
-        classes = [(int(ram * 1024), float(weight))
+        classes = [(int(ram) * 1024, float(weight))
                    for ram, weight in config_weights.items()]
 
         self._classes = sorted(classes, key=itemgetter(0), reverse=True)

--- a/nova/tests/unit/scheduler/weights/test_weights_hv_ram_class.py
+++ b/nova/tests/unit/scheduler/weights/test_weights_hv_ram_class.py
@@ -108,3 +108,13 @@ class HvRamClassWeigherTestCase(test.NoDBTestCase):
                     'host0', 'host6',
                     'host1', 'host3']
         self.assertEqual(expected, [h.obj.host for h in weighed_hosts])
+
+    def test_load_classes_handles_strings(self):
+        """We get strings from the config file"""
+        CONF.set_override('hv_ram_class_weights_gib',
+                          {'1024': '1', '3027': '0.5'},
+                          group='filter_scheduler')
+        self.weighers[0]._load_classes()
+
+        self.assertEqual({1024 * 1024: 1.0, 3027 * 1024: 0.5},
+                         dict(self.weighers[0]._classes))


### PR DESCRIPTION
The config comes in as strings and we multiplied that string by 1024 instead of first converting it to int and then multiplying by 1024 to make it MiB.

Change-Id: I6f3a06303652e1160e990b2f9574ef5dbbf198f1
fixup-for: Ia042e466544b73b8dd15ee7231d3baf1da6069a1