### PR TITLE
Bin-pack big VMs across clusters

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -532,6 +532,14 @@ Possible values:
 * An integer or float value, where the value corresponds to the multipler
   ratio for this weigher.
 """),
+    cfg.FloatOpt("hana_binpack_weight_multiplier",
+        default=1.0,
+        help="""
+Multiplier used for weighing HANA/BigVM flavors only.
+
+A positive value will stack/bin-pack the instances, while a negative value
+will spread them.
+"""),
     cfg.FloatOpt("cpu_weight_multiplier",
         default=1.0,
         help="""

--- a/nova/scheduler/filters/hana_memory_max_unit_filter.py
+++ b/nova/scheduler/filters/hana_memory_max_unit_filter.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_log import log as logging
+
+import nova.conf
+from nova.scheduler import filters
+from nova.scheduler import utils
+from nova.utils import BIGVM_EXCLUSIVE_TRAIT
+
+LOG = logging.getLogger(__name__)
+
+CONF = nova.conf.CONF
+
+
+class HANAMemoryMaxUnitFilter(filters.BaseHostFilter):
+    """Memory max unit filter that runs only on HANA/BigVM flavors
+
+    This filter is used to filter out those hosts which don't have
+    enough memory reported by memory_mb_max_unit to fit the flavor.
+    """
+
+    RUN_ON_REBUILD = False
+
+    def host_passes(self, host_state, spec_obj):
+        trait = f"trait:{BIGVM_EXCLUSIVE_TRAIT}"
+        extra_specs = spec_obj.flavor.extra_specs
+        if extra_specs.get(trait) != "required":
+            return True
+
+        memory_mb_max_unit = utils.get_memory_mb_max_unit(host_state)
+
+        if memory_mb_max_unit is None:
+            return True
+
+        if memory_mb_max_unit >= spec_obj.memory_mb:
+            return True
+
+        LOG.info("%(host_state)s with memory_mb_max_unit = "
+                 "%(memory_mb_max_unit)s doesn't have a node with enough "
+                 "free RAM to fit a VM with memory_mb = %(memory_mb)s",
+                 {"host_state": host_state,
+                  "memory_mb_max_unit": memory_mb_max_unit,
+                  "memory_mb": spec_obj.memory_mb})
+        return False

--- a/nova/scheduler/utils.py
+++ b/nova/scheduler/utils.py
@@ -1512,3 +1512,14 @@ def is_non_vmware_spec(spec_obj):
             return True
 
     return False
+
+
+def get_memory_mb_max_unit(host_state):
+    """Gets the memory_mb_max_unit stat reported by a HostState
+
+    This is a stat reported by the VMware compute hosts and
+    represents the free RAM of the freest host in the cluster.
+
+    Returns None if the stat is missing
+    """
+    return host_state.stats.get("memory_mb_max_unit")

--- a/nova/scheduler/weights/hana_binpack.py
+++ b/nova/scheduler/weights/hana_binpack.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+HANA/BigVM Bin-Packing Weigher.
+
+This only runs for flavors having trait:CUSTOM_HANA_EXCLUSIVE_HOST required.
+It stacks these VMs by the memory_mb_max_unit reported by the host, where
+hosts with a smaller value get a bigger weight.
+"""
+from oslo_log import log as logging
+
+import nova.conf
+from nova.scheduler import utils
+from nova.scheduler import weights
+from nova.utils import BIGVM_EXCLUSIVE_TRAIT
+
+CONF = nova.conf.CONF
+
+LOG = logging.getLogger(__name__)
+
+
+class HANABinPackWeigher(weights.BaseHostWeigher):
+
+    def weight_multiplier(self, host_state):
+        """Override the weight multiplier."""
+        return -1 * utils.get_weight_multiplier(
+            host_state, 'hana_binpack_weight_multiplier',
+            CONF.filter_scheduler.hana_binpack_weight_multiplier)
+
+    def _weigh_object(self, host_state, weight_properties):
+        """We want stacking to be the default."""
+        memory_mb_max_unit = utils.get_memory_mb_max_unit(host_state)
+        if memory_mb_max_unit is None:
+            return 0
+
+        trait = f"trait:{BIGVM_EXCLUSIVE_TRAIT}"
+        extra_specs = weight_properties.flavor.extra_specs
+        if extra_specs.get(trait) == "required":
+            return memory_mb_max_unit
+
+        return 0

--- a/nova/tests/unit/scheduler/filters/test_hana_memory_max_unit_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_hana_memory_max_unit_filter.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import ddt
+import mock
+
+from nova import objects
+from nova.scheduler.filters import hana_memory_max_unit_filter
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+@ddt.ddt
+class TestHANAMemoryMaxUnitFilter(test.NoDBTestCase):
+    def setUp(self):
+        super(TestHANAMemoryMaxUnitFilter, self).setUp()
+        self.filt_cls = (
+            hana_memory_max_unit_filter.HANAMemoryMaxUnitFilter())
+
+    def test_passes(self):
+        host = fakes.FakeHostState('host1', 'compute', {
+            'stats': {'memory_mb_max_unit': 2048}
+        })
+        extra_specs = {'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'required'}
+
+        flavor = objects.Flavor(memory_mb=1024,
+                                extra_specs=extra_specs)
+
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            flavor=flavor)
+
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_not_pass_too_big_flavor(self):
+        host = fakes.FakeHostState('host1', 'compute', {
+            'stats': {'memory_mb_max_unit': 2048}
+        })
+        extra_specs = {'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'required'}
+
+        flavor = objects.Flavor(memory_mb=2048 + 1,
+                                extra_specs=extra_specs)
+
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            flavor=flavor)
+
+        self.assertFalse(self.filt_cls.host_passes(host, spec_obj))
+
+    @ddt.data({},
+              {'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'forbidden'})
+    def test_passes_non_hana(self, extra_specs):
+        host = fakes.FakeHostState('host1', 'compute', {
+            'stats': {'memory_mb_max_unit': 2048}
+        })
+
+        flavor = objects.Flavor(memory_mb=3072,
+                                extra_specs=extra_specs)
+
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            flavor=flavor)
+
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))
+
+    def test_passes_no_maxunit(self):
+        host = fakes.FakeHostState('host1', 'compute', {
+            'stats': {}
+        })
+        extra_specs = {'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'required'}
+
+        flavor = objects.Flavor(memory_mb=3072,
+                                extra_specs=extra_specs)
+
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            flavor=flavor)
+
+        self.assertTrue(self.filt_cls.host_passes(host, spec_obj))

--- a/nova/tests/unit/scheduler/weights/test_hana_binpack.py
+++ b/nova/tests/unit/scheduler/weights/test_hana_binpack.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import ddt
+
+from unittest import mock
+
+from nova import objects
+from nova.scheduler import weights
+from nova.scheduler.weights import hana_binpack
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+@ddt.ddt
+class HANABingPackWeigherTestCase(test.NoDBTestCase):
+    def setUp(self):
+        super(HANABingPackWeigherTestCase, self).setUp()
+        self.weight_handler = weights.HostWeightHandler()
+        self.weighers = [hana_binpack.HANABinPackWeigher()]
+        self._hana_spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            flavor=objects.Flavor(extra_specs={
+                'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'required'
+            }))
+
+    def _get_weighed_host(self, hosts, weight_properties=None,
+                          extra_specs=None):
+        if weight_properties is None:
+            weight_properties = objects.RequestSpec(
+                context=mock.sentinel.ctx,
+                flavor=objects.Flavor(extra_specs=extra_specs or {}))
+        return self.weight_handler.get_weighed_objects(self.weighers,
+                hosts, weight_properties)[0]
+
+    def _get_all_hosts(self):
+        host_values = [
+            ('host1', 'node1', {'stats': {'memory_mb_max_unit': 3072}}),
+            ('host2', 'node2', {'stats': {'memory_mb_max_unit': 8192}}),
+            ('host3', 'node3', {'stats': {'memory_mb_max_unit': 1024}}),
+            ('host4', 'node4', {'stats': {'memory_mb_max_unit': 512}})
+        ]
+        return [fakes.FakeHostState(host, node, values)
+                for host, node, values in host_values]
+
+    def test_default_of_stacking_first(self):
+        hostinfo_list = self._get_all_hosts()
+        # host4 should win:
+        weighed_host = self._get_weighed_host(hostinfo_list,
+                                              self._hana_spec_obj)
+        self.assertEqual('host4', weighed_host.obj.host)
+
+    def test_multiplier(self):
+        self.flags(hana_binpack_weight_multiplier=2.0,
+                   group='filter_scheduler')
+        hostinfo_list = self._get_all_hosts()
+        # host4 should win:
+        weighed_host = self._get_weighed_host(hostinfo_list,
+                                              self._hana_spec_obj)
+        self.assertEqual('host4', weighed_host.obj.host)
+
+    def test_multiplier_zero(self):
+        self.flags(hana_binpack_weight_multiplier=0.0,
+                   group='filter_scheduler')
+        hostinfo_list = self._get_all_hosts()
+        weighed_host = self._get_weighed_host(hostinfo_list,
+                                              self._hana_spec_obj)
+        # first host will win:
+        self.assertEqual('host1', weighed_host.obj.host)
+
+    def test_negative_multiplier(self):
+        self.flags(hana_binpack_weight_multiplier=-1.0,
+                   group='filter_scheduler')
+        hostinfo_list = self._get_all_hosts()
+        weighed_host = self._get_weighed_host(hostinfo_list,
+                                              self._hana_spec_obj)
+        # spreading instead of stacking, host2 should win
+        self.assertEqual('host2', weighed_host.obj.host)
+
+    @ddt.data({},
+              {'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'forbidden'})
+    def test_normal_flavor(self, extra_specs):
+        hostinfo_list = self._get_all_hosts()
+        # first host will win:
+        weighed_host = self._get_weighed_host(hostinfo_list,
+                                              extra_specs=extra_specs)
+        self.assertEqual('host1', weighed_host.obj.host)
+        self.assertEqual(0, weighed_host.weight)
+
+    def test_no_memory_mb_max_unit(self):
+        attrs = {'stats': {}}
+        host_list = [fakes.FakeHostState('host1', 'node1', attrs),
+                     fakes.FakeHostState('host2', 'node2', attrs)]
+        weighed_host = self._get_weighed_host(host_list,
+                                              self._hana_spec_obj)
+        self.assertEqual('host1', weighed_host.obj.host)
+        self.assertEqual(0, weighed_host.weight)

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2375,6 +2375,9 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.assertEqual(
                 [("i686", "vmware", "hvm"), ("x86_64", "vmware", "hvm")],
                 stats['supported_instances'])
+        max_unit = stats['stats']['memory_mb_max_unit']
+        # memory_mb_used = fake.HostSystem.overallMemoryUsage = 500
+        self.assertEqual(max_unit, 1024 - 500)
 
     @mock.patch('nova.virt.vmwareapi.ds_util.get_available_datastores')
     def test_update_provider_tree(self, mock_get_avail_ds):

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -394,7 +394,31 @@ class VMwareVCDriver(driver.ComputeDriver):
                                       CONF.reserved_host_cpus)
         stats["cpu_info"] = jsonutils.dumps(stats['cpu_info'], sort_keys=True)
 
+        # Report additional stats which will be stored in the
+        # ComputeNode.stats dict and will be available to the scheduler
+        if nodename == self._nodename:
+            stats["stats"] = self._get_cluster_stats(host_stats)
+
         return stats
+
+    def _get_cluster_stats(self, host_stats):
+        # memory_mb_max_unit represents the free memory of the freest host
+        # available in the cluster. Can be used by the scheduler to determine
+        # if the cluster can accommodate a big VM.
+        memory_mb_max_unit = 0
+        for nodename, resources in host_stats.items():
+            # Skip the cluster node
+            if nodename == self._nodename:
+                continue
+            memory_mb_free = (resources['memory_mb'] -
+                              resources['memory_mb_used'] -
+                              resources['memory_mb_reserved'])
+            if memory_mb_max_unit < memory_mb_free:
+                memory_mb_max_unit = memory_mb_free
+
+        return {
+            "memory_mb_max_unit": memory_mb_max_unit
+        }
 
     def get_available_resource(self, nodename):
         """Retrieve resource info.


### PR DESCRIPTION
Bin-pack big VMs across clusters

hana_* flavors cannot move automatically through DRS on spawning
and thus we need any VM going to a CUSTOM_HANA_EXCLUSIVE_HOST
cluster to be placed by Nova by filling the fullest nodes first.

Clusters now report memory_mb_max_unit representing the free
memory of the most free host in the cluster.

HANAMemoryMaxUnitFilter uses memory_mb_max_unit to filter out
hosts which don't have enough memory_mb_max_unit to fit the VM.

HANABinPackWeigher stacks hana VMs across the clusters.
It can be controlled via the configuration property
[filter_scheduler] hana_binpack_weight_multiplier where positive
values increase the stacking.

Change-Id: Ia1cc1e59b391bd83741e72b7e9462c810f2be2d0