### PR TITLE
FCD related fixes

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_volumeops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_volumeops.py
@@ -456,7 +456,8 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
         connection_info = {'data': {'id': fcd_id,
                                     'ds_ref_val': ds_ref_val,
                                     'adapter_type': adapter_type},
-                           'volume_id': 'volume-fake-id'}
+                           'volume_id': 'volume-fake-id',
+                           'serial': 'volume-fake-id'}
         instance = mock.sentinel.instance
 
         if adapter_type == constants.ADAPTER_TYPE_IDE and not powered_off:

--- a/nova/tests/unit/virt/vmwareapi/test_volumeops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_volumeops.py
@@ -435,17 +435,17 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
 
     @mock.patch.object(vm_util, 'get_vm_ref')
     @mock.patch.object(vm_util, 'get_vm_state')
-    @mock.patch.object(vm_util, 'get_vmdk_volume_disk')
+    @mock.patch.object(vm_util, 'get_vmdk_backed_disk_device')
     @mock.patch.object(vm_util, '_create_fcd_id_obj')
     @mock.patch.object(vm_util, 'detach_fcd')
     def _test__detach_volume_fcd(
-            self, detach_fcd, _create_fcd_id_obj, get_vmdk_volume_disk,
+            self, detach_fcd, _create_fcd_id_obj, get_vmdk_backed_disk_device,
             get_vm_state, get_vm_ref, adapter_type=constants.ADAPTER_TYPE_IDE,
             powered_off=True):
         vm_ref = mock.sentinel.vm_ref
         get_vm_ref.return_value = vm_ref
         _create_fcd_id_obj.return_value = mock.sentinel.disk_id
-        get_vmdk_volume_disk.return_value = mock.sentinel.device
+        get_vmdk_backed_disk_device.return_value = mock.sentinel.device
 
         if adapter_type == constants.ADAPTER_TYPE_IDE:
             get_vm_state.return_value = (
@@ -455,6 +455,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
         ds_ref_val = mock.sentinel.ds_ref_val
         connection_info = {'data': {'id': fcd_id,
                                     'ds_ref_val': ds_ref_val,
+                                    'volume_id': 'volume-fake-id',
                                     'adapter_type': adapter_type}}
         instance = mock.sentinel.instance
 
@@ -468,19 +469,12 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
             with mock.patch.object(self._volumeops, '_session') as session, \
                     mock.patch.object(self._volumeops, 'detach_disk_from_vm') \
                         as detach_disk_from_vm:
-                fcd_obj = mock.Mock()
-                fcd_obj.config.backing.filePath = mock.sentinel.filepath
-                fcd_obj.config.name = f"volume-{uuids.volume}"
-                session.invoke_api.return_value = fcd_obj
-
+                disk_to_detach = mock.sentinel.device
+                session.invoke_api.return_value = [disk_to_detach]
                 self._volumeops._detach_volume_fcd(connection_info, instance)
                 detach_fcd.assert_not_called()
-                session.invoke_api.assert_called_once_with(session.vim,
-                    'RetrieveVStorageObject',
-                    session.vim.service_content.vStorageObjectManager,
-                    id=mock.sentinel.disk_id, datastore=ds_ref_val)
                 detach_disk_from_vm.assert_called_once_with(vm_ref, instance,
-                    mock.sentinel.device, volume_uuid=uuids.volume)
+                    mock.sentinel.device, volume_uuid='volume-fake-id')
 
     @ddt.data(
         constants.ADAPTER_TYPE_BUSLOGIC, constants.ADAPTER_TYPE_IDE,

--- a/nova/tests/unit/virt/vmwareapi/test_volumeops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_volumeops.py
@@ -455,8 +455,8 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
         ds_ref_val = mock.sentinel.ds_ref_val
         connection_info = {'data': {'id': fcd_id,
                                     'ds_ref_val': ds_ref_val,
-                                    'volume_id': 'volume-fake-id',
-                                    'adapter_type': adapter_type}}
+                                    'adapter_type': adapter_type},
+                           'volume_id': 'volume-fake-id'}
         instance = mock.sentinel.instance
 
         if adapter_type == constants.ADAPTER_TYPE_IDE and not powered_off:

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -704,6 +704,7 @@ class VMwareVolumeOps(object):
                 raise exception.Invalid(_('%s does not support disk '
                                           'hotplug.') % adapter_type)
         volume_uuid = connection_info['volume_id']
+        # Copy the volume_id to data, as we need this for device search
         data['volume_id'] = volume_uuid
         device = self._get_vmdk_backed_disk_device(vm_ref, data)
         self.detach_disk_from_vm(vm_ref, instance, device,

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -703,7 +703,7 @@ class VMwareVolumeOps(object):
             if state != power_state.SHUTDOWN:
                 raise exception.Invalid(_('%s does not support disk '
                                           'hotplug.') % adapter_type)
-        volume_uuid = data['volume_id']
+        volume_uuid = connection_info['volume_id']
         device = self._get_vmdk_backed_disk_device(vm_ref, data)
         self.detach_disk_from_vm(vm_ref, instance, device,
                                  volume_uuid=volume_uuid)

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -704,6 +704,7 @@ class VMwareVolumeOps(object):
                 raise exception.Invalid(_('%s does not support disk '
                                           'hotplug.') % adapter_type)
         volume_uuid = connection_info['volume_id']
+        data['volume_id'] = volume_uuid
         device = self._get_vmdk_backed_disk_device(vm_ref, data)
         self.detach_disk_from_vm(vm_ref, instance, device,
                                  volume_uuid=volume_uuid)

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -26,6 +26,7 @@ from nova.compute import power_state
 import nova.conf
 from nova import exception
 from nova.i18n import _
+from nova.virt import block_device
 from nova.virt import driver
 from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import ds_util
@@ -703,7 +704,7 @@ class VMwareVolumeOps(object):
             if state != power_state.SHUTDOWN:
                 raise exception.Invalid(_('%s does not support disk '
                                           'hotplug.') % adapter_type)
-        volume_uuid = connection_info['volume_id']
+        volume_uuid = block_device.get_volume_id(connection_info)
         # Copy the volume_id to data, as we need this for device search
         data['volume_id'] = volume_uuid
         device = self._get_vmdk_backed_disk_device(vm_ref, data)


### PR DESCRIPTION
- Skip FCD type volumes and don't try to delete the shadow vm: 
  The fcd implementation lookups volumes from a catalog using 2 identifiers fcd_id and ds_mo_ref, so no shadowvm are present for this kind of volumes, and so the deletion would run into exception due to non-existing shadowvm ....

- Fix/simplify fcd detach:
  If a cinder volume gets relocated to a different datastore, the connection_info cached in the bdm is still referring the old ds, so the lookup of fcd_obj fails due to the out-of-date ds_mo_ref. Even in migration the volume_id stays a stable id, so this fix is just lookups the volume using the volume_id on the backing.uuid instead of lookup of fcd_obj to figure out the vmdk_path The terminate_connection to cinder does not result a refreshed connection_info, and calling the initiate_connection on detach would probably be not idea...