### PR TITLE
[vmware] Improve the order of attaching/detaching volumes

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -1254,17 +1254,45 @@ class VMwareVMOpsTestCase(test.TestCase):
     def test_attach_volumes(self, fake_attach_volume):
         block_device_info = {
             'block_device_mapping': [
-                {'mount_device': '/dev/sda', 'connection_info': {'id': 'c'}},
+                {'mount_device': '/dev/sda', 'connection_info': {'id': 'a'}},
                 {'mount_device': '/dev/sdb', 'connection_info': {'id': 'b'}},
-                {'mount_device': '/dev/sdc', 'connection_info': {'id': 'a'}},
+                {'mount_device': '/dev/sdc', 'connection_info': {'id': 'c'}},
+                {'mount_device': '/dev/sdd', 'boot_index': -1,
+                 'connection_info': {'id': 'd'}},
+                {'mount_device': '/dev/sde', 'boot_index': 0,
+                 'connection_info': {'id': 'e'}},
             ]
         }
         self._vmops._attach_volumes(self._instance, block_device_info,
                                     mock.sentinel.adapter_type)
         fake_attach_volume.assert_has_calls([
-            mock.call({'id': 'c'}, self._instance, mock.sentinel.adapter_type),
-            mock.call({'id': 'b'}, self._instance, mock.sentinel.adapter_type),
+            mock.call({'id': 'e'}, self._instance, mock.sentinel.adapter_type),
             mock.call({'id': 'a'}, self._instance, mock.sentinel.adapter_type),
+            mock.call({'id': 'b'}, self._instance, mock.sentinel.adapter_type),
+            mock.call({'id': 'c'}, self._instance, mock.sentinel.adapter_type),
+            mock.call({'id': 'd'}, self._instance, mock.sentinel.adapter_type),
+        ])
+
+    @mock.patch.object(volumeops.VMwareVolumeOps, 'detach_volume')
+    def test_detach_volumes(self, fake_attach_volume):
+        block_device_info = {
+            'block_device_mapping': [
+                {'mount_device': '/dev/sda', 'connection_info': {'id': 'a'}},
+                {'mount_device': '/dev/sdb', 'connection_info': {'id': 'b'}},
+                {'mount_device': '/dev/sdc', 'connection_info': {'id': 'c'}},
+                {'mount_device': '/dev/sdd', 'boot_index': -1,
+                 'connection_info': {'id': 'd'}},
+                {'mount_device': '/dev/sde', 'boot_index': 0,
+                 'connection_info': {'id': 'e'}},
+            ]
+        }
+        self._vmops._detach_volumes(self._instance, block_device_info)
+        fake_attach_volume.assert_has_calls([
+            mock.call({'id': 'd'}, self._instance),
+            mock.call({'id': 'c'}, self._instance),
+            mock.call({'id': 'b'}, self._instance),
+            mock.call({'id': 'a'}, self._instance),
+            mock.call({'id': 'e'}, self._instance),
         ])
 
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata')

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -3429,9 +3429,7 @@ class VMwareVMOps(object):
         disks = driver.block_device_info_get_mapping(block_device_info)
         # Detach the volumes in reverse order, so if we roll it back
         # that the device order will still be preserved
-        for disk in sorted(disks,
-                           reverse=True,
-                           key=itemgetter('mount_device')):
+        for disk in self._sort_disks(disks, reverse=True):
             try:
                 self._volumeops.detach_volume(disk['connection_info'],
                                               instance)
@@ -3443,14 +3441,22 @@ class VMwareVMOps(object):
                         existing_disks=None):
         disks = driver.block_device_info_get_mapping(block_device_info)
         # make sure the disks are attached by the device_name order
-        for disk in sorted(disks,
-                           key=itemgetter('mount_device')):
+        for disk in self._sort_disks(disks):
             if existing_disks and disk['volume_id'] in existing_disks:
                 continue
 
             adapter_type = disk.get('disk_bus') or adapter_type
             self._volumeops.attach_volume(disk['connection_info'], instance,
                                           adapter_type)
+
+    def _sort_disks(self, disks, reverse=False):
+        """Since mount_device can be controlled from outside, we want to
+        make sure the boot disk is always at the top of the list.
+        """
+        return sorted(
+            disks,
+            key=lambda d: (d.get('boot_index') != 0, d.get('mount_device')),
+            reverse=reverse)
 
     def _find_esx_host(self, cluster_ref, ds_ref):
         """Find ESX host in the specified cluster which is also connected to


### PR DESCRIPTION
Currently the ordering is done only by sorting the mount_device, which might lead into incorrect index of the boot device in the OS.

With this patch, we are looking at the boot_index to make sure the boot device is attached first (and detached the last). The rest of block devices will still be sorted by mount_device.

Change-Id: I17af17955159fe4a6cd18028e6efe1feb47e4ff9