### PR TITLE
Skip memory_mb_reserved when calculating the free memory for HANAs

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -4125,15 +4125,16 @@ class VMwareVMOpsTestCase(test.TestCase):
                 'name': 'host2',
                 'available': True,
                 'memory_mb': 4096,
-                'memory_mb_used': 1024,
-                'memory_mb_reserved': 512,
+                'memory_mb_used': 1536
             },
             'host-2': {
                 'name': 'host2',
                 'available': True,
                 'memory_mb': 4096,
-                'memory_mb_used': 1024,
-                'memory_mb_reserved': 1024,
+                'memory_mb_used': 2048,
+                # memory_mb_reserved should not be used
+                # when determining the memory_mb_free
+                'memory_mb_reserved': 2048,
             },
             # host-3 is the fullest one but never gets
             # elected because it has available: False
@@ -4141,8 +4142,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                 'name': 'host3',
                 'available': False,
                 'memory_mb': 4096,
-                'memory_mb_used': 1560,
-                'memory_mb_reserved': 1024,
+                'memory_mb_used': 2560
             }
         }
 
@@ -4160,15 +4160,13 @@ class VMwareVMOpsTestCase(test.TestCase):
                 'name': 'host1',
                 'available': True,
                 'memory_mb': 4096,
-                'memory_mb_used': 1024,
-                'memory_mb_reserved': 1024,
+                'memory_mb_used': 1024
             },
             'host-2': {
                 'name': 'host2',
                 'available': True,
                 'memory_mb': 4096,
-                'memory_mb_used': 1024,
-                'memory_mb_reserved': 1024,
+                'memory_mb_used': 1024
             }
         }
         # the hosts have the same fill-grade, so the order they

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -415,8 +415,7 @@ class VMwareVCDriver(driver.ComputeDriver):
             if nodename == self._nodename:
                 continue
             memory_mb_free = (resources['memory_mb'] -
-                              resources['memory_mb_used'] -
-                              resources['memory_mb_reserved'])
+                              resources['memory_mb_used'])
             if memory_mb_max_unit < memory_mb_free:
                 memory_mb_max_unit = memory_mb_free
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1620,8 +1620,7 @@ class VMwareVMOps(object):
             if not info['available']:
                 continue
             memory_mb_free = (info['memory_mb'] -
-                              info['memory_mb_used'] -
-                              info['memory_mb_reserved'])
+                              info['memory_mb_used'])
             if memory_mb_free < instance.memory_mb:
                 hosts_full.append((info['name'], memory_mb_free))
             else:


### PR DESCRIPTION
A free ESXi host still reports tens of GB RAM used while empty.

Adding the memory_mb_used of the ESXi itself + the 5% reservation can lead to an empty 6TB host not being able to accept a 6TB VM.

Since HANA flavors are spawned on their dedicated hardware, we get rid of the memory_mb_reserved to solve the empty-host problem.

Change-Id: I86d75af93ae3f9735cdb4884acae70a9c7f8ddce