### PR TITLE
libvirt: Make SMBIOS Chassis Asset tag configurable

### DIFF
--- a/nova/conf/libvirt.py
+++ b/nova/conf/libvirt.py
@@ -745,6 +745,17 @@ per-host serials in addition to per-instance serial numbers, then consider
 restricting flavors via host aggregates.
 """
                ),
+    cfg.StrOpt('smbios_asset_tag',
+               default=None,
+               help="""
+Set the SMBIOS chassis asset tag to the specified value, so users can identify
+the cloud-platform they're running on. E.g. Amazon sets this to "Amazon EC2".
+
+Possible values:
+
+* Any string or None to not populate the asset tag.
+"""
+               ),
     cfg.IntOpt('mem_stats_period_seconds',
                default=10,
                help='A number of seconds to memory usage statistics period. '

--- a/nova/tests/unit/virt/libvirt/test_config.py
+++ b/nova/tests/unit/virt/libvirt/test_config.py
@@ -633,6 +633,19 @@ class LibvirtConfigGuestSysinfoTest(LibvirtConfigBaseTest):
             </sysinfo>
         """)
 
+    def test_config_chassis(self):
+        obj = config.LibvirtConfigGuestSysinfo()
+        obj.chassis_asset = "ACME Cloud VM"
+
+        xml = obj.to_xml()
+        self.assertXmlEqual(xml, """
+            <sysinfo type="smbios">
+              <chassis>
+                <entry name="asset">ACME Cloud VM</entry>
+              </chassis>
+            </sysinfo>
+        """)
+
     def test_config_mixed(self):
         obj = config.LibvirtConfigGuestSysinfo()
         obj.bios_vendor = "Acme"
@@ -640,6 +653,7 @@ class LibvirtConfigGuestSysinfoTest(LibvirtConfigBaseTest):
         obj.system_product = "Wile Coyote"
         obj.system_uuid = "c7a5fdbd-edaf-9455-926a-d65c16db1809"
         obj.system_family = "Anvils"
+        obj.chassis_asset = "ACME Cloud VM"
 
         xml = obj.to_xml()
         self.assertXmlEqual(xml, """
@@ -653,6 +667,9 @@ class LibvirtConfigGuestSysinfoTest(LibvirtConfigBaseTest):
                 <entry name="uuid">c7a5fdbd-edaf-9455-926a-d65c16db1809</entry>
                 <entry name="family">Anvils</entry>
               </system>
+              <chassis>
+                <entry name="asset">ACME Cloud VM</entry>
+              </chassis>
             </sysinfo>
         """)
 

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -20501,6 +20501,36 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                     self.assertEqual(cpu_model, expect_model[0])
 
 
+class TestGuestConfigSysinfoAssetTag(test.NoDBTestCase):
+    def setUp(self):
+        super(TestGuestConfigSysinfoAssetTag, self).setUp()
+
+        # Don't import libvirt
+        self.useFixture(fixtures.MockPatch('nova.virt.libvirt.driver.libvirt'))
+
+        # Don't initialise the Host
+        self.useFixture(fixtures.MockPatch('nova.virt.libvirt.driver.host'))
+
+    def _test_get_guest_config_sysinfo_chassis_asset(self, expected_chassis):
+        drvr = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), True)
+
+        test_instance = _create_test_instance()
+        instance_ref = objects.Instance(**test_instance)
+
+        cfg = drvr._get_guest_config_sysinfo(instance_ref)
+
+        self.assertIsInstance(cfg, vconfig.LibvirtConfigGuestSysinfo)
+        self.assertEqual(expected_chassis, cfg.chassis_asset)
+
+    def test_get_guest_config_sysinfo_chassis_default_none(self):
+        self._test_get_guest_config_sysinfo_chassis_asset(None)
+
+    def test_get_guest_config_sysinfo_chassis_from_config(self):
+        expected_chassis = "ACME Cloud VM"
+        CONF.set_override("smbios_asset_tag", expected_chassis, "libvirt")
+        self._test_get_guest_config_sysinfo_chassis_asset(expected_chassis)
+
+
 class TestGuestConfigSysinfoSerialOS(test.NoDBTestCase):
     def setUp(self):
         super(TestGuestConfigSysinfoSerialOS, self).setUp()

--- a/nova/virt/libvirt/config.py
+++ b/nova/virt/libvirt/config.py
@@ -1000,6 +1000,7 @@ class LibvirtConfigGuestSysinfo(LibvirtConfigObject):
         self.system_serial = None
         self.system_uuid = None
         self.system_family = None
+        self.chassis_asset = None
 
     def format_dom(self):
         sysinfo = super(LibvirtConfigGuestSysinfo, self).format_dom()
@@ -1008,6 +1009,7 @@ class LibvirtConfigGuestSysinfo(LibvirtConfigObject):
 
         bios = etree.Element("bios")
         system = etree.Element("system")
+        chassis = etree.Element("chassis")
 
         if self.bios_vendor is not None:
             bios.append(self._text_node("entry", self.bios_vendor,
@@ -1041,11 +1043,18 @@ class LibvirtConfigGuestSysinfo(LibvirtConfigObject):
             system.append(self._text_node("entry", self.system_family,
                                           name="family"))
 
+        if self.chassis_asset is not None:
+            chassis.append(self._text_node("entry", self.chassis_asset,
+                                           name="asset"))
+
         if len(list(bios)) > 0:
             sysinfo.append(bios)
 
         if len(list(system)) > 0:
             sysinfo.append(system)
+
+        if len(list(chassis)) > 0:
+            sysinfo.append(chassis)
 
         return sysinfo
 

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -5511,6 +5511,9 @@ class LibvirtDriver(driver.ComputeDriver):
 
         sysinfo.system_family = "Virtual Machine"
 
+        if CONF.libvirt.smbios_asset_tag:
+            sysinfo.chassis_asset = CONF.libvirt.smbios_asset_tag
+
         return sysinfo
 
     def _set_managed_mode(self, pcidev):


### PR DESCRIPTION
At SAP we use the chassis asset tag within the SMBIOS sysinfo structure to track billing. This PR allows configuring the tag in libvirt like [how it's configured in VMWare](https://github.com/sapcc/nova/blob/e446e928429ecb52abb945922ac37bb1cfa7be38/nova/conf/vmware.py#L424>).

This PR is one part of the fix for ["setting chassis_asset_tag to 'SAP CCloud VM' for KVM vms"](<https://github.com/cobaltcore-dev/cobaltcore/issues/37>).