### PR TITLE
Hack: libvirt: Support maxphysaddr.

### DIFF
--- a/nova/conf/workarounds.py
+++ b/nova/conf/workarounds.py
@@ -413,7 +413,12 @@ compatibility on the destination host during live migration.
 This will skip the CPU comparison call at the startup of Compute
 service and lets libvirt handle it.
 """),
-
+    cfg.BoolOpt('libvirt_use_host_maxphysaddr',
+               default=False,
+               help="""
+This is a hack: Pass simply the maxphysaddr from the host to the VM.
+This is to be replaced by the proper libvirt-maxphysaddr-support
+"""),
 ]
 
 


### PR DESCRIPTION
This is a hacky version of libvirt: Support maxphysaddr, which does it properly over flavor and images,
but needs also a trait upgrade.

Do not port it to later versions.

With Libvirt v8.7.0+, the <maxphysaddr> sub-element of the <cpu> element specifies the number of vCPU
physical address bits [1].

[1] https://libvirt.org/news.html#v8-7-0-2022-09-01

Change-Id: If89f71511c050a494657614b789adcdb80297725