### PR TITLE
Fix `Quotas.check_deltas()` after overhaul

### DIFF
--- a/nova/objects/quotas.py
+++ b/nova/objects/quotas.py
@@ -363,9 +363,9 @@ class Quotas(base.NovaObject):
             # to report this resource as it's in the deltas.
             if resource.startswith('instances_'):
                 if resource not in check_kwargs['project_values']:
-                    check_kwargs['project_values'][resource] = deltas[res]
+                    check_kwargs['project_values'][resource] = deltas[resource]
                 if resource not in check_kwargs['user_values']:
-                    check_kwargs['user_values'][resource] = deltas[res]
+                    check_kwargs['user_values'][resource] = deltas[resource]
         if check_project_id is not None:
             check_kwargs['project_id'] = check_project_id
         if check_user_id is not None:


### PR DESCRIPTION
In "quota:separate: Fix Quotas.check_deltas()" we changed the code but failed to use the right variables so it created a `KeyError` afterwards if the resource was not used by the project, yet.

Change-Id: I57414cd78343bb26e603628f19e72bbc0fac2984