### PR TITLE
Add ResizeVcpuMaxUnitFilter for resizing to smaller flavors

### DIFF
--- a/nova/scheduler/filters/resize_vcpu_max_unit_filter.py
+++ b/nova/scheduler/filters/resize_vcpu_max_unit_filter.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_log import log as logging
+
+import nova.conf
+from nova import context as nova_context
+from nova import objects
+from nova.scheduler import filters
+from nova.scheduler import utils
+
+LOG = logging.getLogger(__name__)
+
+CONF = nova.conf.CONF
+
+
+class ResizeVcpuMaxUnitFilter(filters.BaseHostFilter):
+    """Filter for resizing to a smaller flavor in VMware.
+
+    This checks if the host can fit the current flavor of the
+    instance. Reason is that in VMware, when a VM is resized
+    to a smaller flavor, it's still being cloned with the
+    initial size to the destination host and only resized
+    afterward. If the original size had more vCPUs than
+    the new target host can manage, the clone will fail.
+    """
+
+    RUN_ON_REBUILD = False
+
+    def filter_all(self, filter_obj_list, spec_obj):
+        if utils.is_non_vmware_spec(spec_obj):
+            return filter_obj_list
+
+        if not utils.request_is_resize(spec_obj):
+            return filter_obj_list
+
+        context = nova_context.get_admin_context()
+        instance = objects.Instance.get_by_uuid(
+            context, spec_obj.instance_uuid,
+            expected_attrs=['flavor'])
+
+        # Only account for resizing to smaller flavors
+        if instance.flavor.vcpus <= spec_obj.vcpus:
+            return filter_obj_list
+
+        return [host_state for host_state in filter_obj_list
+                if self._host_passes(host_state, instance)]
+
+    @staticmethod
+    def _host_passes(host_state, instance):
+        vcpus_max = host_state.stats.get('vcpus_max_unit')
+
+        if not vcpus_max:
+            return False
+
+        if vcpus_max < instance.flavor.vcpus:
+            LOG.debug('%(host_state)s has vcpus_max_unit=%(vcpus_max)s, thus '
+                      'it cannot fit the instance with %(vcpus)s vCPUs.',
+                      {'host_state': host_state,
+                       'vcpus_max': vcpus_max,
+                       'vcpus': instance.flavor.vcpus})
+            return False
+
+        return True

--- a/nova/tests/unit/scheduler/filters/test_resize_vcpu_max_unit_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_resize_vcpu_max_unit_filter.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2024 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import ddt
+import mock
+
+from oslo_utils.fixture import uuidsentinel as uuids
+
+from nova import objects
+from nova.scheduler.filters import resize_vcpu_max_unit_filter
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+@ddt.ddt
+class TestResizeVcpuMaxUnitFilter(test.NoDBTestCase):
+    def setUp(self):
+        super(TestResizeVcpuMaxUnitFilter, self).setUp()
+        self.filt_cls = (
+            resize_vcpu_max_unit_filter.ResizeVcpuMaxUnitFilter())
+
+    @mock.patch('nova.scheduler.utils.is_non_vmware_spec', return_value=True)
+    def test_passes_non_vmware(self, non_vmware_spec):
+        hosts = [fakes.FakeHostState('host1', 'compute', {})]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx)
+
+        self.assertEqual(hosts, self.filt_cls.filter_all(hosts, spec_obj))
+        non_vmware_spec.assert_called_once_with(spec_obj)
+
+    @mock.patch('nova.scheduler.utils.is_non_vmware_spec', return_value=False)
+    @mock.patch('nova.scheduler.utils.request_is_resize', return_value=False)
+    def test_passes_non_resize(self, is_resize, non_vmware_spec):
+        hosts = [fakes.FakeHostState('host1', 'compute', {})]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx)
+
+        self.assertEqual(hosts, self.filt_cls.filter_all(hosts, spec_obj))
+        is_resize.assert_called_once_with(spec_obj)
+        non_vmware_spec.assert_called_once_with(spec_obj)
+
+    @ddt.data(4, 6)
+    def test_passes_bigger_flavor(self, vcpus):
+        hosts = [fakes.FakeHostState('host1', 'compute', {})]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            instance_uuid=uuids.instance,
+            flavor=objects.Flavor(vcpus=vcpus))
+
+        flavor = objects.Flavor(vcpus=4)
+        instance = objects.Instance(uuid=uuids.instance,
+                                    flavor=flavor)
+
+        admin_ctx = mock.sentinel.admin_context
+        with test.nested(
+                mock.patch('nova.objects.Instance.get_by_uuid',
+                           return_value=instance),
+                mock.patch('nova.scheduler.utils.is_non_vmware_spec',
+                           return_value=False),
+                mock.patch('nova.scheduler.utils.request_is_resize',
+                           return_value=True),
+                mock.patch('nova.context.get_admin_context',
+                           return_value=admin_ctx),
+        ) as (get_by_uuid, non_vmware_spec, is_resize, get_context):
+            self.assertEqual(hosts, self.filt_cls.filter_all(hosts, spec_obj))
+            get_by_uuid.assert_called_once_with(admin_ctx, uuids.instance,
+                                                expected_attrs=['flavor'])
+            is_resize.assert_called_once_with(spec_obj)
+            non_vmware_spec.assert_called_once_with(spec_obj)
+
+    def test_filters_hosts(self):
+        hosts = [
+            fakes.FakeHostState('host1', 'compute',
+                                {'stats': {'vcpus_max_unit': 2}}),
+            fakes.FakeHostState('host2', 'compute',
+                                {'stats': {'vcpus_max_unit': 4}}),
+            fakes.FakeHostState('host3', 'compute',
+                                {'stats': {'vcpus_max_unit': 6}}),
+            fakes.FakeHostState('host4', 'compute',
+                                {'stats': {}})
+        ]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            instance_uuid=uuids.instance,
+            flavor=objects.Flavor(vcpus=2))
+
+        flavor = objects.Flavor(vcpus=4)
+        instance = objects.Instance(uuid=uuids.instance,
+                                    flavor=flavor)
+
+        admin_ctx = mock.sentinel.admin_context
+        with test.nested(
+                mock.patch('nova.objects.Instance.get_by_uuid',
+                           return_value=instance),
+                mock.patch('nova.scheduler.utils.is_non_vmware_spec',
+                           return_value=False),
+                mock.patch('nova.scheduler.utils.request_is_resize',
+                           return_value=True),
+                mock.patch('nova.context.get_admin_context',
+                           return_value=admin_ctx),
+        ) as (get_by_uuid, non_vmware_spec, is_resize, get_context):
+            results = [h.host for h in
+                       self.filt_cls.filter_all(hosts, spec_obj)]
+            self.assertEqual(['host2', 'host3'], results)
+
+            get_by_uuid.assert_called_once_with(admin_ctx, uuids.instance,
+                                                expected_attrs=['flavor'])
+            is_resize.assert_called_once_with(spec_obj)
+            non_vmware_spec.assert_called_once_with(spec_obj)

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -406,6 +406,10 @@ class VMwareVCDriver(driver.ComputeDriver):
         # available in the cluster. Can be used by the scheduler to determine
         # if the cluster can accommodate a big VM.
         memory_mb_max_unit = 0
+        # vcpus_max_unit represents the vCPUs of a physical node from the
+        # cluster. It can be used to determine if a VM can be powered-on in
+        # this cluster, by comparing its flavor.vcpus to this value.
+        vcpus_max_unit = 0
         for nodename, resources in host_stats.items():
             # Skip the cluster node
             if nodename == self._nodename:
@@ -416,8 +420,13 @@ class VMwareVCDriver(driver.ComputeDriver):
             if memory_mb_max_unit < memory_mb_free:
                 memory_mb_max_unit = memory_mb_free
 
+            vcpus = resources['vcpus']
+            if vcpus_max_unit < vcpus:
+                vcpus_max_unit = vcpus_max_unit
+
         return {
-            "memory_mb_max_unit": memory_mb_max_unit
+            "memory_mb_max_unit": memory_mb_max_unit,
+            "vcpus_max_unit": vcpus_max_unit
         }
 
     def get_available_resource(self, nodename):


### PR DESCRIPTION
When resizing a VM, we create a clone of the original VM onto the new cluster/HV. During the clone, we specify minimal cpu/memory requirements as target. VMware does not use these minimal requirements during the clone but only after the clone. Therefore, resizing from having 288 to 192 VCPUs might not work if the target cluster cannot support 288 VCPUs.

The ResizeVcpuMaxUnitFilter looks at the vcpus_max_unit reported by each cluster, which is the amount of CPUs of an individual node, and makes sure the original VM size can still fit in the destination host, by comparing the current flavor.vcpus with that value.

Change-Id: I77aea8ed9b756bd5e0c857db87e2be595c4b55d2