### PR TITLE
[vmware] delete template VMs with invalid size

### DIFF
--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -30,6 +30,7 @@ from oslo_utils import units
 from oslo_vmware import exceptions as vexc
 from oslo_vmware.image_transfer import image_pull_from_url
 from oslo_vmware import rw_handles
+from oslo_vmware import vim_util as vutil
 
 from nova import exception
 from nova.i18n import _
@@ -51,6 +52,9 @@ IMAGE_API = glance.API()
 QUEUE_BUFFER_SIZE = 10
 NFC_LEASE_UPDATE_PERIOD = 60  # update NFC lease every 60sec.
 CHUNK_SIZE = 64 * units.Ki  # default chunk size for image transfer
+
+# VMDK images having this size are considered invalid/incomplete downloads
+INVALID_VMDK_SIZE = 4096000
 
 
 class VMwareImage(object):
@@ -399,6 +403,10 @@ def fetch_image_stream_optimized(context, instance, session, vm_name,
     LOG.info("Downloaded image file data %(image_ref)s",
              {'image_ref': instance.image_ref}, instance=instance)
     vmdk = vm_util.get_vmdk_info(session, imported_vm_ref)
+    if not ensure_valid_template_vm(session,
+                                    imported_vm_ref,
+                                    vmdk.capacity_in_bytes):
+        raise vexc.ImageTransferException("Incomplete VMDK download.")
     vm_util.mark_vm_as_template(session, instance, imported_vm_ref)
     return vmdk.capacity_in_bytes, vmdk.path
 
@@ -592,3 +600,22 @@ def upload_image_stream_optimized(context, image_id, instance, session,
 
     LOG.debug("Uploaded image %s to the Glance image server", image_id,
               instance=instance)
+
+
+def ensure_valid_template_vm(session, templ_vm_ref, vmdk_size):
+    """Deletes an invalid template VM by checking the vmdk_size."""
+    if vmdk_size != INVALID_VMDK_SIZE:
+        return True
+
+    try:
+        LOG.warning("Deleting invalid template VM %s",
+                    vutil.get_moref_value(templ_vm_ref))
+        destroy_task = session._call_method(
+            session.vim,
+            "Destroy_Task",
+            templ_vm_ref)
+        session._wait_for_task(destroy_task)
+    except Exception:
+        LOG.exception("Failed to delete the template VM %s",
+                      vutil.get_moref_value(templ_vm_ref))
+    return False

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -771,6 +771,9 @@ class VMwareVMOps(object):
     def _cache_vm_image_from_template(self, vi, templ_vm_ref):
         LOG.debug("Caching VDMK from template VM", instance=vi.instance)
         vmdk = vm_util.get_vmdk_info(self._session, templ_vm_ref)
+        if not images.ensure_valid_template_vm(
+                self._session, templ_vm_ref, vmdk.capacity_in_bytes):
+            return False
         # The size of the image is different from the size of the virtual disk.
         # We want to use the latter. On vSAN this is the only way to get this
         # size because there is no VMDK descriptor.
@@ -974,6 +977,11 @@ class VMwareVMOps(object):
             tmp_vi.datastore = ds
             other_templ_vm_ref = self._find_image_template_vm(tmp_vi)
             if other_templ_vm_ref:
+                vmdk = vm_util.get_vmdk_info(self._session, other_templ_vm_ref)
+                if not images.ensure_valid_template_vm(
+                        self._session, other_templ_vm_ref,
+                        vmdk.capacity_in_bytes):
+                    continue
                 rel_spec = vm_util.relocate_vm_spec(
                     client_factory,
                     res_pool=self._root_resource_pool,
@@ -1011,6 +1019,21 @@ class VMwareVMOps(object):
                 return templ_vm_ref
 
     def _fetch_image_if_missing(self, context, vi):
+        max_attempts = 3
+        image_available = None
+        for i in range(max_attempts):
+            try:
+                image_available = self._do_fetch_image_if_missing(context, vi)
+                if image_available:
+                    return
+            except vexc.ImageTransferException:
+                LOG.exception("Image download attempt failed (%s / %s)",
+                              i + 1, max_attempts)
+
+        if not image_available:
+            raise exception.ImageUnacceptable(reason="Incomplete download")
+
+    def _do_fetch_image_if_missing(self, context, vi):
         image_prepare, image_fetch, image_cache = self._get_image_callbacks(vi)
         LOG.debug("Processing image %s", vi.ii.image_id, instance=vi.instance)
 
@@ -1027,6 +1050,17 @@ class VMwareVMOps(object):
                     ds_browser,
                     vi.cache_image_folder,
                     vi.cache_image_path.basename)
+                if (image_available and ds_util.file_size(
+                        self._session,
+                        ds_browser,
+                        vi.cache_image_folder,
+                        vi.cache_image_path.basename) ==
+                        images.INVALID_VMDK_SIZE):
+                    LOG.warning("Deleting invalid VMDK %s",
+                                vi.cache_image_path)
+                    ds_util.file_delete(self._session, vi.cache_image_path,
+                                        vi.dc_info.ref)
+                    image_available = False
 
             if not image_available:
                 # no matter if image_as_template is set, we can use the
@@ -1063,11 +1097,14 @@ class VMwareVMOps(object):
                 if tmp_dir_loc:
                     self._delete_datastore_file(str(tmp_dir_loc),
                                                 vi.dc_info.ref)
+                image_available = True
 
             # The size of the sparse image is different from the size of the
             # virtual disk. We want to use the latter.
             if vi.ii.disk_type == constants.DISK_TYPE_SPARSE:
                 self._update_image_size(vi)
+
+            return image_available
 
     def _create_and_attach_thin_disk(self, instance, vm_ref, dc_info, size,
                                      adapter_type, path):


### PR DESCRIPTION
There were a lot of occurrences where broken / interrupted image downloads laid out 3.91MiB (4096000 bytes) vmdk files.

We now treat this size as an INVALID_VMDK_SIZE and we delete any cached template VM or vmdk file having that size.

Change-Id: Id2cded69fd88f2d208dcb3421d5744f6291856a2