### PR TITLE
Fix filters relying on host stats integers

### DIFF
--- a/nova/scheduler/filters/resize_vcpu_max_unit_filter.py
+++ b/nova/scheduler/filters/resize_vcpu_max_unit_filter.py
@@ -60,7 +60,10 @@ class ResizeVcpuMaxUnitFilter(filters.BaseHostFilter):
 
     @staticmethod
     def _host_passes(host_state, instance):
-        vcpus_max = host_state.stats.get('vcpus_max_unit')
+        try:
+            vcpus_max = int(host_state.stats.get('vcpus_max_unit'))
+        except (TypeError, ValueError):
+            return False
 
         if not vcpus_max:
             return False

--- a/nova/scheduler/utils.py
+++ b/nova/scheduler/utils.py
@@ -1522,4 +1522,7 @@ def get_memory_mb_max_unit(host_state):
 
     Returns None if the stat is missing
     """
-    return host_state.stats.get("memory_mb_max_unit")
+    try:
+        return int(host_state.stats.get("memory_mb_max_unit"))
+    except (TypeError, ValueError):
+        return None

--- a/nova/tests/unit/scheduler/filters/test_hana_memory_max_unit_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_hana_memory_max_unit_filter.py
@@ -30,7 +30,7 @@ class TestHANAMemoryMaxUnitFilter(test.NoDBTestCase):
 
     def test_passes(self):
         host = fakes.FakeHostState('host1', 'compute', {
-            'stats': {'memory_mb_max_unit': 2048}
+            'stats': {'memory_mb_max_unit': '2048'}
         })
         extra_specs = {'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'required'}
 
@@ -45,7 +45,7 @@ class TestHANAMemoryMaxUnitFilter(test.NoDBTestCase):
 
     def test_not_pass_too_big_flavor(self):
         host = fakes.FakeHostState('host1', 'compute', {
-            'stats': {'memory_mb_max_unit': 2048}
+            'stats': {'memory_mb_max_unit': '2048'}
         })
         extra_specs = {'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'required'}
 
@@ -62,7 +62,7 @@ class TestHANAMemoryMaxUnitFilter(test.NoDBTestCase):
               {'trait:CUSTOM_HANA_EXCLUSIVE_HOST': 'forbidden'})
     def test_passes_non_hana(self, extra_specs):
         host = fakes.FakeHostState('host1', 'compute', {
-            'stats': {'memory_mb_max_unit': 2048}
+            'stats': {'memory_mb_max_unit': '2048'}
         })
 
         flavor = objects.Flavor(memory_mb=3072,

--- a/nova/tests/unit/scheduler/filters/test_resize_vcpu_max_unit_filter.py
+++ b/nova/tests/unit/scheduler/filters/test_resize_vcpu_max_unit_filter.py
@@ -82,11 +82,11 @@ class TestResizeVcpuMaxUnitFilter(test.NoDBTestCase):
     def test_filters_hosts(self):
         hosts = [
             fakes.FakeHostState('host1', 'compute',
-                                {'stats': {'vcpus_max_unit': 2}}),
+                                {'stats': {'vcpus_max_unit': '2'}}),
             fakes.FakeHostState('host2', 'compute',
-                                {'stats': {'vcpus_max_unit': 4}}),
+                                {'stats': {'vcpus_max_unit': '4'}}),
             fakes.FakeHostState('host3', 'compute',
-                                {'stats': {'vcpus_max_unit': 6}}),
+                                {'stats': {'vcpus_max_unit': '6'}}),
             fakes.FakeHostState('host4', 'compute',
                                 {'stats': {}})
         ]

--- a/nova/tests/unit/scheduler/weights/test_hana_binpack.py
+++ b/nova/tests/unit/scheduler/weights/test_hana_binpack.py
@@ -46,10 +46,10 @@ class HANABingPackWeigherTestCase(test.NoDBTestCase):
 
     def _get_all_hosts(self):
         host_values = [
-            ('host1', 'node1', {'stats': {'memory_mb_max_unit': 3072}}),
-            ('host2', 'node2', {'stats': {'memory_mb_max_unit': 8192}}),
-            ('host3', 'node3', {'stats': {'memory_mb_max_unit': 1024}}),
-            ('host4', 'node4', {'stats': {'memory_mb_max_unit': 512}})
+            ('host1', 'node1', {'stats': {'memory_mb_max_unit': '3072'}}),
+            ('host2', 'node2', {'stats': {'memory_mb_max_unit': '8192'}}),
+            ('host3', 'node3', {'stats': {'memory_mb_max_unit': '1024'}}),
+            ('host4', 'node4', {'stats': {'memory_mb_max_unit': '512'}})
         ]
         return [fakes.FakeHostState(host, node, values)
                 for host, node, values in host_values]

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2375,9 +2375,12 @@ class VMwareAPIVMTestCase(test.TestCase,
         self.assertEqual(
                 [("i686", "vmware", "hvm"), ("x86_64", "vmware", "hvm")],
                 stats['supported_instances'])
-        max_unit = stats['stats']['memory_mb_max_unit']
+        memory_mbmax_unit = stats['stats']['memory_mb_max_unit']
+        vcpus_max_unit = stats['stats']['vcpus_max_unit']
         # memory_mb_used = fake.HostSystem.overallMemoryUsage = 500
-        self.assertEqual(max_unit, 1024 - 500)
+        self.assertEqual(memory_mbmax_unit, 1024 - 500)
+        # vcpus_max_unit = fake.HostSystem.summary.hardware.numCpuThreads
+        self.assertEqual(vcpus_max_unit, 16)
 
     @mock.patch('nova.virt.vmwareapi.ds_util.get_available_datastores')
     def test_update_provider_tree(self, mock_get_avail_ds):

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -422,7 +422,7 @@ class VMwareVCDriver(driver.ComputeDriver):
 
             vcpus = resources['vcpus']
             if vcpus_max_unit < vcpus:
-                vcpus_max_unit = vcpus_max_unit
+                vcpus_max_unit = vcpus
 
         return {
             "memory_mb_max_unit": memory_mb_max_unit,


### PR DESCRIPTION
It seems that `ComputeNode.stats` are converted to string before being stored in the database (it's a `DictOfNullableStringsField`).

Thus, we must convert it to `int` before using it in the filters.

There are multiple fixes in this PR, so please read the individual commit messages.

The fixes are for:
- HANABinPackWeigher
- HANAMemoryMaxUnitFilter
- ResizeVcpuMaxUnitFilter