### PR TITLE
SAP: Introduce external scheduler filter

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -947,6 +947,28 @@ Possible values are:
 Related options:
 
 * ``[DEFAULT] bigvm_mb``
+"""),
+    cfg.StrOpt("external_scheduler_api_url",
+        default="",
+        help="""
+The API URL of the external scheduler.
+
+If this URL is provided, Nova will call an external service after filters
+and weighers have been applied. This service can reorder and filter the
+list of hosts before Nova attempts to place the instance.
+
+If not provided, this step will be skipped.
+"""),
+    cfg.IntOpt("external_scheduler_timeout",
+        default=10,
+        min=1,
+        help="""
+The timeout in seconds for the external scheduler.
+
+If external_scheduler_api_url is configured, Nova will call and wait for the
+external scheduler to respond for this long. If the external scheduler does not
+respond within this time, the request will be aborted. In this case, the
+scheduler will continue with the original host selection and weights.
 """)
 ]
 

--- a/nova/scheduler/external.py
+++ b/nova/scheduler/external.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2025 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+This module provides functionality to interact with an external scheduler API
+to reorder and filter hosts based on additional criteria.
+
+The external scheduler API is expected to take a list of weighed hosts and
+their weights, along with the request specification, and return a reordered
+and filtered list of host names.
+"""
+import jsonschema
+from oslo_log import log as logging
+import requests
+
+import nova.conf
+from nova.scheduler import utils
+
+CONF = nova.conf.CONF
+LOG = logging.getLogger(__name__)
+
+
+# The expected response schema from the external scheduler api.
+# The response should contain a list of ordered host names.
+response_schema = {
+  "type": "object",
+  "properties": {
+    "hosts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["hosts"],
+  "additionalProperties": False,
+}
+
+
+def call_external_scheduler_api(weighed_hosts, weights, spec_obj):
+    """Reorder and filter hosts using an external scheduler service."""
+    if not weighed_hosts:
+        return weighed_hosts
+    if not (url := CONF.filter_scheduler.external_scheduler_api_url):
+        LOG.debug("External scheduler API is not enabled.")
+        return weighed_hosts
+    timeout = CONF.filter_scheduler.external_scheduler_timeout
+
+    json_data = {
+        "spec": spec_obj.obj_to_primitive(),
+        # Extract some flags from the spec to indicate the type of
+        # request. This will allow the external scheduler to quickly
+        # decide if it wants to handle the request or not.
+        "rebuild": utils.request_is_rebuild(spec_obj),
+        "resize": utils.request_is_resize(spec_obj),
+        "live": utils.request_is_live_migrate(spec_obj),
+        "vmware": not utils.is_non_vmware_spec(spec_obj),
+        # Only provide basic information for the hosts for now.
+        # The external scheduler is expected to fetch statistics
+        # about the hosts separately, so we don't need to pass
+        # them here.
+        "hosts": [
+            {
+                "host": h.host,  # e.g. nova-compute-bb123
+                "hypervisor_hostname": h.hypervisor_hostname,
+                "status": h.status,
+            } for h in weighed_hosts
+        ],
+        # Also pass previous weights from the Nova weigher pipeline.
+        # The external scheduler api is expected to take these weights
+        # into account if provided.
+        "weights": weights,
+    }
+    LOG.debug("Calling external scheduler API with %s", json_data)
+    try:
+        response = requests.post(url, json=json_data, timeout=timeout)
+        response.raise_for_status()
+        # If the JSON parsing fails, this will also raise a RequestException.
+        response_json = response.json()
+    except requests.RequestException as e:
+        LOG.error("Failed to call external scheduler API: %s", e)
+        return weighed_hosts
+
+    # The external scheduler api is expected to return a json with
+    # a sorted list of host names. Note that no weights are returned.
+    try:
+        jsonschema.validate(response_json, response_schema)
+    except jsonschema.ValidationError as e:
+        LOG.error("External scheduler response is invalid: %s", e)
+        return weighed_hosts
+
+    # The list of host names can also be empty. In this case, we trust
+    # the external scheduler decision and return an empty list.
+    if not (host_names := response_json["hosts"]):
+        # If this case happens often, it may indicate an issue.
+        LOG.warning("External scheduler filtered out all hosts.")
+
+    # Reorder the weighed hosts based on the list of host names returned
+    # by the external scheduler api.
+    weighed_hosts_dict = {h.host: h for h in weighed_hosts}
+    return [weighed_hosts_dict[h] for h in host_names]

--- a/nova/tests/unit/scheduler/test_external.py
+++ b/nova/tests/unit/scheduler/test_external.py
@@ -1,0 +1,209 @@
+# Copyright 2025 SAP SE or an SAP affiliate company.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+# Tests for external scheduler api.
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import sentinel
+
+import requests
+
+from nova import objects
+from nova.scheduler.external import call_external_scheduler_api
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+class ExternalSchedulerAPITestCase(test.NoDBTestCase):
+    def setUp(self):
+        super(ExternalSchedulerAPITestCase, self).setUp()
+        self.flags(
+            external_scheduler_api_url='http://127.0.0.1:1234',
+            group='filter_scheduler'
+        )
+        self.example_hosts = [
+            fakes.FakeHostState('host1', 'node1', {'status': 'up'}),
+            fakes.FakeHostState('host2', 'node2', {'status': 'up'}),
+            fakes.FakeHostState('host3', 'node3', {'status': 'down'})
+        ]
+        self.example_weights = {
+            'host1': 1.0,
+            'host2': 0.5,
+            'host3': 0.0,
+        }
+        self.example_spec = objects.RequestSpec(
+            context=sentinel.ctx,
+            flavor=objects.Flavor(
+                name='small',
+                vcpus=4,
+                memory_mb=1024,
+                extra_specs={},
+            ),
+        )
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.debug')
+    def test_enabled_api_success(self, mock_debug_log, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': ['host1', 'host3']}
+        mock_post.return_value = mock_response
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_debug_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+        self.assertEqual(
+            ['host1', 'host3'],
+            [h.host for h in hosts]
+        )
+        self.assertIn('Calling external scheduler API with ', log)
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.warning')
+    def test_enabled_api_empty_response(self, mock_warn_log, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': []}
+        mock_post.return_value = mock_response
+
+        hosts = call_external_scheduler_api(
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+        self.assertEqual([], hosts)
+        mock_warn_log.assert_called_with(
+            'External scheduler filtered out all hosts.'
+        )
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.error')
+    def test_enabled_api_timeout(self, mock_err_log, mock_post):
+        mock_post.side_effect = requests.exceptions.Timeout
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API: ', log)
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.error')
+    def test_enabled_api_invalid_response(self, mock_err_log, mock_post):
+        invalid_response_dicts = [
+            {},
+            {"hosts": "not a list"},
+            {"hosts": [1, 2, "host1"]},
+            {"hosts": [{"name": "host1", "status": "up"}]},
+        ]
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        for response_dict in invalid_response_dicts:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = response_dict
+            mock_post.return_value = mock_response
+
+            hosts = call_external_scheduler_api(
+                self.example_hosts,
+                self.example_weights,
+                self.example_spec,
+            )
+            # Should fallback to the original host list.
+            self.assertEqual(
+                ['host1', 'host2', 'host3'],
+                [h.host for h in hosts]
+            )
+            self.assertIn('External scheduler response is invalid: ', log)
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.error')
+    def test_enabled_api_json_decode_err(self, mock_err_log, mock_post):
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        # Note: requests.exceptions.InvalidJSONError is also a RequestException
+        mock_response.json.side_effect = requests.exceptions.InvalidJSONError
+        mock_post.return_value = mock_response
+
+        hosts = call_external_scheduler_api(
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API: ', log)
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.error')
+    def test_enabled_api_error_reply(self, mock_err_log, mock_post):
+        mock_post.side_effect = requests.exceptions.HTTPError
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API: ', log)

--- a/nova/tests/unit/scheduler/test_manager.py
+++ b/nova/tests/unit/scheduler/test_manager.py
@@ -932,6 +932,26 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         # remaining list of weighed host state objects
         self.assertEqual([hs2, hs1], results)
 
+    @mock.patch('requests.post')
+    @mock.patch('nova.scheduler.host_manager.HostManager.get_weighed_hosts')
+    @mock.patch('nova.scheduler.host_manager.HostManager.get_filtered_hosts')
+    def test_get_sorted_hosts_external_scheduler_disabled(
+        self, mock_filt, mock_weighed, mock_post
+    ):
+        """Tests that the external scheduler is not called when disabled."""
+        self.flags(external_scheduler_api_url="", group='filter_scheduler')
+        hs1 = mock.Mock(spec=host_manager.HostState, host='host1',
+                cell_uuid=uuids.cell1)
+        hs2 = mock.Mock(spec=host_manager.HostState, host='host2',
+                cell_uuid=uuids.cell2)
+        mock_filt.return_value = [hs1, hs2]
+        mock_weighed.return_value = [
+            weights.WeighedHost(hs1, 1.0), weights.WeighedHost(hs2, 1.0),
+        ]
+        _ = self.manager._get_sorted_hosts(mock.sentinel.spec,
+            [hs1, hs2], mock.sentinel.index)
+        mock_post.assert_not_called()
+
     @mock.patch('random.choice', side_effect=lambda x: x[0])
     @mock.patch('nova.scheduler.host_manager.HostManager.get_weighed_hosts')
     @mock.patch('nova.scheduler.host_manager.HostManager.get_filtered_hosts')


### PR DESCRIPTION
SAP: Introduce an external scheduler filter

Provides support for an external service that can perform advanced scheduling 
decisions. SchedulerManager now calls a function call_external_scheduler_api
after executing filters and weighers. This function sends the hosts and their
current weights to an external scheduling service. This service then performs
advanced scheduling decisions and returns the sorted list of host names, from
highest priority to lowest priority. To toggle this feature, provide
external_scheduler_api_url to Nova's configuration.