### PR TITLE
scheduler: Add AggregateMultiTenancyIsolation weigher

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -736,6 +736,41 @@ Related options:
 
 * ``[filter_scheduler] weight_classes``
 """),
+    cfg.FloatOpt(
+        "aggregate_multi_tenancy_isolation_weight_multiplier",
+        default=1.0,
+        help="""
+Multiplier used for weighing hosts part of a filter_tenant_id aggregate
+
+This option determines how much weight is placed on a host which is part of an
+aggregate containing a ``filter_tenant_id`` property with the
+``filter_tenant_id`` containing the project of the current scheduling request.
+
+Setting ``filter_tenant_id`` on an aggregate and adding hosts to the aggregate
+dedicates these hosts to these projects. No other customers can spawn instances
+there. Since hosts not being in such an aggregate can be used by anyone, users
+should use their dedicated resources first instead of consuming the generally
+available resources. This weigher can ensure that by having the appropriate
+multiplier set.
+
+Note that this setting only affects scheduling if the
+``AggregateMultiTenancyIsolation`` weigher is enabled.
+
+The value of this configuration option can be overridden per host aggregate
+by setting the aggregate metadata key with the same name
+(``aggregate_multi_tenancy_isolation_weight_multiplier``).
+
+Possible values:
+
+* An integer or float value, where the value corresponds to the multiplier
+  ratio for this weigher. Positive values mean the weigher will prefer
+  dedicated hosts.
+  Negative values mean the weigher will prefer generally available hosts
+
+Related options:
+
+* ``[filter_scheduler] weight_classes``
+"""),
     cfg.BoolOpt(
         "shuffle_best_same_weighed_hosts",
         default=False,

--- a/nova/scheduler/weights/aggregate_multitenancy_isolation.py
+++ b/nova/scheduler/weights/aggregate_multitenancy_isolation.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2024 SAP
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import nova.conf
+from nova.scheduler.filters import utils as filter_utils
+from nova.scheduler import utils
+from nova.scheduler import weights
+
+
+CONF = nova.conf.CONF
+
+
+class AggregateMultiTenancyIsolation(weights.BaseHostWeigher):
+    """Weigh hosts based on them being in a specific aggregate
+
+    The AggregateMultiTenancyIsolation filter makes sure that VMs cannot land
+    on hosts that are dedicated to specific projects via the `filter_tenant_id`
+    aggregate property. This weigher uses the same information, but prioritizes
+    hosts that belong to such a given aggregate. Use-case is to make sure users
+    having dedicated hosts will use these hosts on priority and not use
+    resources on hardware available for everyone.
+    """
+
+    def weight_multiplier(self, host_state):
+        """Override the weight multiplier."""
+        return 1 * utils.get_weight_multiplier(
+            host_state, 'aggregate_multi_tenancy_isolation_weight_multiplier',
+            CONF.filter_scheduler
+                .aggregate_multi_tenancy_isolation_weight_multiplier)
+
+    def _weigh_object(self, host_state, spec_obj):
+        """Prioritise hosts in aggregates with filter_tenant_id."""
+        tenant_id = spec_obj.project_id
+
+        metadata = filter_utils.aggregate_metadata_get_by_host(host_state,
+                                                        key="filter_tenant_id")
+
+        if not metadata:
+            return 0.0
+
+        configured_tenant_ids = metadata.get("filter_tenant_id")
+        if not configured_tenant_ids:
+            return 0.0
+
+        if tenant_id not in configured_tenant_ids:
+            return 0.0
+
+        return 1.0

--- a/nova/tests/unit/scheduler/weights/test_weights_aggregate_multitenancy_isolation.py
+++ b/nova/tests/unit/scheduler/weights/test_weights_aggregate_multitenancy_isolation.py
@@ -1,0 +1,109 @@
+# Copyright 2024 SAP
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import mock
+
+from nova import objects
+from nova.scheduler import weights
+from nova.scheduler.weights import aggregate_multitenancy_isolation as a_m_i
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+@mock.patch('nova.scheduler.filters.utils.aggregate_metadata_get_by_host')
+class TestAggregateMultitenancyIsolationWeigher(test.NoDBTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.weight_handler = weights.HostWeightHandler()
+        self.weighers = [a_m_i.AggregateMultiTenancyIsolation()]
+
+        # NOTE(jkulik): We need at least 2 hosts for the HostWeightHandler to
+        # do anything. They also need to return different weights or we just
+        # see 0 all the time. The multiplier is applied after the
+        # normalization.
+        self.hosts = [
+            fakes.FakeHostState('host1', 'compute', {}),
+            fakes.FakeHostState('host2', 'compute', {})]
+
+    def test_no_metadata_zero_weight(self, agg_mock):
+        """no metadata, no weight"""
+        agg_mock.side_effect = [{}, {}]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='my_tenantid')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, spec_obj)
+        self.assertEqual(0.0, weighed_hosts[0].weight)
+
+    def test_not_our_key_zero_weight(self, agg_mock):
+        """not our key in metadata, no weight"""
+        agg_mock.side_effect = [{'the_key': 'the_value'}, {}]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='my_tenantid')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, spec_obj)
+        self.assertEqual(0.0, weighed_hosts[0].weight)
+
+    def test_not_in_the_value_zero_weight(self, agg_mock):
+        """our project is not in the metadata value, no weight"""
+        agg_mock.side_effect = [
+            {'filter_tenant_id': {'one_project', 'another_project'}},
+            {}]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='my_tenantid')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, spec_obj)
+        self.assertEqual(0.0, weighed_hosts[0].weight)
+
+    def test_in_the_value(self, agg_mock):
+        """our project is in the metadata value, we have weight"""
+        agg_mock.side_effect = [
+            {'filter_tenant_id': {'one_project', 'another_project',
+                                 'my_tenantid'}},
+            {}]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='my_tenantid')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, spec_obj)
+        self.assertEqual(1.0, weighed_hosts[0].weight)
+
+    def test_multiplier(self, agg_mock):
+        """our project is in the metadata value, we have weight multiplied"""
+        self.flags(aggregate_multi_tenancy_isolation_weight_multiplier=5.0,
+                   group='filter_scheduler')
+
+        agg_mock.side_effect = [
+            {'filter_tenant_id': {'one_project', 'another_project',
+                                 'my_tenantid'}},
+            {}]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='my_tenantid')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, spec_obj)
+        self.assertEqual(5.0, weighed_hosts[0].weight)
+
+    def test_disabled(self, agg_mock):
+        """our project is in the metadata value, but multplier disables it"""
+        self.flags(aggregate_multi_tenancy_isolation_weight_multiplier=0.0,
+                   group='filter_scheduler')
+
+        agg_mock.side_effect = [
+            {'filter_tenant_id': {'one_project', 'another_project',
+                                 'my_tenantid'}},
+            {}]
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx, project_id='my_tenantid')
+        weighed_hosts = self.weight_handler.get_weighed_objects(
+            self.weighers, self.hosts, spec_obj)
+        self.assertEqual(0.0, weighed_hosts[0].weight)


### PR DESCRIPTION
We want the hardware we dedicate to specific projects through aggregates with `filter_tenant_id` property to be preferred by those projects compared to generally available hosts.

Change-Id: Ide6471a522785f7f4209d5b3640af2a521a05405