### PR TITLE
Fix update_scheduler_hints to support the legacy format

### DIFF
--- a/nova/objects/request_spec.py
+++ b/nova/objects/request_spec.py
@@ -370,7 +370,9 @@ class RequestSpec(base.NovaObject):
                 self.scheduler_hints is None):
             self._from_hints(scheduler_hints)
         else:
-            self.scheduler_hints.update(scheduler_hints)
+            self.scheduler_hints.update(
+                {hint: value if isinstance(value, list) else [value]
+                 for hint, value in scheduler_hints.items()})
 
     def get_scheduler_hint(self, hint_name, default=None):
         """Convenient helper for accessing a particular scheduler hint since

--- a/nova/tests/unit/objects/test_request_spec.py
+++ b/nova/tests/unit/objects/test_request_spec.py
@@ -287,6 +287,18 @@ class _TestRequestSpecObject(object):
         spec._from_hints(None)
         self.assertIsNone(spec.scheduler_hints)
 
+    def test_update_scheduler_hints(self):
+        spec = objects.RequestSpec(
+            scheduler_hints={'foo': ['1'],
+                             'bar': ['2'],
+                             'baz': ['5']})
+        spec.update_scheduler_hints({'foo': '2',
+                                     'bar': ['3']})
+        expected = {'foo': ['2'],
+                    'bar': ['3'],
+                    'baz': ['5']}
+        self.assertEqual(expected, spec.scheduler_hints)
+
     @mock.patch.object(objects.SchedulerLimits, 'from_dict')
     def test_from_primitives(self, mock_limits):
         spec_dict = {'instance_type': objects.Flavor(),


### PR DESCRIPTION
This function might get called with the legacy scheduler_hints structure where the values were not lists.

We now replicate the logic of _from_hints to convert any value to list of it's not already in this format.

Change-Id: I49eaec81aaca080c078b30d45960a11d630647d9