### PR TITLE
quota: Build instances_$FLAVOR_NAME in a single place

### DIFF
--- a/nova/objects/flavor.py
+++ b/nova/objects/flavor.py
@@ -709,6 +709,6 @@ class FlavorList(base.ObjectListBase, base.NovaObject):
 
         res = {}
         for x in query:
-            res.update({x.id: {'name': 'instances_' + x.name,
+            res.update({x.id: {'name': x.name,
                                'separate': is_separate(x.extra_specs)}})
         return res

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -1581,7 +1581,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
                                                 flavor_info['cur'])
             separate = flavor.extra_specs.get('quota:separate')
             instance_types[flavor.id] = {
-                'name': 'instances_' + flavor.name,
+                'name': flavor.name,
                 'separate': separate == 'true'
             }
 
@@ -1601,7 +1601,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         for old_flavor in flavor_query:
             # Bad hack, but works
             instance_types[old_flavor.id] = {
-                'name': 'instances_' + old_flavor.name,
+                'name': old_flavor.name,
                 'separate': len(old_flavor.extra_specs) > 0
             }
 
@@ -1662,7 +1662,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
                 # Also this should not happen.
                 LOG.error('Unknown instance type id %s', type_id)
             if itype and itype.get('separate', False):
-                t_name = itype['name']
+                t_name = f"instances_{itype['name']}"
                 counts[t_name] = counts.get(t_name, 0) + instance_count
             else:
                 counts['instances'] += instance_count


### PR DESCRIPTION
Instead of returning "instances_$FLAVOR_NAME" during finding the instance types during quota counting we only return the actual flavor name. There are (currently) three different places that return instance type data. Having the generation of "instances_$FLAVOR_NAME" in a single place seems better. Additionally, the attribute "name" returned by the three places does not reflect that it contains the "separate" name and not the instance type name.

Change-Id: Idc007bea83f9198783dcd1af2d53d8934f28ede1