### PR TITLE
ironic: Fix fetching instances

### DIFF
--- a/nova/virt/ironic/driver.py
+++ b/nova/virt/ironic/driver.py
@@ -676,9 +676,11 @@ class IronicDriver(virt_driver.ComputeDriver):
         :raises: VirtDriverNotReady
 
         """
-
-        uuids = [node.instance_uuid for node in self._get_node_list(
-            associated=True, fields=['instance_uuid'])]
+        conductor_group = CONF.ironic.conductor_group
+        kwargs = {'associated': True, 'fields': ['instance_uuid']}
+        if conductor_group is not None:
+            kwargs['conductor_group'] = conductor_group
+        uuids = [node.instance_uuid for node in self._get_node_list(**kwargs)]
         filters = {'uuid': uuids}
         context = nova_context.get_admin_context()
         instances = objects.InstanceList.get_by_filters(context,


### PR DESCRIPTION
When fetching instances in `list_instances()` we need to provide the `conductor_group` parameter to `_get_node_list()`. Otherwise, we would get the instances of all Ironic nodes and therefore also steal other Ironic node's instances when `CONF.ironic.update_host` is set.

Change-Id: I18c1a60c197551865500b289dfc538cdf5cb0b12
Fixup-for: If1abb6ba8ba96b8d8ea69f169d715472041f20aa