### PR TITLE
Add hardware-versioned quota based on Flavor extra_specs

### DIFF
--- a/nova/api/validation/extra_specs/quota.py
+++ b/nova/api/validation/extra_specs/quota.py
@@ -210,6 +210,18 @@ EXTRA_SPEC_VALIDATORS.extend([
             'type': bool,
         },
     ),
+    base.ExtraSpecValidator(
+        name=utils.QUOTA_HW_VERSION_KEY,
+        description=(
+            "Consume hardware version specific cores/ram quota i.e. "
+            "hw_version_{hw_version}_cores and hw_version_{hw_version}_ram. "
+            "if unset, unspecific cores/ram are consumed "
+        ),
+        value={
+            'type': int,
+            'min': 1,
+        }
+    )
 ])
 
 

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -1582,7 +1582,9 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
             separate = flavor.extra_specs.get(utils.QUOTA_SEPARATE_KEY)
             instance_types[flavor.id] = {
                 'name': flavor.name,
-                'separate': separate == 'true'
+                'separate': separate == 'true',
+                'hw_version':
+                    flavor.extra_specs.get(utils.QUOTA_HW_VERSION_KEY),
             }
 
     @staticmethod
@@ -1664,6 +1666,12 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
             if itype and itype.get('separate', False):
                 t_name = f"instances_{itype['name']}"
                 counts[t_name] = counts.get(t_name, 0) + instance_count
+            elif itype and (hw_version := itype.get('hw_version')):
+                counts['instances'] += instance_count
+                cores_name = f"hw_version_{hw_version}_cores"
+                counts[cores_name] = counts.get(cores_name, 0) + int(cores)
+                ram_name = f"hw_version_{hw_version}_ram"
+                counts[ram_name] = counts.get(ram_name, 0) + int(ram)
             else:
                 counts['instances'] += instance_count
                 counts['cores'] += int(cores)

--- a/nova/objects/quotas.py
+++ b/nova/objects/quotas.py
@@ -358,10 +358,10 @@ class Quotas(base.NovaObject):
                     total = count['user'][res] + deltas[res]
                     check_kwargs['user_values'][res] = total
             # NOTE(jkulik): We need special sauce here, because we won't report
-            # any instances_* resource in our count_as_dict() if the
-            # project/user doesn't use any instance of that type. We still need
-            # to report this resource as it's in the deltas.
-            if resource.startswith('instances_'):
+            # any instances_*/hw_version_* resource in our count_as_dict() if
+            # the project/user doesn't use any instance of that type. We still
+            # need to report this resource as it's in the deltas.
+            if resource.startswith(('instances_', 'hw_version_')):
                 if resource not in check_kwargs['project_values']:
                     check_kwargs['project_values'][resource] = deltas[resource]
                 if resource not in check_kwargs['user_values']:

--- a/nova/tests/unit/compute/test_compute_utils.py
+++ b/nova/tests/unit/compute/test_compute_utils.py
@@ -1437,7 +1437,7 @@ class ComputeUtilsQuotaTestCase(test.TestCase):
                                usages={'instances': 1, 'cores': 1, 'ram': 512},
                                overs=overs)
         e = exception.OverQuota(**over_quota_args)
-        fake_flavor = objects.Flavor(vcpus=1, memory_mb=512)
+        fake_flavor = objects.Flavor(vcpus=1, memory_mb=512, extra_specs={})
         instance_num = 1
         proj_count = {'instances': 1, 'cores': 1, 'ram': 512}
         user_count = proj_count.copy()
@@ -1464,7 +1464,7 @@ class ComputeUtilsQuotaTestCase(test.TestCase):
         # Return no per-user quota.
         mock_get.return_value = {'project_id': self.context.project_id,
                                  'user_id': self.context.user_id}
-        fake_flavor = objects.Flavor(vcpus=1, memory_mb=512)
+        fake_flavor = objects.Flavor(vcpus=1, memory_mb=512, extra_specs={})
         compute_utils.check_num_instances_quota(
             self.context, fake_flavor, 1, 1)
         deltas = {'instances': 1, 'cores': 1, 'ram': 512}
@@ -1484,7 +1484,8 @@ class ComputeUtilsQuotaTestCase(test.TestCase):
             mock_get.return_value = {'project_id': self.context.project_id,
                                      'user_id': self.context.user_id,
                                      resource: 5}
-            fake_flavor = objects.Flavor(vcpus=1, memory_mb=512)
+            fake_flavor = objects.Flavor(vcpus=1, memory_mb=512,
+                                         extra_specs={})
             compute_utils.check_num_instances_quota(
                 self.context, fake_flavor, 1, 1)
             deltas = {'instances': 1, 'cores': 1, 'ram': 512}

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -91,6 +91,7 @@ BIGVM_EXCLUSIVE_TRAIT = 'CUSTOM_HANA_EXCLUSIVE_HOST'
 
 QUOTA_SEPARATE_KEY = 'quota:separate'
 QUOTA_INSTANCE_ONLY_KEY = 'quota:instance_only'
+QUOTA_HW_VERSION_KEY = 'quota:hw_version'
 
 _FILE_CACHE = {}
 


### PR DESCRIPTION
We want to support adding cores/ram quota for different hardware versions. Reading the `quota:hw_version` property from all flavors' `extra_specs`, we build a list of supported hardware versions and create quota resources of the form `cores_{hw_version}`.

Change-Id: Ic7725f49a788188e3b1f046ed857c582b2646819