### PR TITLE
[scheduler] Catch empty external scheduler responses

### DIFF
--- a/nova/scheduler/external.py
+++ b/nova/scheduler/external.py
@@ -99,11 +99,13 @@ def call_external_scheduler_api(weighed_hosts, weights, spec_obj):
         LOG.error("External scheduler response is invalid: %s", e)
         return weighed_hosts
 
-    # The list of host names can also be empty. In this case, we trust
-    # the external scheduler decision and return an empty list.
+    # The external scheduler should not filter out all hosts. If it does,
+    # we should fall back to the original host list. This will prevent the
+    # external scheduler from blocking all scheduling requests.
     if not (host_names := response_json["hosts"]):
-        # If this case happens often, it may indicate an issue.
-        LOG.warning("External scheduler filtered out all hosts.")
+        errmsg = "External scheduler filtered out all hosts."
+        LOG.error("External scheduler response is invalid: %s", errmsg)
+        return weighed_hosts
 
     # Reorder the weighed hosts based on the list of host names returned
     # by the external scheduler api.

--- a/nova/tests/unit/scheduler/test_external.py
+++ b/nova/tests/unit/scheduler/test_external.py
@@ -80,22 +80,32 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
         self.assertIn('Calling external scheduler API with ', log)
 
     @patch('requests.post')
-    @patch('nova.scheduler.external.LOG.warning')
-    def test_enabled_api_empty_response(self, mock_warn_log, mock_post):
+    @patch('nova.scheduler.external.LOG.error')
+    def test_enabled_api_empty_response(self, mock_err_log, mock_post):
         mock_response = MagicMock()
         mock_response.status_code = 200
+        # Response with no hosts (all hosts filtered out).
         mock_response.json.return_value = {'hosts': []}
         mock_post.return_value = mock_response
+
+        log = ""
+
+        def append_log(msg, data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
 
         hosts = call_external_scheduler_api(
             self.example_hosts,
             self.example_weights,
             self.example_spec,
         )
-        self.assertEqual([], hosts)
-        mock_warn_log.assert_called_with(
-            'External scheduler filtered out all hosts.'
+        # Should revert back to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.host for h in hosts]
         )
+        self.assertIn('External scheduler filtered out all hosts.', log)
 
     @patch('requests.post')
     @patch('nova.scheduler.external.LOG.error')


### PR DESCRIPTION
Before, the external scheduler could filter out all hosts
in the request. However, it is better to catch this case
for now and revert back to the original host list. In this
way, we avoid that, in case of an issue in the external
scheduler, all hosts are blocked. This increases the
safety of the external call.