### PR TITLE
vmware: Fix unrescue by resetting boot device order

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -1977,30 +1977,46 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         mock_reconfigure.assert_called_once_with(session, 'fake-ref', mock.ANY)
 
     def test_get_vm_boot_spec(self):
-        self._test_get_vm_boot_spec(efi=False)
+        self._test_get_vm_boot_spec(efi=False, reset=False)
 
     def test_get_vm_boot_spec_efi(self):
-        self._test_get_vm_boot_spec(efi=True)
+        self._test_get_vm_boot_spec(efi=True, reset=False)
 
-    def _test_get_vm_boot_spec(self, efi):
-        disk = fake.VirtualDisk()
-        disk.key = 7
+    def test_get_vm_boot_reset_spec(self):
+        self._test_get_vm_boot_spec(efi=False, reset=True)
+
+    def test_get_vm_boot_reset_spec_efi(self):
+        self._test_get_vm_boot_spec(efi=True, reset=True)
+
+    def _test_get_vm_boot_spec(self, efi, reset):
+        if not reset:
+            disk = fake.VirtualDisk()
+            disk.key = 7
+        else:
+            disk = None
+
         fake_factory = fake.FakeFactory()
         result = vm_util.get_vm_boot_spec(fake_factory,
                                           disk, efi)
         expected = fake_factory.create('ns0:VirtualMachineConfigSpec')
-        boot_disk = fake_factory.create(
-            'ns0:VirtualMachineBootOptionsBootableDiskDevice')
-        boot_disk.deviceKey = disk.key
+
         boot_options = fake_factory.create('ns0:VirtualMachineBootOptions')
-        boot_options.bootOrder = [boot_disk]
         expected.bootOptions = boot_options
+
+        if reset:
+            boot_options.bootOrder = []
+        else:
+            boot_disk = fake_factory.create(
+                'ns0:VirtualMachineBootOptionsBootableDiskDevice')
+            boot_disk.deviceKey = disk.key
+            boot_options.bootOrder = [boot_disk]
 
         if efi:
             opt = fake_factory.create('ns0:OptionValue')
             opt.key = 'efi.quickBoot.enabled'
-            opt.value = 'FALSE'
+            opt.value = 'FALSE' if not reset else ''
             expected.extraConfig = [opt]
+
         self.assertEqual(expected, result)
 
     def _get_devices(self, filename):

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -526,27 +526,36 @@ def create_serial_port_spec(client_factory):
     return dev_spec
 
 
-def get_vm_boot_spec(client_factory, device, is_efi=False):
+def get_vm_boot_spec(client_factory, device=None, is_efi=False):
     """Returns updated boot settings for the instance.
+
+    If device is set, we want to boot from a non-standard device (rescue disk)
 
     The boot order for the instance will be changed to have the
     input device as the boot disk.
 
     If "is_efi" is True, "quickBoot" will be disabled for the VM so it can
     actually see the rescue disk during the boot decision.
+
+    If device is unset, we restore the defaults.
     """
-    config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
-    boot_disk = client_factory.create(
-        'ns0:VirtualMachineBootOptionsBootableDiskDevice')
-    boot_disk.deviceKey = device.key
     boot_options = client_factory.create('ns0:VirtualMachineBootOptions')
-    boot_options.bootOrder = [boot_disk]
+
+    if device:
+        boot_disk = client_factory.create(
+            'ns0:VirtualMachineBootOptionsBootableDiskDevice')
+        boot_disk.deviceKey = device.key
+        boot_options.bootOrder = [boot_disk]
+    else:
+        boot_options.bootOrder = []
+
+    config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
     config_spec.bootOptions = boot_options
 
     if is_efi:
         opt = client_factory.create('ns0:OptionValue')
         opt.key = 'efi.quickBoot.enabled'
-        opt.value = 'FALSE'
+        opt.value = 'FALSE' if device else ''  # '' Clears the value
         config_spec.extraConfig = [opt]
 
     return config_spec

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2126,16 +2126,10 @@ class VMwareVMOps(object):
 
         firmware = vim_util.get_object_property(self._session, vm_ref,
                                                 'config.firmware')
-        if firmware == 'efi':
-            # Enable quickBoot again, since we only needed it to find the
-            # rescue disk
-            factory = self._session.vim.client.factory
-            config_spec = factory.create('ns0:VirtualMachineConfigSpec')
-            opt = factory.create('ns0:OptionValue')
-            opt.key = 'efi.quickBoot.enabled'
-            opt.value = ''  # an empty value deletes the option
-            config_spec.extraConfig = [opt]
-            vm_util.reconfigure_vm(self._session, vm_ref, config_spec)
+        factory = self._session.vim.client.factory
+        boot_spec = vm_util.get_vm_boot_spec(factory, is_efi=(
+            firmware == 'efi'))
+        vm_util.reconfigure_vm(self._session, vm_ref, boot_spec)
         if power_on:
             vm_util.power_on_instance(self._session, instance, vm_ref=vm_ref)
 


### PR DESCRIPTION
The device order persists, and may refer to another device. That breaks cloning the vm for the purpose of a snapshot, where the disk gets removed.

Squash-into: I64cf1cd4478a9c48a4cce723d224dac31edf85c6
Change-Id: I90d7890f6b10622b7a6efc8e988d7736a3e87df2