### PR TITLE
Fix SAPQuotaEngine cache client initialization

### DIFF
--- a/nova/quota.py
+++ b/nova/quota.py
@@ -1117,9 +1117,16 @@ class SAPQuotaEngine(QuotaEngine):
 
     def __init__(self, quota_driver=None, resources=None):
         self._original_resources = {}
-        expiration_time = CONF.quota.sap_resources_cache_time
-        self._cache = cache.get_client(expiration_time=expiration_time)
+        self.__cache = None
         super().__init__(resources=resources, quota_driver=quota_driver)
+
+    @property
+    def _cache(self):
+        if not self.__cache:
+            expiration_time = CONF.quota.sap_resources_cache_time
+            self.__cache = cache.get_client(
+                                    expiration_time=expiration_time)
+        return self.__cache
 
     @property
     def _resources(self):


### PR DESCRIPTION
The SAPQuotaEngine instance is created as a module variable (nova.quota.QUOTAS), so the CONF might have not been initialized at the point when SAPQuotaEngine.__init__ is called.

Similarily to how the self._driver is initialised, we are now initializing the self._cache client outside of the constructor, making sure the CONF is also initialized at that point.

This fixes the issues where DictCacheBackend was used by the SAPQuotaEngine, instead of the configured Memcached backend.

Change-Id: Iceba3c7820f9c6b9255ef6e00a9f49ed4677c12f