### PR TITLE
scheduler: Send request context to external scheduler

### DIFF
--- a/nova/scheduler/external.py
+++ b/nova/scheduler/external.py
@@ -48,8 +48,14 @@ response_schema = {
 }
 
 
-def call_external_scheduler_api(weighed_hosts, weights, spec_obj):
-    """Reorder and filter hosts using an external scheduler service."""
+def call_external_scheduler_api(context, weighed_hosts, weights, spec_obj):
+    """Reorder and filter hosts using an external scheduler service.
+
+    :param context: The RequestContext object containing request id, user, etc.
+    :param weighed_hosts: List of hosts to send to the external scheduler.
+    :param weights: A dictionary of host names and their corresponding weights.
+    :param spec_obj: The RequestSpec object with the vm specification.
+    """
     if not weighed_hosts:
         return weighed_hosts
     if not (url := CONF.filter_scheduler.external_scheduler_api_url):
@@ -59,6 +65,9 @@ def call_external_scheduler_api(weighed_hosts, weights, spec_obj):
 
     json_data = {
         "spec": spec_obj.obj_to_primitive(),
+        # Also serialize the request context, which contains the global request
+        # id and other information helpful for logging and request tracing.
+        "context": context.to_dict(),
         # Extract some flags from the spec to indicate the type of
         # request. This will allow the external scheduler to quickly
         # decide if it wants to handle the request or not.

--- a/nova/scheduler/manager.py
+++ b/nova/scheduler/manager.py
@@ -419,7 +419,7 @@ class SchedulerManager(manager.Manager):
             # Reset the field so it's not persisted accidentally.
             spec_obj.obj_reset_changes(['instance_uuid'])
 
-            hosts = self._get_sorted_hosts(spec_obj, hosts, num)
+            hosts = self._get_sorted_hosts(context, spec_obj, hosts, num)
             if not hosts:
                 # NOTE(jaypipes): If we get here, that means not all instances
                 # in instance_uuids were able to be matched to a selected host.
@@ -490,6 +490,7 @@ class SchedulerManager(manager.Manager):
         # claimed allocation request. Now we need to find alternates for each
         # host.
         return self._get_alternate_hosts(
+            context,
             claimed_hosts,
             spec_obj,
             hosts,
@@ -564,7 +565,7 @@ class SchedulerManager(manager.Manager):
                 spec_obj.instance_uuid = instance_uuid
                 spec_obj.obj_reset_changes(['instance_uuid'])
 
-            hosts = self._get_sorted_hosts(spec_obj, hosts, num)
+            hosts = self._get_sorted_hosts(context, spec_obj, hosts, num)
             if not hosts:
                 # No hosts left, so break here, and the
                 # _ensure_sufficient_hosts() call below will handle this.
@@ -584,7 +585,7 @@ class SchedulerManager(manager.Manager):
         # representing the selected host along with zero or more alternates
         # from the same cell.
         return self._get_alternate_hosts(
-            selected_hosts, spec_obj, hosts, num, num_alts)
+            context, selected_hosts, spec_obj, hosts, num, num_alts)
 
     @staticmethod
     def _consume_selected_host(selected_host, spec_obj, instance_uuid=None):
@@ -608,7 +609,7 @@ class SchedulerManager(manager.Manager):
                     uuid=instance_uuid)
 
     def _get_alternate_hosts(
-        self, selected_hosts, spec_obj, hosts, index, num_alts,
+        self, context, selected_hosts, spec_obj, hosts, index, num_alts,
         alloc_reqs_by_rp_uuid=None, allocation_request_version=None,
         selected_alloc_reqs=None,
     ):
@@ -631,7 +632,7 @@ class SchedulerManager(manager.Manager):
             # The selected_hosts have all had resources 'claimed' via
             # _consume_selected_host, so we need to filter/weigh and sort the
             # hosts again to get an accurate count for alternates.
-            hosts = self._get_sorted_hosts(spec_obj, hosts, index)
+            hosts = self._get_sorted_hosts(context, spec_obj, hosts, index)
 
         # This is the overall list of values to be returned. There will be one
         # item per instance, and each item will be a list of Selection objects
@@ -698,7 +699,7 @@ class SchedulerManager(manager.Manager):
 
         return selections_to_return
 
-    def _get_sorted_hosts(self, spec_obj, host_states, index):
+    def _get_sorted_hosts(self, context, spec_obj, host_states, index):
         """Returns a list of HostState objects that match the required
         scheduling constraints for the request spec object and have been sorted
         according to the weighers.
@@ -740,7 +741,7 @@ class SchedulerManager(manager.Manager):
         # Call an external service that can modify `weighed_hosts` once more.
         # This service may filter out some hosts, or it may re-order them.
         weighed_hosts = call_external_scheduler_api(
-            weighed_hosts, weights, spec_obj)
+            context, weighed_hosts, weights, spec_obj)
         if not weighed_hosts:
             return []
 

--- a/nova/tests/unit/scheduler/test_external.py
+++ b/nova/tests/unit/scheduler/test_external.py
@@ -16,10 +16,10 @@
 
 from unittest.mock import MagicMock
 from unittest.mock import patch
-from unittest.mock import sentinel
 
 import requests
 
+from nova import context
 from nova import objects
 from nova.scheduler.external import call_external_scheduler_api
 from nova import test
@@ -43,14 +43,51 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
             'host2': 0.5,
             'host3': 0.0,
         }
+        self.example_ctx = context.RequestContext(
+            user_id='fake_user',
+            project_id='fake_project',
+            is_admin=False,
+            read_deleted='no',
+            global_request_id='fake_global_request_id',
+        )
         self.example_spec = objects.RequestSpec(
-            context=sentinel.ctx,
+            context=self.example_ctx,
             flavor=objects.Flavor(
                 name='small',
                 vcpus=4,
                 memory_mb=1024,
                 extra_specs={},
             ),
+        )
+
+    @patch('requests.post')
+    def test_context_included_in_request(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': ['host1', 'host3']}
+        mock_post.return_value = mock_response
+
+        call_external_scheduler_api(
+            self.example_ctx,
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+
+        # Check that the context is serialized and included in the request
+        _, kwargs = mock_post.call_args
+        self.assertIn(
+            'context', kwargs['json'],
+            'Context should be included in the request'
+        )
+        self.assertIn(
+            'global_request_id', kwargs['json']['context'],
+            'Global request ID should be included in the context'
+        )
+        self.assertEqual(
+            self.example_ctx.to_dict(),
+            kwargs['json']['context'],
+            'Context should be serialized correctly'
         )
 
     @patch('requests.post')
@@ -69,6 +106,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
         mock_debug_log.side_effect = append_log
 
         hosts = call_external_scheduler_api(
+            self.example_ctx,
             self.example_hosts,
             self.example_weights,
             self.example_spec,
@@ -88,6 +126,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
         mock_post.return_value = mock_response
 
         hosts = call_external_scheduler_api(
+            self.example_ctx,
             self.example_hosts,
             self.example_weights,
             self.example_spec,
@@ -110,6 +149,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
         mock_err_log.side_effect = append_log
 
         hosts = call_external_scheduler_api(
+            self.example_ctx,
             self.example_hosts,
             self.example_weights,
             self.example_spec,
@@ -145,6 +185,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
             mock_post.return_value = mock_response
 
             hosts = call_external_scheduler_api(
+                self.example_ctx,
                 self.example_hosts,
                 self.example_weights,
                 self.example_spec,
@@ -173,6 +214,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
         mock_post.return_value = mock_response
 
         hosts = call_external_scheduler_api(
+            self.example_ctx,
             self.example_hosts,
             self.example_weights,
             self.example_spec,
@@ -197,6 +239,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
         mock_err_log.side_effect = append_log
 
         hosts = call_external_scheduler_api(
+            self.example_ctx,
             self.example_hosts,
             self.example_weights,
             self.example_spec,

--- a/nova/tests/unit/scheduler/test_manager.py
+++ b/nova/tests/unit/scheduler/test_manager.py
@@ -413,7 +413,7 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
 
         visited_instances = set([])
 
-        def fake_get_sorted_hosts(_spec_obj, host_states, index):
+        def fake_get_sorted_hosts(context, _spec_obj, host_states, index):
             # Keep track of which instances are passed to the filters.
             visited_instances.add(_spec_obj.instance_uuid)
             return all_host_states
@@ -429,7 +429,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         mock_get_all_states.assert_called_once_with(
             ctx.elevated.return_value, spec_obj,
             mock.sentinel.provider_summaries)
-        mock_get_hosts.assert_called_once_with(spec_obj, all_host_states, 0)
+        mock_get_hosts.assert_called_once_with(
+            ctx, spec_obj, all_host_states, 0)
 
         self.assertEqual(len(selected_hosts), 1)
         self.assertEqual(expected_hosts, selected_hosts)
@@ -485,7 +486,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         )
         all_host_states = [host_state]
         mock_get_all_states.return_value = all_host_states
-        mock_get_hosts.side_effect = lambda spec_obj, hosts, num: list(hosts)
+        mock_get_hosts.side_effect = lambda ctx, spec_obj, hosts, num: list(
+            hosts)
 
         instance_uuids = None
         ctx = mock.Mock()
@@ -495,7 +497,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         mock_get_all_states.assert_called_once_with(
             ctx.elevated.return_value, spec_obj,
             mock.sentinel.provider_summaries)
-        mock_get_hosts.assert_called_once_with(spec_obj, all_host_states, 0)
+        mock_get_hosts.assert_called_once_with(
+            ctx, spec_obj, all_host_states, 0)
 
         self.assertEqual(len(selected_hosts), 1)
         expected_host = objects.Selection.from_host_state(host_state)
@@ -545,7 +548,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         all_host_states = [host_state]
         mock_get_all_states.return_value = all_host_states
         # simulate that every host passes the filtering
-        mock_get_hosts.side_effect = lambda spec_obj, hosts, num: list(hosts)
+        mock_get_hosts.side_effect = lambda ctx, spec_obj, hosts, num: list(
+            hosts)
         mock_claim.return_value = True
 
         instance_uuids = [uuids.instance]
@@ -620,7 +624,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         )
         all_host_states = [host_state]
         mock_get_all_states.return_value = all_host_states
-        mock_get_hosts.side_effect = lambda spec_obj, hosts, num: list(hosts)
+        mock_get_hosts.side_effect = lambda ctx, spec_obj, hosts, num: list(
+            hosts)
         mock_claim.return_value = False
 
         instance_uuids = [uuids.instance]
@@ -637,7 +642,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         mock_get_all_states.assert_called_once_with(
             ctx.elevated.return_value, spec_obj,
             mock.sentinel.provider_summaries)
-        mock_get_hosts.assert_called_once_with(spec_obj, mock.ANY, 0)
+        mock_get_hosts.assert_called_once_with(
+            ctx, spec_obj, mock.ANY, 0)
         mock_claim.assert_called_once_with(ctx.elevated.return_value,
                 self.manager.placement_client, spec_obj, uuids.instance,
                 alloc_reqs_by_rp_uuid[uuids.cn1][0],
@@ -687,7 +693,7 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
 
         calls = []
 
-        def fake_get_sorted_hosts(spec_obj, hosts, num):
+        def fake_get_sorted_hosts(context, spec_obj, hosts, num):
             c = len(calls)
             calls.append(1)
             # first instance: return all the hosts (only one)
@@ -772,7 +778,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         all_host_states = [host_state0, host_state1, host_state2]
         mock_get_all_states.return_value = all_host_states
         # simulate that every host passes the filtering
-        mock_get_hosts.side_effect = lambda spec_obj, hosts, num: list(hosts)
+        mock_get_hosts.side_effect = lambda ctx, spec_obj, hosts, num: list(
+            hosts)
         mock_claim.return_value = True
 
         instance_uuids = [uuids.instance0]
@@ -861,7 +868,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         all_host_states = [host_state0, host_state1, host_state2]
         mock_get_all_states.return_value = all_host_states
         # simulate that every host passes the filtering
-        mock_get_hosts.side_effect = lambda spec_obj, hosts, num: list(hosts)
+        mock_get_hosts.side_effect = lambda ctx, spec_obj, hosts, num: list(
+            hosts)
         mock_claim.return_value = True
 
         instance_uuids = [uuids.instance0]
@@ -963,7 +971,7 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         visited_instances = set([])
         get_sorted_hosts_called_with_host_states = []
 
-        def fake_get_sorted_hosts(_spec_obj, host_states, index):
+        def fake_get_sorted_hosts(context, _spec_obj, host_states, index):
             # Keep track of which instances are passed to the filters.
             visited_instances.add(_spec_obj.instance_uuid)
             if index % 2:
@@ -999,8 +1007,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         # second time, we pass it the hosts that were returned from
         # _get_sorted_hosts() the first time
         sorted_host_calls = [
-            mock.call(spec_obj, mock.ANY, 0),
-            mock.call(spec_obj, mock.ANY, 1),
+            mock.call(ctx, spec_obj, mock.ANY, 0),
+            mock.call(ctx, spec_obj, mock.ANY, 1),
         ]
         mock_get_hosts.assert_has_calls(sorted_host_calls)
         self.assertEqual(
@@ -1049,8 +1057,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
                     self.assertIsInstance(weighed_host, weights.WeighedHost)
         debug.side_effect = fake_debug
 
-        results = self.manager._get_sorted_hosts(mock.sentinel.spec,
-            all_host_states, mock.sentinel.index)
+        results = self.manager._get_sorted_hosts(mock.sentinel.ctx,
+            mock.sentinel.spec, all_host_states, mock.sentinel.index)
         debug.assert_called()
 
         mock_filt.assert_called_once_with(all_host_states, mock.sentinel.spec,
@@ -1081,8 +1089,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         mock_weighed.return_value = [
             weights.WeighedHost(hs1, 1.0), weights.WeighedHost(hs2, 1.0),
         ]
-        _ = self.manager._get_sorted_hosts(mock.sentinel.spec,
-            [hs1, hs2], mock.sentinel.index)
+        _ = self.manager._get_sorted_hosts(mock.sentinel.ctx,
+            mock.sentinel.spec, [hs1, hs2], mock.sentinel.index)
         mock_post.assert_not_called()
 
     @mock.patch('random.choice', side_effect=lambda x: x[0])
@@ -1104,8 +1112,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
             weights.WeighedHost(hs1, 1.0), weights.WeighedHost(hs2, 1.0),
         ]
 
-        results = self.manager._get_sorted_hosts(mock.sentinel.spec,
-            all_host_states, mock.sentinel.index)
+        results = self.manager._get_sorted_hosts(mock.sentinel.ctx,
+            mock.sentinel.spec, all_host_states, mock.sentinel.index)
 
         mock_filt.assert_called_once_with(all_host_states, mock.sentinel.spec,
             mock.sentinel.index)
@@ -1136,8 +1144,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
             weights.WeighedHost(hs1, 1.0), weights.WeighedHost(hs2, 1.0),
         ]
 
-        results = self.manager._get_sorted_hosts(mock.sentinel.spec,
-            all_host_states, mock.sentinel.index)
+        results = self.manager._get_sorted_hosts(mock.sentinel.ctx,
+            mock.sentinel.spec, all_host_states, mock.sentinel.index)
 
         mock_filt.assert_called_once_with(all_host_states, mock.sentinel.spec,
             mock.sentinel.index)
@@ -1174,8 +1182,8 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
             weights.WeighedHost(hs4, 0.5),
         ]
 
-        results = self.manager._get_sorted_hosts(mock.sentinel.spec,
-            all_host_states, mock.sentinel.index)
+        results = self.manager._get_sorted_hosts(mock.sentinel.ctx,
+            mock.sentinel.spec, all_host_states, mock.sentinel.index)
 
         mock_filt.assert_called_once_with(all_host_states, mock.sentinel.spec,
             mock.sentinel.index)
@@ -1339,7 +1347,7 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
 
         calls = []
 
-        def fake_get_sorted_hosts(spec_obj, hosts, num):
+        def fake_get_sorted_hosts(context, spec_obj, hosts, num):
             c = len(calls)
             calls.append(1)
             if c == 0:
@@ -1378,7 +1386,7 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
             alloc_reqs[hs.uuid] = [{}]
 
         mock_get_all_hosts.return_value = all_host_states
-        mock_sorted.side_effect = lambda spec_obj, hosts, num: list(hosts)
+        mock_sorted.side_effect = lambda ctx, spec_obj, hosts, num: list(hosts)
         mock_claim.return_value = True
         total_returned = num_alternates + 1
         self.flags(max_attempts=total_returned, group="scheduler")
@@ -1449,7 +1457,7 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
         # instance and then once again before picking alternates.
         calls = []
 
-        def fake_get_sorted_hosts(spec_obj, hosts, num):
+        def fake_get_sorted_hosts(context, spec_obj, hosts, num):
             c = len(calls)
             calls.append(1)
             if c == 0:
@@ -1510,7 +1518,7 @@ class SchedulerManagerTestCase(test.NoDBTestCase):
             alloc_reqs[hs.uuid] = [{}]
 
         mock_get_all_hosts.return_value = all_host_states
-        mock_sorted.side_effect = lambda spec_obj, hosts, num: list(hosts)
+        mock_sorted.side_effect = lambda ctx, spec_obj, hosts, num: list(hosts)
         mock_claim.return_value = True
         # Set the total returned to more than the number of available hosts
         self.flags(max_attempts=max_attempts, group="scheduler")


### PR DESCRIPTION
To allow request tracing from Nova to the external scheduler, 
this change propagates the request context from the scheduler 
manager through to the external scheduler call. There, it is
serialized to a dict and sent as part of the post request.