### PR TITLE
quota: Treat missing instance_* usage key as 0

### DIFF
--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -1087,7 +1087,7 @@ def upsize_quota_delta(new_flavor, old_flavor):
 
 
 def get_headroom(quotas, usages, deltas):
-    headroom = {res: quotas[res] - usages[res]
+    headroom = {res: quotas[res] - usages.get(res, 0)
                 for res in quotas.keys()}
     # If quota_cores is unlimited [-1]:
     # - set cores headroom based on instances headroom:


### PR DESCRIPTION
The `usage` kwarg in the `OverQuota` exception does not contain instance-separate usages if it's not used yet.

Change-Id: Ic2bb1e7b9223ca47e1ce944d7bbb711de277e31b