### PR TITLE
Fix issue with "disable db-only delete" when using --force

### DIFF
--- a/nova/api/openstack/compute/deferred_delete.py
+++ b/nova/api/openstack/compute/deferred_delete.py
@@ -47,7 +47,7 @@ class DeferredDeleteController(wsgi.Controller):
                     'restore', id)
 
     @wsgi.response(202)
-    @wsgi.expected_errors((404, 409))
+    @wsgi.expected_errors((404, 409, 503))
     @wsgi.action('forceDelete')
     def _force_delete(self, req, id, body):
         """Force delete of instance before deferred cleanup."""
@@ -62,3 +62,6 @@ class DeferredDeleteController(wsgi.Controller):
             raise webob.exc.HTTPNotFound(explanation=e.format_message())
         except exception.InstanceIsLocked as e:
             raise webob.exc.HTTPConflict(explanation=e.format_message())
+        except exception.ComputeServiceUnavailable as e:
+            raise webob.exc.HTTPServiceUnavailable(
+                explanation=e.format_message())

--- a/nova/api/openstack/compute/servers.py
+++ b/nova/api/openstack/compute/servers.py
@@ -1114,10 +1114,9 @@ class ServersController(wsgi.Controller):
         except exception.InstanceInvalidState as state_error:
             common.raise_http_conflict_for_instance_invalid_state(state_error,
                     'delete', id)
-        except exception.ComputeServiceUnavailable:
-            msg = _("The server's hypervisor is not available at the moment. "
-                    "Please try again later.")
-            raise webob.exc.HTTPServiceUnavailable(explanation=msg)
+        except exception.ComputeServiceUnavailable as e:
+            raise webob.exc.HTTPServiceUnavailable(
+                explanation=e.format_message())
 
     def _image_from_req_data(self, server_dict, create_kwargs):
         """Get image data from the request or raise appropriate

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -2522,8 +2522,10 @@ class API:
                         # get deleted once the compute service is up again
                         instance.task_state = None
                         instance.save()
+                        msg = _("The server's hypervisor is not available at "
+                                "the moment. Please try again later.")
                         raise exception.ComputeServiceUnavailable(
-                            host=instance.host)
+                            host=instance.host, message=msg)
                 if not is_local_delete:
                     if original_task_state in (task_states.DELETING,
                                                   task_states.SOFT_DELETING):


### PR DESCRIPTION
With "disable db only delete" enabled, when using force delete, a ComputeServiceUnavailable exception is raised but not caught. This change fixes this, catching the exception and reporting the same error message to the user as if they used delete without force.