### PR TITLE
Read quota:separate from flavors

### DIFF
--- a/nova/api/openstack/compute/sap_admin_api.py
+++ b/nova/api/openstack/compute/sap_admin_api.py
@@ -25,6 +25,7 @@ from nova import exception
 from nova.i18n import _
 from nova import objects
 from nova.policies import sap_admin_api as sap_policies
+from nova.quota import QUOTAS
 
 
 # list of endpoints registered with _register_endpoint below
@@ -106,6 +107,21 @@ class SAPAdminApiController(wsgi.Controller):
                     usage[key] += value
 
         return {'project': aggregated}
+
+    @wsgi.response(202)
+    @wsgi.expected_errors(404)
+    @_register_endpoint('POST')
+    def clear_quota_resources_cache(self, req, body):
+        """Clears the cache used by the SAPQuotaEngine"""
+        context = req.environ['nova.context']
+        context.can(sap_policies.POLICY_ROOT % 'clear-quota-resources-cache')
+
+        # if we're not running with our custom quota engine for some reason
+        if not hasattr(QUOTAS, 'clear_cache'):
+            txt = 'Quota engine does not support cache clearing'
+            raise exc.HTTPNotFound(explanation=txt)
+
+        QUOTAS.clear_cache()
 
     @_register_endpoint('GET')
     def endpoints(self, req):

--- a/nova/api/validation/extra_specs/quota.py
+++ b/nova/api/validation/extra_specs/quota.py
@@ -15,6 +15,7 @@
 """Validators for ``quota`` namespaced extra specs."""
 
 from nova.api.validation.extra_specs import base
+from nova import utils
 
 
 EXTRA_SPEC_VALIDATORS = []
@@ -184,6 +185,32 @@ for stat in ('inbound', 'outbound'):
                 },
             )
         )
+
+
+# SAP custom quotas
+EXTRA_SPEC_VALIDATORS.extend([
+    base.ExtraSpecValidator(
+        name=utils.QUOTA_SEPARATE_KEY,
+        description=(
+            'if the flavor needs flavor-specific instances quota. '
+            'defaults to false'
+        ),
+        value={
+            'type': bool,
+        },
+    ),
+    base.ExtraSpecValidator(
+        name=utils.QUOTA_INSTANCE_ONLY_KEY,
+        description=(
+            "if set, the flavor does not consume cores/ram quota, only "
+            "instances quota. usually combined with "
+            f"{utils.QUOTA_SEPARATE_KEY}. defaults to false"
+        ),
+        value={
+            'type': bool,
+        },
+    ),
+])
 
 
 def register():

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3746,8 +3746,8 @@ class API:
             try:
                 res_deltas = {'cores': deltas.get('cores', 0),
                               'ram': deltas.get('ram', 0)}
-                # may have instances deltas if switching between
-                # quota:separate and not
+                # may have instances_ deltas if switching between
+                # QUOTA_SEPARATE_KEY and not
                 res_deltas.update(deltas)
                 objects.Quotas.check_deltas(context, res_deltas,
                                             project_id, user_id=user_id,

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -1072,14 +1072,14 @@ def upsize_quota_delta(new_flavor, old_flavor):
         deltas['ram'] = _quota_delta('memory_mb')
 
     # NOTE(jkulik): We need to add the instances_* resource only if we resize
-    # towards a quota:separate flavor, as we're interested in positive deltas
-    # only. Since we only need resource deltas, the old flavor having the same
-    # quota:separate between new and old flavor adds no delta.
+    # towards a QUOTA_SEPARATE_KEY flavor, as we're interested in positive
+    # deltas only. Since we only need resource deltas, the old flavor having
+    # the same QUOTA_SEPARATE_KEY between new and old flavor adds no delta.
     new_extra_specs = new_flavor.get('extra_specs', {})
-    new_separate = new_extra_specs.get('quota:separate') == 'true'
+    new_separate = new_extra_specs.get(utils.QUOTA_SEPARATE_KEY) == 'true'
     if new_separate:
         old_extra_specs = old_flavor.get('extra_specs', {})
-        old_separate = old_extra_specs.get('quota:separate') == 'true'
+        old_separate = old_extra_specs.get(utils.QUOTA_SEPARATE_KEY) == 'true'
         if not old_separate or new_flavor['name'] != old_flavor['name']:
             deltas[f"instances_{new_flavor['name']}"] = 1
 
@@ -1133,14 +1133,14 @@ def check_num_instances_quota(
     deltas = {'instances': max_count, 'cores': req_cores, 'ram': req_ram}
 
     quota_key_instances = 'instances'
-    if flavor.get('extra_specs', {}).get('quota:separate', 'false') == 'true':
+    if flavor.get('extra_specs', {}).get(utils.QUOTA_SEPARATE_KEY) == 'true':
         quota_key_instances = 'instances_' + flavor.name
         deltas[quota_key_instances] = max_count
         deltas['instances'] = 0
         deltas['cores'] = 0
         deltas['ram'] = 0
     reserve_cpu_ram = flavor.get('extra_specs', {}).get(
-        'quota:instance_only', 'false') != 'true'
+        utils.QUOTA_INSTANCE_ONLY_KEY) != 'true'
     if reserve_cpu_ram:
         deltas.update(cores=req_cores, ram=req_ram)
 

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -1063,7 +1063,17 @@ def upsize_quota_delta(new_flavor, old_flavor):
     :param old_flavor: the original instance type
     """
     def _quota_delta(resource):
-        return (new_flavor[resource] - old_flavor[resource])
+        if new_flavor.extra_specs.get(utils.QUOTA_INSTANCE_ONLY_KEY) == 'true':
+            new_count = 0
+        else:
+            new_count = new_flavor[resource]
+
+        if old_flavor.extra_specs.get(utils.QUOTA_INSTANCE_ONLY_KEY) == 'true':
+            old_count = 0
+        else:
+            old_count = old_flavor[resource]
+
+        return (new_count - old_count)
 
     deltas = {}
     if _quota_delta('vcpus') > 0:

--- a/nova/conf/quota.py
+++ b/nova/conf/quota.py
@@ -259,6 +259,15 @@ Operators who want to avoid the performance hit from the EXISTS queries should
 wait to set this configuration option to True until after they have completed
 their online data migrations via ``nova-manage db online_data_migrations``.
 """),
+    cfg.IntOpt('sap_resources_cache_time',
+        min=0,
+        default=600,
+        help="""
+Time in seconds to cache the resources dict
+
+This option configures how often we re-read the flavors from DB to update our
+quota resources based on their `extra_specs` properties.
+"""),
 ]
 
 

--- a/nova/objects/flavor.py
+++ b/nova/objects/flavor.py
@@ -32,6 +32,7 @@ from nova.notifications.objects import flavor as flavor_notification
 from nova import objects
 from nova.objects import base
 from nova.objects import fields
+from nova import utils
 
 
 OPTIONAL_FIELDS = ['extra_specs', 'projects']
@@ -699,7 +700,8 @@ class FlavorList(base.ObjectListBase, base.NovaObject):
 
         def is_separate(extra_specs):
             for spec in extra_specs:
-                if spec.key == 'quota:separate' and spec.value == 'true':
+                if spec.key == utils.QUOTA_SEPARATE_KEY \
+                        and spec.value == 'true':
                     return True
             return False
 

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -1579,7 +1579,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
             flavor_info = jsonutils.loads(db_flavor[0])
             flavor = objects.Flavor.obj_from_primitive(
                                                 flavor_info['cur'])
-            separate = flavor.extra_specs.get('quota:separate')
+            separate = flavor.extra_specs.get(utils.QUOTA_SEPARATE_KEY)
             instance_types[flavor.id] = {
                 'name': flavor.name,
                 'separate': separate == 'true'

--- a/nova/policies/sap_admin_api.py
+++ b/nova/policies/sap_admin_api.py
@@ -55,6 +55,17 @@ sap_admin_api_policies = [
             }
         ],
         scope_types=['system', 'project']),
+    policy.DocumentedRuleDefault(
+        name=POLICY_ROOT % 'clear-quota-resources-cache',
+        check_str=base.RULE_ADMIN_API,
+        description="Clear the cache of known resources in the quota engine",
+        operations=[
+            {
+                'method': 'POST',
+                'path': '/sap/clear_quota_resources_cache'
+            }
+        ],
+        scope_types=['system', 'project']),
 ]
 
 

--- a/nova/quota.py
+++ b/nova/quota.py
@@ -1134,7 +1134,7 @@ class SAPQuotaEngine(QuotaEngine):
     @_resources.setter
     def _resources(self, resources):
         self._original_resources = resources
-        self._cache.delete(self._CACHE_KEY)
+        self.clear_cache()
 
     def update_resources_from_flavors(self, resources):
         """Update the resources dict to contain flavor based resources
@@ -1153,6 +1153,9 @@ class SAPQuotaEngine(QuotaEngine):
         for resource_name in additional_resources:
             resources[resource_name] = SAPCustomResource(resource_name,
                 _instances_cores_ram_count, default=0)
+
+    def clear_cache(self):
+        self._cache.delete(self._CACHE_KEY)
 
 
 @api_db_api.context_manager.reader

--- a/nova/quota.py
+++ b/nova/quota.py
@@ -811,7 +811,7 @@ class BaseResource(object):
                      which specifies the default value of the quota
                      for this resource.
         :param default: Explicitly overwrite the default value. Used for
-                        handling dynamic resources e.g. via quota:separate.
+                        handling dynamic resources e.g. via QUOTA_SEPARATE_KEY.
         """
 
         self.name = name
@@ -886,7 +886,7 @@ class CountableResource(AbsoluteResource):
                      which specifies the default value of the quota
                      for this resource.
         :param default: Explicitly overwrite the default value. Used for
-                        handling dynamic resources e.g. via quota:separate.
+                        handling dynamic resources e.g. via QUOTA_SEPARATE_KEY
         """
 
         super(CountableResource, self).__init__(name, flag=flag,
@@ -1147,7 +1147,7 @@ class SAPQuotaEngine(QuotaEngine):
         for flavor in objects.FlavorList.get_all(ctx):
             extra_specs = flavor['extra_specs']
 
-            if extra_specs.get('quota:separate') == 'true':
+            if extra_specs.get(utils.QUOTA_SEPARATE_KEY) == 'true':
                 additional_resources.add(f"instances_{flavor.name}")
 
         for resource_name in additional_resources:

--- a/nova/tests/unit/scheduler/weights/test_weights_resize_same_host.py
+++ b/nova/tests/unit/scheduler/weights/test_weights_resize_same_host.py
@@ -22,6 +22,7 @@ from nova.scheduler import weights
 from nova.scheduler.weights import resize_same_host
 from nova import test
 from nova.tests.unit.scheduler import fakes
+from nova import utils
 from oslo_utils.fixture import uuidsentinel
 
 
@@ -36,7 +37,7 @@ class PreferSameHostOnResizeWeigherTestCase(test.NoDBTestCase):
         flavor_small = objects.Flavor(id=2, name='small',
                                       memory_mb=1024 * 256, extra_specs={})
         baremetal_extra_specs = {'capabilities:cpu_arch': 'x86_64',
-                                 'quota:separate': 'true'}
+                                 utils.QUOTA_SEPARATE_KEY: 'true'}
         flavor_bm_big = objects.Flavor(id=3, name='bm_big',
                                        memory_mb=1024 * 512,
                                        extra_specs=baremetal_extra_specs)

--- a/nova/tests/unit/test_policy.py
+++ b/nova/tests/unit/test_policy.py
@@ -370,6 +370,7 @@ class RealRolePolicyTestCase(test.NoDBTestCase):
 "os_compute_api:sap:endpoints:list",
 "os_compute_api:sap:in-cluster-vmotion",
 "os_compute_api:sap:usage-by-az",
+"os_compute_api:sap:clear-quota-resources-cache",
 )
 
         self.admin_or_owner_rules = (

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -89,6 +89,9 @@ NUMA_TRAIT_SPEC_PREFIX = 'trait:CUSTOM_NUMASIZE_'
 
 BIGVM_EXCLUSIVE_TRAIT = 'CUSTOM_HANA_EXCLUSIVE_HOST'
 
+QUOTA_SEPARATE_KEY = 'quota:separate'
+QUOTA_INSTANCE_ONLY_KEY = 'quota:instance_only'
+
 _FILE_CACHE = {}
 
 _SERVICE_TYPES = service_types.ServiceTypes()


### PR DESCRIPTION
This PR switches from using quota-class-sets to reading the Flavors' extra_specs. It also cleans up some parts belonging to `quota:separate` and `quota:instance_only` in the process.

Since the new information read from `extra_specs` is cached, we also add a custom API to clear the cache.

Please see the individual commits' messages for more information.