### PR TITLE
Decommissioning weigher

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -518,6 +518,20 @@ Possible values:
 * Multiple integer keys mapping to integer or float values, where the value
   corresponds to a weight and the integer to an upper bound of memory.
 """),
+    cfg.FloatOpt("decommissioning_weight_multiplier",
+                 default=1.0,
+                 help="""
+Multiplier used for de-prioritizing hosts having the CUSTOM_DECOMMISSIONING
+trait associated.
+
+A positive value will de-prioritize the hosts, while a negative value
+will increase their priority.
+
+Possible values:
+
+* An integer or float value, where the value corresponds to the multipler
+  ratio for this weigher.
+"""),
     cfg.FloatOpt("cpu_weight_multiplier",
         default=1.0,
         help="""

--- a/nova/scheduler/host_manager.py
+++ b/nova/scheduler/host_manager.py
@@ -155,6 +155,9 @@ class HostState(object):
         # Host cell (v2) membership
         self.cell_uuid = cell_uuid
 
+        # Traits from Placement
+        self.traits = None
+
         self.updated = None
 
     def update(self, compute=None, service=None, aggregates=None,
@@ -262,6 +265,9 @@ class HostState(object):
 
         # update failed_builds counter reported by the compute
         self.failed_builds = int(self.stats.get('failed_builds', 0))
+
+    def update_from_provider_summary(self, provider_summary):
+        self.traits = provider_summary.get('traits')
 
     def consume_from_request(self, spec_obj):
         """Incrementally update host state from a RequestSpec object."""

--- a/nova/scheduler/manager.py
+++ b/nova/scheduler/manager.py
@@ -656,8 +656,10 @@ class SchedulerManager(manager.Manager):
         compute_uuids = None
         if provider_summaries is not None:
             compute_uuids = list(provider_summaries.keys())
-        return self.host_manager.get_host_states_by_uuids(
+        hosts = self.host_manager.get_host_states_by_uuids(
             context, compute_uuids, spec_obj)
+        return self._update_hosts_from_provider_summaries(
+            hosts, provider_summaries)
 
     def update_aggregates(self, ctxt, aggregates):
         """Updates HostManager internal aggregates information.
@@ -698,3 +700,20 @@ class SchedulerManager(manager.Manager):
         """
         self.host_manager.sync_instance_info(
             context, host_name, instance_uuids)
+
+    @staticmethod
+    def _update_hosts_from_provider_summaries(hosts, provider_summaries):
+        """Updates the 'hosts' generator with provider_summaries
+
+        :returns: a new generator with the updated host states
+        """
+        if not provider_summaries:
+            return hosts
+
+        def _update_host(host_state):
+            provider_summary = provider_summaries.get(host_state.uuid)
+            if provider_summary:
+                host_state.update_from_provider_summary(provider_summary)
+            return host_state
+
+        return (_update_host(host) for host in hosts)

--- a/nova/scheduler/weights/decommissioning.py
+++ b/nova/scheduler/weights/decommissioning.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Decommissioning Weigher.
+
+De-prioritise the hosts which are being decommissioned, by always placing
+them the last in the queue.
+Allow such hosts to be scheduled only when absolutely necessary, i.e.
+when all other hosts are full.
+"""
+
+import nova.conf
+from nova.scheduler import utils
+from nova.scheduler import weights
+
+CONF = nova.conf.CONF
+
+DECOM_TRAIT = 'CUSTOM_DECOMMISSIONING'
+
+
+class DecommissioningWeigher(weights.BaseHostWeigher):
+
+    def weight_multiplier(self, host_state):
+        """Override the weight multiplier."""
+        return -1 * utils.get_weight_multiplier(
+            host_state, 'decommissioning_weight_multiplier',
+            CONF.filter_scheduler.decommissioning_weight_multiplier)
+
+    def _weigh_object(self, host_state, weight_properties):
+        """De-prioritise decommissioning hosts."""
+        if host_state.traits and DECOM_TRAIT in host_state.traits:
+            return 1.0
+        return 0.0

--- a/nova/tests/unit/scheduler/weights/test_weights_decommissioning.py
+++ b/nova/tests/unit/scheduler/weights/test_weights_decommissioning.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+Tests For Decommissioning weigher.
+"""
+
+from nova.scheduler import weights
+from nova.scheduler.weights import decommissioning as decom
+from nova.scheduler.weights.decommissioning import DECOM_TRAIT
+from nova.scheduler.weights import ram
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+class DecommissioningWeigherTestCase(test.NoDBTestCase):
+    def setUp(self):
+        super(DecommissioningWeigherTestCase, self).setUp()
+        self.weight_handler = weights.HostWeightHandler()
+        self.weighers = [ram.RAMWeigher(), decom.DecommissioningWeigher()]
+
+    def _get_weighed_host(self, hosts, weight_properties=None):
+        if weight_properties is None:
+            weight_properties = {}
+        return self.weight_handler.get_weighed_objects(self.weighers,
+                hosts, weight_properties)[0]
+
+    def test_decommissioning_weigher(self):
+        host1 = fakes.FakeHostState('host1', 'node1', {
+            'free_ram_mb': 1024 * 1024
+        })
+        host1.traits = [DECOM_TRAIT]
+        host2 = fakes.FakeHostState('host2', 'node2', {
+            'free_ram_mb': 1024 * 2048
+        })
+        host2.traits = [DECOM_TRAIT]
+
+        host3 = fakes.FakeHostState('host3', 'node3', {
+            'free_ram_mb': 1024
+        })
+
+        hosts = [host1, host2, host3]
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, hosts, {})
+
+        # host1,host2 are decommissioning, host3 should win
+        self.assertEqual('host3', weighed_hosts[0].obj.host)
+        # order determined by other weighers should not be changed
+        self.assertEqual('host2', weighed_hosts[1].obj.host)
+        self.assertEqual('host1', weighed_hosts[2].obj.host)
+
+    def test_decommissioning_weight_multiplier(self):
+        self.flags(decommissioning_weight_multiplier=0.0,
+                   group='filter_scheduler')
+
+        host1 = fakes.FakeHostState('host1', 'node1', {
+            'free_ram_mb': 1024 * 1024
+        })
+        host1.traits = [DECOM_TRAIT]
+        host2 = fakes.FakeHostState('host2', 'node2', {
+            'free_ram_mb': 1024 * 2048
+        })
+        host2.traits = [DECOM_TRAIT]
+        host3 = fakes.FakeHostState('host3', 'node3', {
+            'free_ram_mb': 1024 * 1024
+        })
+
+        hosts = [host1, host2, host3]
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, hosts, {})
+
+        # decommissioning multiplier set to 0, host2 should win
+        self.assertEqual('host2', weighed_hosts[0].obj.host)
+
+    def test_decommissioning_ignoring_normal_hosts(self):
+        host1 = fakes.FakeHostState('host1', 'node1', {
+            'free_ram_mb': 1024 * 1024
+        })
+        host1.traits = ['CUSTOM_TRAIT']
+        host2 = fakes.FakeHostState('host2', 'node2', {
+            'free_ram_mb': 1024 * 2048
+        })
+
+        hosts = [host1, host2]
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, hosts, {})
+
+        # no CUSTOM_DECOMMISSIONING trait, host2 should win
+        self.assertEqual('host2', weighed_hosts[0].obj.host)


### PR DESCRIPTION
> De-prioritise the hosts which are being decommissioned, by always placing
> them the last in the queue.
> Allow such hosts to be scheduled only when absolutely necessary, i.e.
> when all other hosts are full.

See Individual commit messages