### PR TITLE
vmware: Account for hyperthreading when reserving CPUs

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2860,7 +2860,7 @@ class VMwareAPIVMTestCase(test.TestCase,
                 'memory_mb_used': 0,
                 'memory_mb_reserved': memory_mb_reserved,
                 'cpu_info': {},
-                'cpu_mhz': 1800,
+                'cpu_mhz': 900,
             },
             'host2': {
                 'available': True,
@@ -2871,7 +2871,7 @@ class VMwareAPIVMTestCase(test.TestCase,
                 'memory_mb_used': 0,
                 'memory_mb_reserved': 0,
                 'cpu_info': {},
-                'cpu_mhz': 1800,
+                'cpu_mhz': 900,
             },
         }
 

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -79,7 +79,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                 'memory_mb_used': 2,
                 'memory_mb_reserved': 1,
                 'cpu_info': VMwareVMUtilTestCase._expected_cpu_info(),
-                'cpu_mhz': 1800,
+                'cpu_mhz': 900,
             }
 
     def test_aggregate_stats_from_cluster(self):
@@ -192,7 +192,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                     'memory_mb_reserved': 0,
                     'max_mem_mb_per_host': 4096,
                     'vm_reservable_memory_ratio': 1.0,
-                    'cpu_mhz': 1800,
+                    'cpu_mhz': 900,
                 }
             self.assertEqual(expected_stats, result)
 
@@ -258,7 +258,7 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
             'memory_mb_reserved': 512 + 256,    # both
             'max_mem_mb_per_host': 4096 - 256,  # host1
             'vm_reservable_memory_ratio': 1.0,
-            'cpu_mhz': 1800,
+            'cpu_mhz': 900,
         }
         self._test_get_stats_from_cluster(expected_stats=expected)
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -434,7 +434,7 @@ class VMwareVMOps(object):
                 # number-of-CPUs, so we have to translate here.
                 cluster_host_mhz = cluster_stats.get('cpu_mhz', 0)
                 extra_specs.cpu_limits.reservation = \
-                    cpu_reserved * cluster_host_mhz
+                    round(cpu_reserved * cluster_host_mhz)
         extra_specs.cpu_limits.validate()
         extra_specs.memory_limits.validate()
         extra_specs.disk_io_limits.validate()


### PR DESCRIPTION
VMware reports CPU resources in MHz, but this is in relation to the
physical CPU count, not the hyperthreaded CPU count. Check for the
pCPU-to-vCPU ratio (which is either 1 = "no hyperthreading",
or 2 = "hyperthreaded") and adjust the per-CPU MHz number of the host.

The code is very defensive: The first division is inverted as to avoid
a second division in the other line. If either `threads` or `pcpus` is
0 then 1 will be substituted so that the ratio will be 1 in the case
of missing or zero stats.

Fixup-for: I907278b970d5ac658223e821b46461eeac2a5275
Change-Id: I5cb406e53b32b71a802a178b5b7c635657779822
