### PR TITLE
vmware: handle the ToolsUnavailableException on power_off

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2182,9 +2182,14 @@ class VMwareVMOps(object):
 
             LOG.debug("Soft shutdown instance, timeout: %d",
                      timeout, instance=instance)
-            self._session._call_method(self._session.vim,
-                                       "ShutdownGuest",
-                                       vm_ref)
+            try:
+                self._session._call_method(self._session.vim,
+                                           "ShutdownGuest",
+                                           vm_ref)
+            except vexc.ToolsUnavailableException:
+                LOG.info("Failed to _clean_shutdown the instance",
+                         instance=instance)
+                return False
 
             while timeout > 0:
                 wait_time = min(retry_interval, timeout)


### PR DESCRIPTION
Even though Nova checks if the VM has VMware tools running, this exception might still occur if the VMware tools stop running in the meantime.

We return False back, so that Nova continues to hard shutdown.

Change-Id: Ida4d6dfd2dab0ad0a382f7c98b69c8326414bdda