### PR TITLE
vmwarepi: Mock out nova.utils.spawn in test

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -242,8 +242,16 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
         """
         self.useFixture(
             fixtures.MonkeyPatch(
+                'nova.utils.spawn',
+                self._fake_spawn))
+
+        self.useFixture(
+            fixtures.MonkeyPatch(
                 'nova.utils.vm_needs_special_spawning',
                 self._fake_vm_needs_special_spawning))
+
+    def _fake_spawn(self, func, *args, **kwargs):
+        return None
 
     def _fake_vm_needs_special_spawning(self, *args, **kwargs):
         return True


### PR DESCRIPTION
Otherwise, we will spawn sync threads, which we rather want to avoid in the unit tests.

Change-Id: I5a02bd4aba3124649516cda71ecf93129ab8d679