### PR TITLE
vmware: Switch mks console to `webmks`

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -18,7 +18,6 @@ import re
 import time
 
 import ddt
-from oslo_serialization import jsonutils
 from oslo_utils.fixture import uuidsentinel as uuids
 from oslo_utils import units
 from oslo_utils import uuidutils
@@ -4061,10 +4060,8 @@ class VMwareVMOpsTestCase(test.TestCase):
             console = self._vmops.get_mks_console(self._instance)
             self.assertEqual('esx1', console.host)
             self.assertEqual(902, console.port)
-            path = jsonutils.loads(console.internal_access_path)
-            self.assertEqual('fira', path['ticket'])
-            self.assertEqual('aabbccddeeff', path['thumbprint'])
-            self.assertEqual('[ds1] fira/foo.vmx', path['cfgFile'])
+            path = console.internal_access_path
+            self.assertEqual(f"/ticket/{ticket.ticket}", path)
 
     def test_get_cores_per_socket(self):
         extra_specs = {'hw:cpu_sockets': 7}

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -38,7 +38,6 @@ import six
 from oslo_concurrency import lockutils
 from oslo_log import log as logging
 import oslo_messaging as messaging
-from oslo_serialization import jsonutils
 from oslo_utils import excutils
 from oslo_utils import strutils
 from oslo_utils import timeutils
@@ -4202,12 +4201,8 @@ class VMwareVMOps(object):
         ticket = self._session._call_method(self._session.vim,
                                             'AcquireTicket',
                                             vm_ref,
-                                            ticketType='mks')
-        thumbprint = ticket.sslThumbprint.replace(':', '').lower()
-        mks_auth = {'ticket': ticket.ticket,
-                    'cfgFile': ticket.cfgFile,
-                    'thumbprint': thumbprint}
-        internal_access_path = jsonutils.dumps(mks_auth)
+                                            ticketType='webmks')
+        internal_access_path = f"/ticket/{ticket.ticket}"
         return ctype.ConsoleMKS(ticket.host, ticket.port, internal_access_path)
 
     @staticmethod


### PR DESCRIPTION
Since vSphere 6, VMware supports `webmks` as `ticketType` in addition to `mks`. `webmks` provides the remote console of a VM via WebSocket endpoint and is supposed to be used with their SDK. It does fall back to normal VNC which can be used with e.g. `noVNC` though.

With this change, we can follow-up by removing our custom mks proxy code, as we plan to expose `webmks` via Nginx directly.

Change-Id: I99294d7f6bf0539d20887322eeadb2580297fc8a