### PR TITLE
SAP: Use is_instance_storage_share instead of ssh

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -615,6 +615,10 @@ class ComputeVirtAPI(virtapi.VirtAPI):
             self.reportclient.set_traits_for_provider(
                 context, rp_uuid, new_traits, generation=trait_info.generation)
 
+    def is_instance_storage_shared(self, context, instance, host=None):
+        return self._compute._is_instance_storage_shared(context, instance,
+                                                         host=host)
+
 
 class ComputeManager(manager.Manager):
     """Manages the running instances from creation to destruction."""
@@ -6105,7 +6109,7 @@ class ComputeManager(manager.Manager):
             timeout, retry_interval = self._get_power_off_values(
                 instance, clean_shutdown)
             disk_info = self.driver.migrate_disk_and_power_off(
-                context, instance, migration.dest_host,
+                context, instance, migration,
                 flavor, network_info,
                 block_device_info,
                 timeout, retry_interval)

--- a/nova/tests/unit/virt/hyperv/test_driver.py
+++ b/nova/tests/unit/virt/hyperv/test_driver.py
@@ -24,6 +24,7 @@ from unittest import mock
 from os_win import exceptions as os_win_exc
 
 from nova import exception
+from nova import objects
 from nova import safe_utils
 from nova.tests.unit import fake_instance
 from nova.tests.unit.virt.hyperv import test_base
@@ -387,15 +388,17 @@ class HyperVDriverTestCase(test_base.HyperVBaseTestCase):
             mock.sentinel.instance, mock.sentinel.network_info)
 
     def test_migrate_disk_and_power_off(self):
+        migration = objects.Migration(dest_host='10.0.0.1',
+                                      dest_compute='mock-compute')
         self.driver.migrate_disk_and_power_off(
-            mock.sentinel.context, mock.sentinel.instance, mock.sentinel.dest,
+            mock.sentinel.context, mock.sentinel.instance, migration,
             mock.sentinel.flavor, mock.sentinel.network_info,
             mock.sentinel.block_device_info, mock.sentinel.timeout,
             mock.sentinel.retry_interval)
 
         migr_power_off = self.driver._migrationops.migrate_disk_and_power_off
         migr_power_off.assert_called_once_with(
-            mock.sentinel.context, mock.sentinel.instance, mock.sentinel.dest,
+            mock.sentinel.context, mock.sentinel.instance, migration.dest_host,
             mock.sentinel.flavor, mock.sentinel.network_info,
             mock.sentinel.block_device_info, mock.sentinel.timeout,
             mock.sentinel.retry_interval)

--- a/nova/tests/unit/virt/test_virt_drivers.py
+++ b/nova/tests/unit/virt/test_virt_drivers.py
@@ -301,7 +301,7 @@ class _VirtDriverTestCase(_FakeDriverBackendTestCase):
         instance_ref, network_info = self._get_running_instance()
         flavor_ref = test_utils.get_test_flavor()
         self.connection.migrate_disk_and_power_off(
-            self.ctxt, instance_ref, 'dest_host', flavor_ref,
+            self.ctxt, instance_ref, mock.sentinel.migration, flavor_ref,
             network_info)
 
     @catch_notimplementederror

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2488,13 +2488,16 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
     def test_resize_to_smaller_disk(self):
         self._create_vm(flavor='m1.large')
         flavor = self._get_flavor_by_name('m1.small')
-        fake_dest = '1.0|vcenter-uuid'
+        migration = objects.Migration(
+            dest_host='1.0|vcenter-uuid'
+        )
+
         with test.nested(
             mock.patch('nova.compute.utils.is_volume_backed_instance',
                        return_value=False)):
             self.assertRaises(exception.InstanceFaultRollback,
                               self.conn.migrate_disk_and_power_off,
-                              self.context, self.instance, fake_dest, flavor,
+                              self.context, self.instance, migration, flavor,
                               None)
 
     def test_spawn_attach_volume_vmdk(self):

--- a/nova/virt/driver.py
+++ b/nova/virt/driver.py
@@ -733,7 +733,7 @@ class ComputeDriver(object):
         """
         raise NotImplementedError()
 
-    def migrate_disk_and_power_off(self, context, instance, dest,
+    def migrate_disk_and_power_off(self, context, instance, migration,
                                    flavor, network_info,
                                    block_device_info=None,
                                    timeout=0, retry_interval=0):
@@ -742,8 +742,8 @@ class ComputeDriver(object):
 
         :param nova.objects.instance.Instance instance:
             The instance whose disk should be migrated.
-        :param str dest:
-            The IP address of the destination host.
+        :param nova.objects.migration.Migration migration:
+            The migration to be executed
         :param nova.objects.flavor.Flavor flavor:
             The flavor of the instance whose disk get migrated.
         :param nova.network.model.NetworkInfo network_info:

--- a/nova/virt/fake.py
+++ b/nova/virt/fake.py
@@ -255,7 +255,7 @@ class FakeDriver(driver.ComputeDriver):
     def poll_rebooting_instances(self, timeout, instances):
         pass
 
-    def migrate_disk_and_power_off(self, context, instance, dest,
+    def migrate_disk_and_power_off(self, context, instance, migration,
                                    flavor, network_info,
                                    block_device_info=None,
                                    timeout=0, retry_interval=0):
@@ -683,6 +683,9 @@ class FakeVirtAPI(virtapi.VirtAPI):
         pass
 
     def update_compute_provider_status(self, context, rp_uuid, enabled):
+        pass
+
+    def is_instance_storage_shared(self, context, instance, host=None):
         pass
 
 

--- a/nova/virt/hyperv/driver.py
+++ b/nova/virt/hyperv/driver.py
@@ -310,12 +310,14 @@ class HyperVDriver(driver.ComputeDriver):
         """Unplug VIFs from networks."""
         self._vmops.unplug_vifs(instance, network_info)
 
-    def migrate_disk_and_power_off(self, context, instance, dest,
+    def migrate_disk_and_power_off(self, context, instance, migration,
                                    flavor, network_info,
                                    block_device_info=None,
                                    timeout=0, retry_interval=0):
+        dest_host = migration.dest_host
         return self._migrationops.migrate_disk_and_power_off(context,
-                                                             instance, dest,
+                                                             instance,
+                                                             dest_host,
                                                              flavor,
                                                              network_info,
                                                              block_device_info,

--- a/nova/virt/virtapi.py
+++ b/nova/virt/virtapi.py
@@ -34,3 +34,6 @@ class VirtAPI(object):
             the trait would be added.
         """
         raise NotImplementedError()
+
+    def is_instance_storage_shared(self, context, instance, host=None):
+        raise NotImplementedError()

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -324,7 +324,7 @@ class VMwareVCDriver(driver.ComputeDriver):
         """List VM instances from the single compute node."""
         return self._vmops.list_instances()
 
-    def migrate_disk_and_power_off(self, context, instance, dest,
+    def migrate_disk_and_power_off(self, context, instance, migration,
                                    flavor, network_info,
                                    block_device_info=None,
                                    timeout=0, retry_interval=0):
@@ -332,6 +332,7 @@ class VMwareVCDriver(driver.ComputeDriver):
         off the instance before the end.
         """
         # TODO(PhilDay): Add support for timeout (clean shutdown)
+        dest = migration.dest_host
         return self._vmops.migrate_disk_and_power_off(
             context, instance, dest, flavor, network_info, block_device_info)
 


### PR DESCRIPTION
The libvirt-driver implements is_instance_storage_share twice:
Once on driver-internally as `_is_path_shared_with` needing an ssh
trust, and via the driver interface `is_instance_storage_shared`,
relying on RPC.

By exposing `is_instance_storage_shared` in ComputeVirtAPI, the driver
can use this instead of the internal method removing the need for an SSH
key in case of having a shared storage.

But since it requires a change of the driver internal API, it is
questionable if we can upstream the change as it is.

Change-Id: Icddad1ab000ea07dea7af3aa5f7c18974f4eb8fb