### PR TITLE
vmware: Fix CPU reservation host-stats access

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -427,7 +427,7 @@ class VMwareVMOps(object):
             if memory_reserved_mb > 0:
                 extra_specs.memory_limits.reservation = memory_reserved_mb
             if cpu_reserved > 0:
-                cluster_host_stats = self._vc_state.get_host_stats().values()
+                cluster_host_stats = self._vc_state.get_host_stats()
                 cluster_stats = cluster_host_stats.get(
                                         self._vc_state._cluster_node_name, {})
                 # NOTE(jakobk): CPU reservations are given in MHz, not in


### PR DESCRIPTION
> 'dict_values' object has no attribute 'get'

Fixup-for: I907278b970d5ac658223e821b46461eeac2a5275
Change-Id: I10df0902ea6ff27d1d32d20bf6c6d8c597184e22
