### PR TITLE
Schedule big VMs to hosts in DRS-disabled clusters

### DIFF
--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -452,6 +452,15 @@ all clusters in the environment.
 Example: "vmx-13" for vSphere 6.5.
 Versions can be looked up here: https://kb.vmware.com/s/article/1003746
 """),
+    cfg.BoolOpt('drs_disabled_stack_vms',
+                default=True,
+                help="""
+Configures the spawning behaviour when DRS is disabled in a cluster.
+
+When this option is enabled and DRS is set to `disabled`, the VMs will
+be stacked by choosing the fullest host still having enough resources free
+to fit that VM.
+"""),
 ]
 
 vmwareapi_driver_opts = [

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2848,7 +2848,8 @@ class VMwareAPIVMTestCase(test.TestCase,
     def _mock_get_stats_from_cluster_per_host(self,
                                               memory_mb_reserved=0):
         return {
-            'host1': {
+            'host-1': {
+                'name': 'host1',
                 'available': True,
                 'vcpus': 16,
                 'vcpus_used': 0,
@@ -2859,7 +2860,8 @@ class VMwareAPIVMTestCase(test.TestCase,
                 'cpu_info': {},
                 'cpu_mhz': 1800,
             },
-            'host2': {
+            'host-2': {
+                'name': 'host2',
                 'available': True,
                 'vcpus': 16,
                 'vcpus_used': 0,

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -1292,7 +1292,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
 
             call_method.assert_called_once_with(mock.ANY, 'CreateVM_Task',
                 'fake_vm_folder', config='fake_config_spec',
-                pool='fake_res_pool_ref')
+                pool='fake_res_pool_ref', host=None)
             wait_for_task.assert_called_once_with('fake_create_vm_task')
 
     @mock.patch.object(vm_util.LOG, 'warning')

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -2275,7 +2275,8 @@ class VMwareVMOpsTestCase(test.TestCase):
                 self._instance, image_info, extra_specs)
             build_virtual_machine.assert_called_once_with(
                 self._instance, self._context, image_info, vi.datastore, [],
-                extra_specs, self._get_metadata(), 'fake_vm_folder')
+                extra_specs, self._get_metadata(), 'fake_vm_folder',
+                host_ref=None)
             enlist_image.assert_called_once_with(image_info.image_id,
                                                  vi.datastore, vi.dc_info.ref)
             fetch_image.assert_called_once_with(self._context, vi)
@@ -2341,7 +2342,7 @@ class VMwareVMOpsTestCase(test.TestCase):
             build_virtual_machine.assert_called_once_with(
                 self._instance, self._context, image_info, vi.datastore, [],
                 extra_specs, self._get_metadata(is_image_used=False),
-                'fake_vm_folder')
+                'fake_vm_folder', host_ref=None)
             volumeops.attach_root_volume.assert_called_once_with(
                 connection_info1, self._instance, vi.datastore.ref,
                 constants.ADAPTER_TYPE_IDE)
@@ -2397,7 +2398,7 @@ class VMwareVMOpsTestCase(test.TestCase):
         build_virtual_machine.assert_called_once_with(
             self._instance, self._context, image_info, vi.datastore, [],
             extra_specs, self._get_metadata(is_image_used=False),
-            'fake_vm_folder')
+            'fake_vm_folder', host_ref=None)
 
     def test_get_ds_browser(self):
         cache = self._vmops._datastore_browser_mapping
@@ -2683,11 +2684,13 @@ class VMwareVMOpsTestCase(test.TestCase):
                                   return_value=None),
                 mock.patch.object(self._vmops,
                                   '_fetch_image_from_other_datastores',
-                                  return_value=None)
+                                  return_value=None),
+                mock.patch.object(cluster_util,
+                                  "is_drs_enabled", return_value=True),
         ) as (_wait_for_task, _call_method, _generate_uuid, _fetch_image,
               _get_img_svc, _get_inventory_path, _get_extra_specs,
               _get_instance_metadata, file_size, _find_image_template_vm,
-              _fetch_image_from_other_datastores):
+              _fetch_image_from_other_datastores, _is_drs_enabled):
             self._vmops.spawn(self._context, self._instance, image,
                               injected_files='fake_files',
                               admin_password='password',
@@ -2714,7 +2717,8 @@ class VMwareVMOpsTestCase(test.TestCase):
                     self._instance,
                     'fake_vm_folder',
                     'fake_create_spec',
-                    self._cluster.resourcePool)
+                    self._cluster.resourcePool,
+                    host_ref=None)
             mock_get_and_set_vnc_config.assert_called_once_with(
                 self._session.vim.client.factory,
                 self._instance,
@@ -2943,7 +2947,8 @@ class VMwareVMOpsTestCase(test.TestCase):
             self._instance, image_info, extra_specs)
         build_virtual_machine.assert_called_once_with(self._instance,
                                                       self._context,
-            image_info, vi.datastore, [], extra_specs, metadata, 'fake-folder')
+            image_info, vi.datastore, [], extra_specs, metadata, 'fake-folder',
+            host_ref=None)
         enlist_image.assert_called_once_with(image_info.image_id,
                                              vi.datastore, vi.dc_info.ref)
         fetch_image.assert_called_once_with(self._context, vi)
@@ -4076,3 +4081,93 @@ class VMwareVMOpsTestCase(test.TestCase):
         extra_specs = self._vmops._get_extra_specs(
             specced_flavor({'trait:CUSTOM_NUMASIZE_C48_M729': 'forbidden'}))
         self.assertEqual(extra_specs.numa_prefer_ht, '')
+
+    def _test_stack_vm_to_host_if_needed(self, instance_memory_mb,
+                                         hosts, expected):
+        with test.nested(
+                mock.patch.object(vm_util,
+                                  'get_stats_from_cluster_per_host',
+                                  return_value=hosts),
+                mock.patch.object(cluster_util, 'is_drs_enabled',
+                                  return_value=False),
+        ) as (_get_stats_from_cluster_per_host, _is_drs_enabled):
+            instance = self._instance.obj_clone()
+            instance.memory_mb = instance_memory_mb
+
+            if expected is None:
+                self.assertRaises(exception.InstanceUnacceptable,
+                                  self._vmops._stack_vm_to_host_if_needed,
+                                  instance)
+                return
+
+            host_ref = self._vmops._stack_vm_to_host_if_needed(instance)
+
+            _get_stats_from_cluster_per_host.assert_called_once_with(
+                self._session, self._cluster.obj)
+            _is_drs_enabled.assert_called_once_with(self._session,
+                                                    self._cluster.obj)
+            self.assertEqual(expected, host_ref.value if host_ref else None)
+
+    @ddt.unpack
+    @ddt.data(
+        (512, 'host-2'),
+        (1024, 'host-2'),
+        (2048, 'host-2'),
+        (2560, 'host-1'),
+        (3072, None))
+    def test_stack_vm_to_host_if_needed(self, requested_mb, expected):
+        hosts = {
+            'host-1': {
+                'name': 'host2',
+                'available': True,
+                'memory_mb': 4096,
+                'memory_mb_used': 1024,
+                'memory_mb_reserved': 512,
+            },
+            'host-2': {
+                'name': 'host2',
+                'available': True,
+                'memory_mb': 4096,
+                'memory_mb_used': 1024,
+                'memory_mb_reserved': 1024,
+            },
+            # host-3 is the fullest one but never gets
+            # elected because it has available: False
+            'host-3': {
+                'name': 'host3',
+                'available': False,
+                'memory_mb': 4096,
+                'memory_mb_used': 1560,
+                'memory_mb_reserved': 1024,
+            }
+        }
+
+        self._test_stack_vm_to_host_if_needed(
+            requested_mb, hosts, expected)
+
+    @ddt.unpack
+    @ddt.data(
+        (1024, 'host-1'),
+        (2048, 'host-1'))
+    def test_stack_vm_to_host_if_needed_equal_hosts(
+            self, requested_mb, expected):
+        hosts = {
+            'host-1': {
+                'name': 'host1',
+                'available': True,
+                'memory_mb': 4096,
+                'memory_mb_used': 1024,
+                'memory_mb_reserved': 1024,
+            },
+            'host-2': {
+                'name': 'host2',
+                'available': True,
+                'memory_mb': 4096,
+                'memory_mb_used': 1024,
+                'memory_mb_reserved': 1024,
+            }
+        }
+        # the hosts have the same fill-grade, so the order they
+        # were returned into is not changed
+        self._test_stack_vm_to_host_if_needed(
+            requested_mb, hosts, expected)

--- a/nova/virt/vmwareapi/host.py
+++ b/nova/virt/vmwareapi/host.py
@@ -124,9 +124,9 @@ class VCState(object):
             "numa_topology": None,
         }
 
-        for host, stats in per_host_stats.items():
-            data[host] = self._merge_stats(host, stats, defaults)
-
+        for host_ref_value, info in per_host_stats.items():
+            data[info["name"]] = self._merge_stats(info["name"], info,
+                                                   defaults)
         cluster_stats = vm_util.aggregate_stats_from_cluster(per_host_stats)
         cluster_stats["hypervisor_type"] = self._hypervisor_type
         cluster_stats["hypervisor_version"] = self._hypervisor_version

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1738,6 +1738,7 @@ def _process_host_stats(obj, host_reservations_map):
     stats = {
         "available": (not runtime_summary.inMaintenanceMode and
                       runtime_summary.connectionState == "connected"),
+        "name": host_props["name"],
         "vcpus": threads,
         "vcpus_used": 0,
         "memory_mb": mem_mb,
@@ -1748,11 +1749,21 @@ def _process_host_stats(obj, host_reservations_map):
 
     _set_hypervisor_type_and_version(stats, host_props)
     _set_host_reservations(stats, host_reservations_map, obj.obj)
-    return host_props["name"], stats
+    return vutil.get_moref_value(obj.obj), stats
 
 
 def get_stats_from_cluster_per_host(session, cluster):
-    """Get the resource stats per host of a cluster."""
+    """Get the hosts with the underlying resource stats.
+
+    Returns a dict containing the host mo-ref value as key, and the
+    host properties and stats as a value.
+    {
+      'host-1234': {
+        'name': 'node001',
+        'memory_mb': 2048,
+      }
+    }
+    """
     host_mors, host_reservations_map = \
         get_hosts_and_reservations_for_cluster(session, cluster)
 
@@ -1926,13 +1937,14 @@ def get_vmdk_adapter_type(adapter_type):
 @loopingcall.RetryDecorator(
     max_retry_count=20, inc_sleep_time=2, max_sleep_time=20,
     exceptions=(vexc.VimFaultException,))
-def create_vm(session, instance, vm_folder, config_spec, res_pool_ref):
+def create_vm(session, instance, vm_folder, config_spec, res_pool_ref,
+              host_ref=None):
     """Create VM on ESX host."""
     LOG.debug("Creating VM on the ESX host", instance=instance)
     vm_create_task = session._call_method(
         session.vim,
         "CreateVM_Task", vm_folder,
-        config=config_spec, pool=res_pool_ref)
+        config=config_spec, pool=res_pool_ref, host=host_ref)
     try:
         task_info = session._wait_for_task(vm_create_task)
     except vexc.VMwareDriverException:


### PR DESCRIPTION
We want to be able to stack VMs instead of spreading them (i.e. bin packing), but DRS does not support that.

We implement a simple bin packing algorithm in the vmwareapi driver that choses the fullest host still having enough resources free.

We determine the fullest host by looking at the free memory because this feature will only run on hana-exclusive BBs where we deal with NUMA-aligned VMs, and because we currently don't know the number of vCPUs used within a cluster.

There are 2 conditions for the stacking to happen
1. DRS is set to disabled.
2. [vmware]/drs_disabled_stack_vms is set to True

Change-Id: Icffda14ecc43f6cb6e0d31842ae2e0ca5e513eb3