### PR TITLE
vmware: Fix delete_shadow_vms() for VolumeMoRefProxy

### DIFF
--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -830,7 +830,7 @@ class VMwareVolumeOps(object):
                 if driver_type == constants.DISK_FORMAT_FCD:
                     continue
                 data = connection_info["data"]
-                volume_ref = self._get_volume_ref(data["volume"])
+                volume_ref = self._get_volume_ref(data)
                 destroy_task = session._call_method(session.vim,
                                             "Destroy_Task",
                                             volume_ref)


### PR DESCRIPTION
Since we upstreamed `VolumeMoRefProxy`, we didn't pick the patch for it locally anymore and thus didn't patch our live-migration code to properly support it.

Change-Id: Ib35be72a7f350cc8e2ea8cdfe16b457a52e6a8b2
Fixup-for: If8c7265c53b64f00292e6689d1f6860ff29c671e