### PR TITLE
libvirt: fix maxphysaddr passthrough dom parsing

### DIFF
--- a/nova/tests/unit/virt/libvirt/test_config.py
+++ b/nova/tests/unit/virt/libvirt/test_config.py
@@ -525,7 +525,7 @@ class LibvirtConfigCPUTest(LibvirtConfigBaseTest):
             </cpu>
         """)
 
-    def test_parse_dom(self):
+    def test_parse_dom_emulate(self):
         xml = """
             <cpu>
               <maxphysaddr mode='emulate' bits='42'/>
@@ -537,6 +537,20 @@ class LibvirtConfigCPUTest(LibvirtConfigBaseTest):
 
         self.assertEqual("emulate", obj.maxphysaddr.mode)
         self.assertEqual(42, obj.maxphysaddr.bits)
+
+    def test_parse_dom_passthrough(self):
+        """Passthrough mode has no "bits" attribute"""
+        xml = """
+            <cpu>
+              <maxphysaddr mode='passthrough'/>
+            </cpu>
+        """
+        xmldoc = etree.fromstring(xml)
+        obj = config.LibvirtConfigCPU()
+        obj.parse_dom(xmldoc)
+
+        self.assertEqual("passthrough", obj.maxphysaddr.mode)
+        self.assertIsNone(obj.maxphysaddr.bits)
 
 
 class LibvirtConfigGuestCPUTest(LibvirtConfigBaseTest):

--- a/nova/virt/libvirt/config.py
+++ b/nova/virt/libvirt/config.py
@@ -789,7 +789,8 @@ class LibvirtConfigCPUMaxPhysAddr(LibvirtConfigObject):
         super(LibvirtConfigCPUMaxPhysAddr, self).parse_dom(xmldoc)
 
         self.mode = xmldoc.get("mode")
-        self.bits = int(xmldoc.get("bits"))
+        if xmldoc.get("bits") is not None:
+            self.bits = int(xmldoc.get("bits"))
 
     def format_dom(self):
         m = super(LibvirtConfigCPUMaxPhysAddr, self).format_dom()


### PR DESCRIPTION
applying patch from Johannes that has been merged upstream

see [upstream](https://review.opendev.org/c/openstack/nova/+/942371)
see [slack](https://convergedcloud.slack.com/archives/C06JTCKNMDM/p1743156956514089?thread_ts=1739983849.479619&cid=C06JTCKNMDM)

---

If `hw:maxphysaddr_mode` is set to `passthrough`, the generated XML doesn't contain a `bits` attribute. Our
`LibvirtConfigCPUMaxPhysAddr.parse_dom()` assumed `bits` was always set and the tests only tested parsing the XML for the `emulate` mode.

Closes-Bug: #2099663
Change-Id: Ic16561dfb38612ac46c2148f2847006f6890940e