### PR TITLE
[nova-compute] clean up VMs stuck in deleting

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -47,6 +47,7 @@ import eventlet.timeout
 import futurist
 from keystoneauth1 import exceptions as keystone_exception
 import os_traits
+from oslo_concurrency import lockutils
 from oslo_log import log as logging
 import oslo_messaging as messaging
 from oslo_serialization import jsonutils
@@ -10679,6 +10680,54 @@ class ComputeManager(manager.Manager):
                     LOG.warning("Periodic reclaim failed to delete "
                                 "instance: %s",
                                 e, instance=instance)
+
+    @periodic_task.periodic_task(
+            spacing=CONF.instances_stuck_in_deleting_cleanup_interval)
+    def _cleanup_instances_stuck_in_deleting(self, context):
+        """Get instances stuck in DELETING state, but not really destroyed,
+        and retrigger terminate_instance for them.
+        """
+        filters = {'task_state': task_states.DELETING,
+                   'host': self.host}
+        instances = objects.InstanceList.get_by_filters(
+            context, filters,
+            expected_attrs=objects.instance.INSTANCE_DEFAULT_FIELDS,
+             use_slave=True)
+        for instance in instances:
+            # Check if the instance has a process lock
+            try:
+                with lockutils.lock(instance.uuid,
+                                    lock_file_prefix="nova-",
+                                    external=False, blocking=False):
+                    LOG.info(
+                            "Cleanup instance found in DELETING state but "
+                            "has no process lock", instance=instance)
+                    try:
+                        bdms = (objects.BlockDeviceMappingList.
+                                        get_by_instance_uuid(context,
+                                                             instance.uuid))
+                    except Exception as e:
+                        LOG.info("Failed to get bdms of the instance "
+                                 "to delete: %s %s", e, instance=instance)
+                        continue
+
+                    try:
+                        self._delete_instance(context, instance, bdms)
+                    except exception.InstanceNotFound:
+                        LOG.info("Instance disappeared during terminate",
+                                 instance=instance)
+                    except Exception as e:
+                        LOG.warning("Failed to delete instance: %s %s",
+                                    e, instance=instance)
+            except lockutils.AcquireLockFailedException:
+                # as we are acquiring a non-blocking lock this means another
+                # thread is running and already acquired the lock
+                continue
+            except Exception as e:
+                LOG.warning("Failed while acquiring lock for instance "
+                            "in deleting: %s %s",
+                            e, instance=instance)
+                continue
 
     def _get_nodename(self, instance, refresh=False):
         """Helper method to get the name of the first available node

--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -1236,6 +1236,19 @@ Related options:
 * ``maximum_instance_delete_attempts`` from instance_cleaning_opts
   group.
 """),
+    cfg.IntOpt('instances_stuck_in_deleting_cleanup_interval',
+        default=300,
+        help="""
+Interval between two cleanup jobs.
+
+This option sets the interval for the periodic task that cleans up instances
+stuck in ``DELETING`` task state.
+
+Possible values:
+
+* Any value <= 0: Disables the option.
+* Any positive integer in seconds.
+"""),
     cfg.IntOpt('block_device_allocate_retries_interval',
         default=3,
         min=0,

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -29,6 +29,7 @@ from cinderclient import exceptions as cinder_exception
 import ddt
 from keystoneclient import exceptions as keystone_exception
 from neutronclient.common import exceptions as neutron_exceptions
+from oslo_concurrency import lockutils
 from oslo_log import log as logging
 import oslo_messaging as messaging
 from oslo_serialization import base64
@@ -8168,6 +8169,47 @@ class ComputeTestCase(BaseTestCase,
         mock_delete_inst.assert_has_calls([
             mock.call(ctxt, instance1, []),
             mock.call(ctxt, instance2, [])])
+
+    @mock.patch.object(objects.BlockDeviceMappingList, 'get_by_instance_uuid')
+    @mock.patch.object(objects.InstanceList, 'get_by_filters')
+    @mock.patch.object(compute_manager.ComputeManager, '_delete_instance')
+    def test_cleanup_instances_stuck_in_deleting(
+            self, mock_delete_instance,
+            mock_get_by_filters, mock_get_by_instance_uuid):
+        # Create a fake instance in DELETING state
+        instance = fake_instance.fake_instance_obj(
+                self.context, task_state=task_states.DELETING)
+        mock_get_by_filters.return_value = [instance]
+
+        # Mock the bdms
+        bdms = block_device_obj.block_device_make_list(self.context, [])
+        mock_get_by_instance_uuid.return_value = bdms
+
+        # Create lock for something else.
+        with lockutils.lock("another-uuid", lock_file_prefix="nova-"):
+            # Call the method
+            self.compute._cleanup_instances_stuck_in_deleting(self.context)
+            # Verify that terminate_instance was called for the instance
+            mock_delete_instance.assert_called_once_with(
+                    self.context, instance, bdms)
+
+    @mock.patch.object(objects.InstanceList, 'get_by_filters')
+    @mock.patch.object(compute_manager.ComputeManager, '_delete_instance')
+    def test_cleanup_instances_in_deleting_state_but_not_stuck(
+            self, mock_delete_instance,
+            mock_get_by_filters):
+        # Create a fake instance in DELETING state
+        instance = fake_instance.fake_instance_obj(
+                self.context, task_state=task_states.DELETING)
+        mock_get_by_filters.return_value = [instance]
+
+        # Create Lock using the instance uuid
+        with lockutils.lock(instance.uuid, lock_file_prefix="nova-"):
+            # Call the method
+            self.compute._cleanup_instances_stuck_in_deleting(self.context)
+
+            # Verify that terminate_instance was not called for the instance
+            mock_delete_instance.assert_not_called()
 
     @mock.patch.object(fake.FakeDriver, 'get_info')
     @mock.patch.object(compute_manager.ComputeManager,


### PR DESCRIPTION
Add a periodic task to clean up all VMs in DELETING task state and do not have a process lock with its UUID.

The issue it solves:
- Nova-api sets the VM in DELETING task state when it receives a delete instance API call, and triggers an RPC call.
- if RabbitMQ failed before nove-compute picks up the message from queue, the request get lost, but the VM stays in DELETING task state. 
- This task state makes nova-api ignore all new coming delete instance API requests, which case the VM to stuck in DELETING task state.

Change-Id: Ie53b3bca16d35407b3d3bcfc6e43085622053a0b