### PR TITLE
Use cpu_arch extra-spec to identify flavors as BM

### DIFF
--- a/nova/objects/flavor.py
+++ b/nova/objects/flavor.py
@@ -697,12 +697,6 @@ class FlavorList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def get_by_id(cls, context, ids):
 
-        def is_baremetal(extra_specs):
-            for spec in extra_specs:
-                if spec.key == 'quota:separate' and spec.value == 'true':
-                    return True
-            return False
-
         query = Flavor._flavor_get_query_from_db(context).\
             filter_by(disabled=False).\
             filter(api_models.Flavors.id.in_(ids))
@@ -710,5 +704,5 @@ class FlavorList(base.ObjectListBase, base.NovaObject):
         res = {}
         for x in query:
             res.update({x.id: {'name': 'instances_' + x.name,
-                               'baremetal': is_baremetal(x.extra_specs)}})
+                               'baremetal': utils.is_baremetal_flavor(x)}})
         return res

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -1579,10 +1579,9 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
             flavor_info = jsonutils.loads(db_flavor[0])
             flavor = objects.Flavor.obj_from_primitive(
                                                 flavor_info['cur'])
-            separate = flavor.extra_specs.get('quota:separate')
             instance_types[flavor.id] = {
                 'name': 'instances_' + flavor.name,
-                'baremetal': separate == 'true'
+                'baremetal': utils.is_baremetal_flavor(flavor)
             }
 
     @staticmethod
@@ -1602,7 +1601,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
             # Bad hack, but works
             instance_types[old_flavor.id] = {
                 'name': 'instances_' + old_flavor.name,
-                'baremetal': len(old_flavor.extra_specs) > 0
+                'baremetal': utils.is_baremetal_flavor(old_flavor)
             }
 
     @staticmethod


### PR DESCRIPTION
... when listing flavors & when recovering deleted flavor info.

Use the nova.utils method instead of looking for quota:separate,
because we will use that extra-spec for non-baremetal flavors as well
going forward.
