### PR TITLE
vmware: Default to 0 CPU-MHz with no HW-summary

### DIFF
--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1743,7 +1743,7 @@ def _process_host_stats(obj, host_reservations_map):
         "memory_mb": mem_mb,
         "memory_mb_used": getattr(stats_summary, "overallMemoryUsage", 0),
         "cpu_info": _host_props_to_cpu_info(host_props),
-        "cpu_mhz": getattr(hardware_summary, "cpuMhz"),
+        "cpu_mhz": getattr(hardware_summary, "cpuMhz", 0),
     }
 
     _set_hypervisor_type_and_version(stats, host_props)


### PR DESCRIPTION
Zero MHz will be ignored later in `aggregate_stats_from_cluster()` when calculating the cluster's median MHz value.

Change-Id: Ic06bb756d37e2d552c1b734b8600a6cdc08b3c08
