### PR TITLE
vmware: Support disabled admission control

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/fake.py
+++ b/nova/tests/unit/virt/vmwareapi/fake.py
@@ -651,6 +651,8 @@ class ClusterComputeResource(ManagedObject):
         policy = None
         configuration.dasConfig.admissionControlPolicy = policy
         self.set("configuration.dasConfig.admissionControlPolicy", policy)
+        configuration.dasConfig.admissionControlEnabled = True
+        self.set("configuration.dasConfig.admissionControlEnabled", True)
 
         vm_list = DataObject()
         vm_list.ManagedObjectReference = []

--- a/nova/virt/vmwareapi/special_spawning.py
+++ b/nova/virt/vmwareapi/special_spawning.py
@@ -190,8 +190,9 @@ class _SpecialVmSpawningServer(object):
         group = self._get_group(cluster_config)
 
         failover_hosts = []
+        enabled = cluster_config.dasConfig.admissionControlEnabled
         policy = cluster_config.dasConfig.admissionControlPolicy
-        if policy and hasattr(policy, 'failoverHosts'):
+        if enabled and policy and hasattr(policy, 'failoverHosts'):
             failover_hosts = set(vutil.get_moref_value(h)
                                  for h in policy.failoverHosts)
 

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1775,7 +1775,9 @@ def get_stats_from_cluster_per_host(session, cluster):
 def get_hosts_and_reservations_for_cluster(session, cluster):
     # Get the Host and Resource Pool Managed Object Refs
     admission_policy_key = "configuration.dasConfig.admissionControlPolicy"
-    props = ["host", "resourcePool", admission_policy_key]
+    admission_enabled_key = "configuration.dasConfig.admissionControlEnabled"
+    props = ["host", "resourcePool", admission_policy_key,
+             admission_enabled_key]
     if CONF.vmware.hostgroup_reservations_json_file:
         props.append("configurationEx")
     prop_dict = session._call_method(vutil,
@@ -1786,8 +1788,9 @@ def get_hosts_and_reservations_for_cluster(session, cluster):
         return None, None
 
     failover_hosts = []
+    enabled = prop_dict.get(admission_enabled_key, True)
     policy = prop_dict.get(admission_policy_key)
-    if policy and hasattr(policy, 'failoverHosts'):
+    if enabled and policy and hasattr(policy, 'failoverHosts'):
         failover_hosts = set(h.value for h in policy.failoverHosts)
 
     group_ret = getattr(prop_dict.get('configurationEx'), 'group', None)


### PR DESCRIPTION
When the administrator disables admission control in vSphere, the property `admissionControlEnabled` gets set to `False` - the property `admissionControlPolicy` stays at its old value keeping the configuration in place. Therefore, to support disabling admission control, we have to fetch an additional property.

Change-Id: I9bd5319d00b46b089669d7869148e2e831d0b417