### PR TITLE
vmware: Support disabled admission control

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/fake.py
+++ b/nova/tests/unit/virt/vmwareapi/fake.py
@@ -654,6 +654,8 @@ class ClusterComputeResource(ManagedObject):
         policy = None
         configuration.dasConfig.admissionControlPolicy = policy
         self.set("configuration.dasConfig.admissionControlPolicy", policy)
+        configuration.dasConfig.admissionControlEnabled = True
+        self.set("configuration.dasConfig.admissionControlEnabled", True)
 
     def _add_root_resource_pool(self, r_pool):
         if r_pool:

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -100,14 +100,16 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                                      maintenance_mode=False,
                                      failover_policy=None,
                                      failover_hosts_filtered=0,
-                                     expected_stats=None):
+                                     expected_stats=None,
+                                     policy_enabled=True):
         ManagedObjectRefs = [fake.ManagedObjectReference("HostSystem",
                                                          "host1"),
                              fake.ManagedObjectReference("HostSystem",
                                                          "host2")]
         hosts = fake._convert_to_array_of_mor(ManagedObjectRefs)
         respool = fake.ManagedObjectReference("ResourcePool", "resgroup-11")
-        prop_dict = {'host': hosts, 'resourcePool': respool}
+        prop_dict = {'host': hosts, 'resourcePool': respool,
+            'configuration.dasConfig.admissionControlEnabled': policy_enabled}
 
         if failover_policy:
             k = 'configuration.dasConfig.admissionControlPolicy'
@@ -215,6 +217,17 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         self._test_get_stats_from_cluster(failover_policy=policy,
                                           failover_hosts_filtered=1)
 
+    def test_get_stats_from_cluster_failover_host_matches_disabled(self):
+        policy = fake.DataObject('ClusterFailoverHostAdmissionControlPolicy')
+        # it looks like a moref, but it's called a FailoverHosts object
+        host = fake.DataObject('failoverHosts')
+        host.value = 'host1'
+        host._type = 'HostSystem'
+        policy.failoverHosts = [host]
+        self._test_get_stats_from_cluster(failover_policy=policy,
+                                          failover_hosts_filtered=0,
+                                          policy_enabled=False)
+
     def test_get_stats_from_cluster_failover_host_no_matches(self):
         policy = fake.DataObject('ClusterFailoverHostAdmissionControlPolicy')
         # it looks like a moref, but it's called a FailoverHosts object
@@ -264,6 +277,18 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         self._test_get_stats_from_cluster(failover_policy=policy,
                                           failover_hosts_filtered=0,
                                           expected_stats=expected)
+
+    def test_get_stats_from_cluster_failover_resources_policy_disabled(self):
+        name = 'ClusterFailoverResourcesAdmissionControlPolicy'
+        policy = fake.DataObject(name)
+        policy.cpuFailoverResourcesPercent = 25
+        policy.memoryFailoverResourcesPercent = 25
+        policy.resourceReductionToToleratePercent = 100
+        policy.autoComputePercentages = True
+
+        self._test_get_stats_from_cluster(failover_policy=policy,
+                                          failover_hosts_filtered=0,
+                                          policy_enabled=False)
 
     @mock.patch('nova.virt.vmwareapi.vm_util._get_host_reservations_map')
     def test_get_stats_from_cluster_reservations(self, mock_map):

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1799,7 +1799,8 @@ def get_stats_from_cluster_per_host(session, cluster):
 def get_hosts_and_reservations_for_cluster(session, cluster):
     # Get the Host and Resource Pool Managed Object Refs
     admission_policy_key = "configuration.dasConfig.admissionControlPolicy"
-    props = ["host", "resourcePool", admission_policy_key]
+    policy_enabled_key = "configuration.dasConfig.admissionControlEnabled"
+    props = ["host", "resourcePool", admission_policy_key, policy_enabled_key]
     if CONF.vmware.hostgroup_reservations_json_file:
         props.append("configurationEx")
     prop_dict = session._call_method(vutil,
@@ -1812,7 +1813,7 @@ def get_hosts_and_reservations_for_cluster(session, cluster):
     failover_hosts = []
     additional_reservations = {}
     policy = prop_dict.get(admission_policy_key)
-    if policy:
+    if policy and prop_dict.get(policy_enabled_key, False):
         # full hosts are reserved for failover
         if hasattr(policy, 'failoverHosts'):
             failover_hosts = set(h.value for h in policy.failoverHosts)


### PR DESCRIPTION
While there can be different policies set for admission control and we already support failover hosts and percentage based HA resource reservations, the admission control can also be disabled. The API will still return the previously-configured config, we can also see it by retrieving an additional property: `admissionControlEnabled`.

If admission control is disabled, we do not reserve any resources.

Change-Id: I45c22f6b48e32a33d7ca78a4975ac52925715ce7