### PR TITLE
[vmware] use soft shutdown on the cold resize/migrate

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -573,6 +573,38 @@ class VMwareVMOpsTestCase(test.TestCase):
             _reconfigure_vm.assert_called_once_with(self._session, vm_ref,
                 expected)
 
+    @ddt.data(
+        # powered-on vm was _clean_shutdown
+        ((True, True), None, True),
+        # vm was already powered off
+        ((False, False), None, False),
+        # couldn't _clean_shutdown the powered-on VM
+        # falling back to hard power-off
+        ((True, False), True, True)
+    )
+    @ddt.unpack
+    def test_soft_shutdown(self, clean_shutdown_ret, power_off_ret,
+                           expected_result):
+        with test.nested(
+            mock.patch.object(vmops.VMwareVMOps, '_clean_shutdown',
+                              return_value=clean_shutdown_ret),
+            mock.patch.object(vm_util, 'power_off_instance',
+                              return_value=power_off_ret)
+        ) as (mock_clean_shutdown, mock_power_off):
+
+            result = self._vmops._soft_shutdown(self._instance)
+
+            mock_clean_shutdown.assert_called_once_with(
+                self._instance,
+                CONF.shutdown_timeout,
+                CONF.compute.shutdown_retry_interval)
+
+            if power_off_ret is not None:
+                mock_power_off.assert_called_once_with(
+                    self._session, self._instance)
+
+            self.assertEqual(expected_result, result)
+
     @mock.patch.object(time, 'sleep')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cached_instances')
     def _test_clean_shutdown(self, mock_update_cached_instances,
@@ -627,7 +659,8 @@ class VMwareVMOpsTestCase(test.TestCase):
             result = self._vmops._clean_shutdown(instance, timeout,
                                                  retry_interval)
 
-        self.assertEqual(succeeds, result)
+        self.assertEqual(returns_on > 0, result[0])
+        self.assertEqual(succeeds, result[1])
         mock_get_vm_ref.assert_called_with(self._session, self._instance)
 
     def test_clean_shutdown_first_time(self):
@@ -972,7 +1005,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_vm_resize_spec',
                        return_value='fake-spec')
-    @mock.patch.object(vm_util, 'power_off_instance')
+    @mock.patch.object(vmops.VMwareVMOps, '_soft_shutdown')
     @mock.patch.object(vm_util, 'get_vm_ref', return_value='fake-ref')
     @mock.patch.object(vm_util, 'power_on_instance')
     @mock.patch.object(vmops.VMwareVMOps, '_detach_volumes')
@@ -982,7 +1015,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     def _test_finish_revert_in_place_migration(
             self, fake_list_instances, fake_relocate_vm, fake_attach_volumes,
             fake_detach_volumes, fake_power_on, fake_get_vm_ref,
-            fake_power_off, fake_resize_spec, fake_reconfigure_vm,
+            fake_soft_shutdown, fake_resize_spec, fake_reconfigure_vm,
             fake_get_browser, fake_original_exists, fake_disk_move,
             fake_disk_delete, fake_remove_ephemerals_and_swap,
             fake_resize_create_ephemerals_and_swap, fake_get_extra_specs,
@@ -1038,9 +1071,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                 pass
 
             vm_ref_calls = [mock.call(self._session, self._instance)]
-            fake_power_off.assert_called_once_with(self._session,
-                                                   self._instance,
-                                                   'fake-ref')
+            fake_soft_shutdown.assert_called_once_with(self._instance)
             # Validate VM reconfiguration
             metadata = ('name:fake_display_name\n'
                         'userid:fake_user\n'
@@ -1567,7 +1598,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'rename_vm')
     @mock.patch.object(vm_util, 'get_vmdk_info')
     @mock.patch.object(vm_util, 'power_on_instance')
-    @mock.patch.object(vm_util, 'power_off_instance')
+    @mock.patch.object(vmops.VMwareVMOps, '_soft_shutdown')
     @mock.patch.object(vm_util, 'get_hardware_devices_by_type',
                        return_value={})
     @mock.patch.object(vim_util, 'get_object_property')
@@ -1583,7 +1614,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                                          fake_get_vm_ref,
                                          fake_get_object_property,
                                          fake_get_hardware_devices_by_type,
-                                         fake_power_off,
+                                         fake_soft_shutdown,
                                          fake_power_on, fake_get_vmdk_info,
                                          fake_rename_vm, fake_vm_device_change,
                                          fake_image_meta, fake_finish_revert,
@@ -1637,8 +1668,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                 self._session, 'source-ref', 'config.firmware')
         fake_rename_vm.assert_called_once_with(self._session, 'source-ref',
                                                self._instance)
-        fake_power_off.assert_called_once_with(self._session, self._instance,
-                                               'source-ref')
+        fake_soft_shutdown.assert_called_once_with(self._instance)
         fake_detach_volumes.assert_called_once_with(
             self._instance, block_device_info)
         fake_get_remove_network_device_change.assert_called_once_with(

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -2198,11 +2198,27 @@ class VMwareVMOps(object):
         """
         if timeout and self._clean_shutdown(instance,
                                             timeout,
-                                            retry_interval):
+                                            retry_interval)[1]:
             return
 
         vm_util.power_off_instance(self._session, instance)
         self.update_cached_instances()
+
+    def _soft_shutdown(self, instance):
+        """Attempt graceful shutdown on the VM, falling back to a
+        power-off after the configured timeout and retry_interval.
+
+        :returns: True if the VM was poweredOn before running the
+                  operation, False otherwise.
+        """
+        vm_was_on, was_shutdown = self._clean_shutdown(
+            instance, CONF.shutdown_timeout,
+            CONF.compute.shutdown_retry_interval)
+
+        if was_shutdown or not vm_was_on:
+            return vm_was_on
+
+        return vm_util.power_off_instance(self._session, instance)
 
     def _clean_shutdown(self, instance, timeout, retry_interval):
         """Perform a soft shutdown on the VM.
@@ -2211,8 +2227,10 @@ class VMwareVMOps(object):
                         shutdown
         :param retry_interval: Interval to check if instance is already
                                shutdown in seconds.
-           :return: True if the instance was shutdown within time limit,
-                    False otherwise.
+        :return: a Tuple(value1, value2) where value1 is True if the VM
+                 was powered on before trying the shutdown, False otherwise,
+                 and value2 is True if the instance was shutdown within
+                 time limit, False otherwise.
         """
         LOG.debug("Performing Soft shutdown on instance", instance=instance)
         vm_ref = vm_util.get_vm_ref(self._session, instance)
@@ -2222,7 +2240,7 @@ class VMwareVMOps(object):
         if props.get("runtime.powerState") != "poweredOn":
             LOG.debug("Instance not in poweredOn state.",
                       instance=instance)
-            return False
+            return False, False
 
         if ((props.get("summary.guest.toolsStatus") == "toolsOk") and
             (props.get("summary.guest.toolsRunningStatus") ==
@@ -2237,7 +2255,7 @@ class VMwareVMOps(object):
             except vexc.ToolsUnavailableException:
                 LOG.info("Failed to _clean_shutdown the instance",
                          instance=instance)
-                return False
+                return True, False
 
             while timeout > 0:
                 wait_time = min(retry_interval, timeout)
@@ -2247,7 +2265,7 @@ class VMwareVMOps(object):
                 if pwr_state == "poweredOff":
                     LOG.info("Soft shutdown succeeded.",
                              instance=instance)
-                    return True
+                    return True, True
 
                 time.sleep(wait_time)
                 timeout -= retry_interval
@@ -2257,7 +2275,7 @@ class VMwareVMOps(object):
         else:
             LOG.debug("VMware Tools not running", instance=instance)
 
-        return False
+        return True, False
 
     def is_instance_in_resource_pool(self, instance):
         try:
@@ -2509,8 +2527,7 @@ class VMwareVMOps(object):
         vm_util.rename_vm(self._session, vm_ref, instance)
 
         # 1. Power off the instance
-        vm_was_on = vm_util.power_off_instance(self._session, instance,
-                                               vm_ref)
+        vm_was_on = self._soft_shutdown(instance)
 
         self._update_instance_progress(context, instance,
                                        step=1,
@@ -2725,7 +2742,7 @@ class VMwareVMOps(object):
                                              block_device_info, network_info):
         vm_ref = vm_util.get_vm_ref(self._session, instance)
         # Ensure that the VM is off
-        vm_util.power_off_instance(self._session, instance, vm_ref)
+        self._soft_shutdown(instance)
         client_factory = self._session.vim.client.factory
         # Reconfigure the VM properties
         extra_specs = self._get_extra_specs(instance.flavor,


### PR DESCRIPTION
Resize uses a hard PowerOff to shut down the VM. This can lead to data not being written to disk and thus broken files.

The _soft_shutdown method first attempts to shutdown the OS via the VMware tools, and fall back to the hard PowerOff after the configured `shutdown_timeout` and `compute.shutdown_retry_interval`.

Change-Id: Id2fdeac6355eb7e49f649ba8fa4b48251bb7db61