### PR TITLE
Save domain name on instance create

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -1459,6 +1459,8 @@ class API:
                     context, instance, boot_meta, idx,
                     security_groups, flavor,
                     num_instances, shutdown_terminate)
+                req_spec.update_scheduler_hints(
+                    {'domain_name': instance.system_metadata['domain_name']})
 
                 block_device_mapping = (
                     self._bdm_validate_set_size_and_instance(context,
@@ -2107,6 +2109,8 @@ class API:
 
         system_meta['owner_user_name'] = context.user_name
         system_meta['owner_project_name'] = context.project_name
+        domain_name = utils.get_domain_name(context, context.project_domain_id)
+        system_meta['domain_name'] = domain_name
 
         instance.system_metadata.update(system_meta)
 

--- a/nova/conf/base.py
+++ b/nova/conf/base.py
@@ -202,7 +202,27 @@ actual aliased flavor will be shown/used respectively.
 The 'x_' prefix in the default sorts aliased flavors towards the end of the
 flavor list (when sorting by flavorid, which is the API default). This
 decreases visibility for aliased flavors.
-""")
+"""),
+    cfg.ListOpt("external_customer_domain_name_prefixes",
+        default=[],
+        help="""
+List of prefixes for domain names to identify an external customer
+
+External customer VMs have to be spawned on specially-prepared hosts. To
+identify that a VM is spawning for an external customer, we check the prefix of
+the domain name against this list.
+
+In the scheduler, if a domain matches, we add an additional trait - the one
+defined in nova.utils.EXTERNAL_CUSTOMER_SUPPORTED_TRAIT - to the request for
+allocations candidates towards Placement.
+
+In the vmwareapi driver, if a domain matches, we make sure that the VM ends up
+on the right hosts.
+
+If kept empty, the trait will not be added to any VM-build request and the
+vmwareapi driver will not consider assigning VMs to HostGroups and will not run
+its sync-loop that ensures the assignment.
+"""),
 ]
 
 metrics_opts = [

--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -196,19 +196,6 @@ Related options:
 
 - ``[compute] compute_driver``
 """),
-    cfg.ListOpt("external_customer_domain_name_prefixes",
-        default=[],
-        help="""
-List of prefixes for domain names to identify an external customer
-
-External customer VMs have to be spawned on specially-prepared hosts. To
-identify that a VM is spawning for an external customer, we check the prefix of
-the domain name against this list. If domain matches, we add an additional
-trait - the one defined in nova.utils.EXTERNAL_CUSTOMER_SUPPORTED_TRAIT - to
-the request for allocations candidates towards Placement.
-
-If kept empty, the trait will not be added to any VM-build request.
-"""),
 ]
 
 filter_scheduler_group = cfg.OptGroup(

--- a/nova/scheduler/request_filter.py
+++ b/nova/scheduler/request_filter.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 import functools
 
-from keystoneauth1 import exceptions as kse
-from keystoneauth1 import loading as ks_loading
 import os_traits
 from oslo_log import log as logging
 from oslo_utils import timeutils
@@ -448,98 +446,6 @@ def ephemeral_encryption_filter(
     return True
 
 
-# Store a cache from project id to domaind id and domain id to domain name used
-# in external_customer_filter
-PROJECT_ID_DOMAIN_ID_CACHE: dict[str, str] = {}
-DOMAIN_ID_NAME_CACHE: dict[str, str] = {}
-_SERVICE_AUTH = None
-
-
-def _fetch_domain_name(project_id: str) -> str:
-    """Fetch the domain name belonging to the given project id"""
-    global _SERVICE_AUTH
-
-    if _SERVICE_AUTH is None:
-        _SERVICE_AUTH = ks_loading.load_auth_from_conf_options(
-                            CONF,
-                            group=
-                            nova.conf.service_token.SERVICE_USER_GROUP)
-        if _SERVICE_AUTH is None:
-            # This indicates a misconfiguration so log a warning and
-            # return the user_auth.
-            LOG.error('Unable to load auth from [service_user] '
-                      'configuration. Ensure "auth_type" is set.')
-            raise exception.NovaException("Unable to load service_user auth")
-
-    adap = None
-    if project_id not in PROJECT_ID_DOMAIN_ID_CACHE:
-        if adap is None:
-            adap = nova_utils.get_ksa_adapter(
-                'identity', ksa_auth=_SERVICE_AUTH,
-                min_version=(3, 0), max_version=(3, 'latest'))
-
-        url = f"/projects/{project_id}"
-        try:
-            resp = adap.get(url, raise_exc=False)
-        except kse.EndpointNotFound:
-            LOG.error(
-                "Keystone identity service version 3.0 was not found. "
-                "This might be because your endpoint points to the v2.0 "
-                "versioned endpoint which is not supported. Please fix "
-                "this.")
-            raise exception.NovaException(
-                f"Could not fetch project {project_id}")
-        except kse.ClientException:
-            LOG.error("Unable to contact keystone to fetch domain %s",
-                      project_id)
-            raise exception.NovaException(
-                f"Could not fetch domain {project_id}")
-
-        if resp.status_code == 404:
-            LOG.error("Fetching project %s returned 404", project_id)
-            raise exception.NovaException(
-                f"Could not fetch domain {project_id}")
-
-        resp.raise_for_status()
-
-        data = resp.json()
-        PROJECT_ID_DOMAIN_ID_CACHE[project_id] = data['project']['domain_id']
-
-    domain_id = PROJECT_ID_DOMAIN_ID_CACHE[project_id]
-
-    if domain_id in DOMAIN_ID_NAME_CACHE:
-        return DOMAIN_ID_NAME_CACHE[domain_id]
-
-    if adap is None:
-        adap = nova_utils.get_ksa_adapter(
-            'identity', ksa_auth=_SERVICE_AUTH,
-            min_version=(3, 0), max_version=(3, 'latest'))
-
-    url = f"/domains/{domain_id}"
-    try:
-        resp = adap.get(url, raise_exc=False)
-    except kse.EndpointNotFound:
-        LOG.error(
-            "Keystone identity service version 3.0 was not found. "
-            "This might be because your endpoint points to the v2.0 "
-            "versioned endpoint which is not supported. Please fix "
-            "this.")
-        raise exception.NovaException(f"Could not fetch domain {domain_id}")
-    except kse.ClientException:
-        LOG.error("Unable to contact keystone to fetch domain %s", domain_id)
-        raise exception.NovaException(f"Could not fetch domain {domain_id}")
-
-    if resp.status_code == 404:
-        LOG.error("Fetching domain %s returned 404", domain_id)
-        raise exception.NovaException(f"Could not fetch domain {domain_id}")
-
-    resp.raise_for_status()
-
-    data = resp.json()
-    DOMAIN_ID_NAME_CACHE[domain_id] = data['domain']['name']
-    return data['domain']['name']
-
-
 @trace_request_filter
 def external_customer_filter(
     ctxt: nova_context.RequestContext,
@@ -551,11 +457,14 @@ def external_customer_filter(
     the domain name the instance is getting spawned in, we add an additional
     filter for the trait CUSTOM_EXTERNAL_CUSTOMER_SUPPORTED.
     """
-    prefixes = tuple(CONF.scheduler.external_customer_domain_name_prefixes)
+    prefixes = tuple(CONF.external_customer_domain_name_prefixes)
     if not prefixes:
         return False
 
-    domain_name = _fetch_domain_name(request_spec.project_id)
+    domain_name = request_spec.get_scheduler_hint("domain_name")
+    if domain_name is None:
+        raise exception.RequestFilterFailed(
+            reason="Could not find 'domain_name' scheduler hint")
     if not domain_name.startswith(prefixes):
         return False
 

--- a/nova/tests/unit/api/openstack/compute/test_access_ips.py
+++ b/nova/tests/unit/api/openstack/compute/test_access_ips.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
+
 from oslo_serialization import jsonutils
 
 from nova.api.openstack.compute import servers as servers_v21
@@ -24,6 +26,8 @@ v4_key = "accessIPv4"
 v6_key = "accessIPv6"
 
 
+@mock.patch('nova.utils.get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class AccessIPsAPIValidationTestV21(test.TestCase):
     validation_error = exception.ValidationError
 

--- a/nova/tests/unit/api/openstack/compute/test_availability_zone.py
+++ b/nova/tests/unit/api/openstack/compute/test_availability_zone.py
@@ -206,6 +206,7 @@ class ServersControllerCreateTestV21(test.TestCase):
         def _populate_instance_for_create(*args, **kwargs):
             instance = args[2]
             instance.uuid = FAKE_UUID
+            instance.system_metadata['domain_name'] = "fake-domain3"
             return instance
 
         self.useFixture(fixtures.GlanceFixture(self))

--- a/nova/tests/unit/api/openstack/compute/test_disk_config.py
+++ b/nova/tests/unit/api/openstack/compute/test_disk_config.py
@@ -170,6 +170,8 @@ class DiskConfigTestCaseV21(test.TestCase):
             if image_dict['id'] in (6, 7):
                 self.assertDiskConfig(image_dict, expected)
 
+    @mock.patch('nova.utils.get_domain_name',
+                new=mock.Mock(return_value='fake-domain'))
     def test_create_server_override_auto(self):
         req = fakes.HTTPRequest.blank('/%s/servers' % self.project_id)
         req.method = 'POST'
@@ -186,6 +188,8 @@ class DiskConfigTestCaseV21(test.TestCase):
         server_dict = jsonutils.loads(res.body)['server']
         self.assertDiskConfig(server_dict, 'AUTO')
 
+    @mock.patch('nova.utils.get_domain_name',
+                new=mock.Mock(return_value='fake-domain'))
     def test_create_server_override_manual(self):
         req = fakes.HTTPRequest.blank('/%s/servers' % self.project_id)
         req.method = 'POST'
@@ -202,6 +206,8 @@ class DiskConfigTestCaseV21(test.TestCase):
         server_dict = jsonutils.loads(res.body)['server']
         self.assertDiskConfig(server_dict, 'MANUAL')
 
+    @mock.patch('nova.utils.get_domain_name',
+                new=mock.Mock(return_value='fake-domain'))
     def test_create_server_detect_from_image(self):
         """If user doesn't pass in diskConfig for server, use image metadata
         to specify AUTO or MANUAL.
@@ -234,6 +240,8 @@ class DiskConfigTestCaseV21(test.TestCase):
         server_dict = jsonutils.loads(res.body)['server']
         self.assertDiskConfig(server_dict, 'AUTO')
 
+    @mock.patch('nova.utils.get_domain_name',
+                new=mock.Mock(return_value='fake-domain'))
     def test_create_server_detect_from_image_disabled_goes_to_manual(self):
         req = fakes.HTTPRequest.blank('/%s/servers' % self.project_id)
         req.method = 'POST'
@@ -264,6 +272,8 @@ class DiskConfigTestCaseV21(test.TestCase):
         res = req.get_response(self.app)
         self.assertEqual(res.status_int, 400)
 
+    @mock.patch('nova.utils.get_domain_name',
+                new=mock.Mock(return_value='fake-domain'))
     def test_create_server_when_disabled_and_manual(self):
         req = fakes.HTTPRequest.blank('/%s/servers' % self.project_id)
         req.method = 'POST'
@@ -363,6 +373,8 @@ class DiskConfigTestCaseV21(test.TestCase):
                }}
         old_create = compute_api.API.create
 
+        @mock.patch('nova.utils.get_domain_name',
+                    new=mock.Mock(return_value='fake-domain'))
         def create(*args, **kwargs):
             self.assertIn('auto_disk_config', kwargs)
             self.assertTrue(kwargs['auto_disk_config'])

--- a/nova/tests/unit/api/openstack/compute/test_servers.py
+++ b/nova/tests/unit/api/openstack/compute/test_servers.py
@@ -4336,6 +4336,8 @@ class ServerStatusTest(test.TestCase):
         self.assertEqual(response['server']['status'], 'SHUTOFF')
 
 
+@mock.patch.object(nova_utils, 'get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class _ServersControllerCreateTest(test.TestCase):
     image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
     flavor_ref = 'http://localhost/123/flavors/3'
@@ -4418,6 +4420,8 @@ class _ServersControllerCreateTest(test.TestCase):
         self.controller.create(self.req, body=self.body).obj['server']
 
 
+@mock.patch.object(nova_utils, 'get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class ServersControllerCreateTest(_ServersControllerCreateTest):
 
     def _invalid_server_create(self, body):
@@ -6187,6 +6191,7 @@ class ServersControllerCreateTest(_ServersControllerCreateTest):
         def _populate_instance_for_create(*args, **kwargs):
             instance = args[2]
             self.instance_cache_by_uuid[instance.uuid] = instance
+            instance.system_metadata['domain_name'] = "fake-domain2"
             return instance
 
         self.stub_out('nova.compute.api.API._populate_instance_for_create',
@@ -6220,6 +6225,7 @@ class ServersControllerCreateTest(_ServersControllerCreateTest):
         def _populate_instance_for_create(*args, **kwargs):
             instance = args[2]
             self.instance_cache_by_uuid[instance.uuid] = instance
+            instance.system_metadata['domain_name'] = "fake-domain2"
             return instance
 
         self.stub_out('nova.compute.api.API._populate_instance_for_create',
@@ -6239,6 +6245,7 @@ class ServersControllerCreateTest(_ServersControllerCreateTest):
         def _populate_instance_for_create(*args, **kwargs):
             instance = args[2]
             self.instance_cache_by_uuid[instance.uuid] = instance
+            instance.system_metadata['domain_name'] = "fake-domain2"
             return instance
 
         self.stub_out('nova.compute.api.API._populate_instance_for_create',
@@ -6370,6 +6377,7 @@ class ServersControllerCreateTest(_ServersControllerCreateTest):
         def _populate_instance_for_create(*args, **kwargs):
             instance = args[2]
             self.instance_cache_by_uuid[instance.uuid] = instance
+            instance.system_metadata['domain_name'] = "fake-domain2"
             return instance
 
         self.stub_out('nova.compute.api.API._populate_instance_for_create',
@@ -6692,6 +6700,8 @@ class ServersControllerCreateTest(_ServersControllerCreateTest):
         self._test_create_extra(params)
 
 
+@mock.patch.object(nova_utils, 'get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class ServersControllerCreateTestV219(_ServersControllerCreateTest):
 
     def _create_instance_req(self, set_desc, desc=None):
@@ -7007,6 +7017,8 @@ class ServersControllerCreateTestV257(test.NoDBTestCase):
         self.assertIn('personality', str(ex))
 
 
+@mock.patch.object(nova_utils, 'get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 @mock.patch('nova.compute.utils.check_num_instances_quota',
             new=lambda *args, **kwargs: 1)
 class ServersControllerCreateTestV260(test.NoDBTestCase):
@@ -7065,6 +7077,8 @@ class ServersControllerCreateTestV260(test.NoDBTestCase):
                       'compute API version 2.60', str(ex))
 
 
+@mock.patch.object(nova_utils, 'get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class ServersControllerCreateTestV263(_ServersControllerCreateTest):
     def _create_instance_req(self, certs=None):
         self.body['server']['trusted_image_certificates'] = certs
@@ -7163,6 +7177,8 @@ class ServersControllerCreateTestV263(_ServersControllerCreateTest):
         self.assertIn('test cert validation error', str(ex))
 
 
+@mock.patch.object(nova_utils, 'get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class ServersControllerCreateTestV267(_ServersControllerCreateTest):
     def setUp(self):
         super(ServersControllerCreateTestV267, self).setUp()
@@ -7336,6 +7352,8 @@ class ServersControllerCreateTestV274(_ServersControllerCreateTest):
         pass
 
 
+@mock.patch.object(nova_utils, 'get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class ServersControllerCreateTestV290(_ServersControllerCreateTest):
 
     def _generate_req(self, hostname=None, api_version='2.90'):

--- a/nova/tests/unit/compute/test_api.py
+++ b/nova/tests/unit/compute/test_api.py
@@ -5360,7 +5360,9 @@ class _ComputeAPIUnitTestMixIn(object):
         fake_rs = fake_request_spec.fake_spec_obj()
         fake_rs.requested_resources = prev_request_groups
         mock_rs.return_value = fake_rs
-        do_test()
+        with mock.patch.object(fake_rs, 'update_scheduler_hints',
+                return_value=None):
+            do_test()
         return mock_get_dp, fake_rs
 
     def test_provision_instances_with_accels_ok(self):
@@ -5481,6 +5483,8 @@ class _ComputeAPIUnitTestMixIn(object):
                         port_resource_requests=mock.sentinel.resource_reqs,
                         request_level_params=mock.sentinel.req_lvl_params
                     ),
+                    mock.call().update_scheduler_hints(
+                        {'domain_name': 'fake-domain'})
                 ] * 2
             )
 
@@ -7448,6 +7452,8 @@ class _ComputeAPIUnitTestMixIn(object):
 
 # TODO(stephenfin): The separation of the mixin is a hangover from cells v1
 # days and should be removed
+@mock.patch('nova.utils.get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class ComputeAPIUnitTestCase(_ComputeAPIUnitTestMixIn, test.NoDBTestCase):
     def setUp(self):
         super(ComputeAPIUnitTestCase, self).setUp()

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -8628,6 +8628,8 @@ class ComputeTestCase(BaseTestCase,
 
 
 @ddt.ddt
+@mock.patch('nova.utils.get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class ComputeAPITestCase(BaseTestCase):
     def setUp(self):
         super(ComputeAPITestCase, self).setUp()
@@ -13459,6 +13461,8 @@ class ComputeAPIAggrCallsSchedulerTestCase(test.NoDBTestCase):
             self.context, agg.uuid, 'fakehost')
 
 
+@mock.patch('nova.utils.get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class DisabledInstanceTypesTestCase(BaseTestCase):
     """Some instance-types are marked 'disabled' which means that they will not
     show up in customer-facing listings. We do, however, want those

--- a/nova/tests/unit/scheduler/test_request_filter.py
+++ b/nova/tests/unit/scheduler/test_request_filter.py
@@ -729,43 +729,33 @@ class TestRequestFilter(test.NoDBTestCase):
     def test_external_customer_filter_no_config(self):
         reqspec = objects.RequestSpec()
 
-        self.flags(external_customer_domain_name_prefixes=[],
-                   group='scheduler')
+        self.flags(external_customer_domain_name_prefixes=[])
 
         self.assertFalse(request_filter.external_customer_filter(
                          self.context, reqspec))
 
-    def test_external_customer_filter_cache_filled(self):
-        reqspec = objects.RequestSpec(project_id="some-project")
+    def test_external_customer_filter_no_scheduler_hint(self):
+        self.flags(external_customer_domain_name_prefixes=['foo', 'bar'])
 
-        request_filter.DOMAIN_ID_NAME_CACHE[mock.sentinel.domain_id] = "test"
-        request_filter.PROJECT_ID_DOMAIN_ID_CACHE["some-project"] = \
-                mock.sentinel.domain_id
-        request_filter._SERVICE_AUTH = mock.sentinel.service_auth
-        self.flags(external_customer_domain_name_prefixes=['foo', 'bar'],
-                   group='scheduler')
+        reqspec = objects.RequestSpec()
+        self.assertRaises(exception.RequestFilterFailed,
+                          request_filter.external_customer_filter,
+                          self.context, reqspec)
 
-        self.assertFalse(request_filter.external_customer_filter(
-                         self.context, reqspec))
+    def test_external_customer_filter_no_match(self):
+        reqspec = objects.RequestSpec(
+            scheduler_hints={'domain_name': ['test']})
 
-    @mock.patch('nova.scheduler.request_filter._fetch_domain_name')
-    def test_external_customer_filter_no_match(self, mock_fetch):
-        reqspec = objects.RequestSpec(project_id="some-project")
-        mock_fetch.return_value = "test"
-
-        self.flags(external_customer_domain_name_prefixes=['foo', 'bar'],
-                   group='scheduler')
+        self.flags(external_customer_domain_name_prefixes=['foo', 'bar'])
 
         self.assertFalse(request_filter.external_customer_filter(
                          self.context, reqspec))
 
-    @mock.patch('nova.scheduler.request_filter._fetch_domain_name')
-    def test_external_customer_filter_matching(self, mock_fetch):
-        reqspec = objects.RequestSpec(project_id="some-project")
-        mock_fetch.return_value = "test"
+    def test_external_customer_filter_matching(self):
+        reqspec = objects.RequestSpec(
+            scheduler_hints={'domain_name': ['test']})
 
-        self.flags(external_customer_domain_name_prefixes=['foo', 'bar', 'te'],
-                   group='scheduler')
+        self.flags(external_customer_domain_name_prefixes=['foo', 'bar', 'te'])
 
         self.assertTrue(request_filter.external_customer_filter(
                          self.context, reqspec))

--- a/nova/tests/unit/test_quota.py
+++ b/nova/tests/unit/test_quota.py
@@ -54,6 +54,8 @@ def _get_fake_get_usages(updates=None):
     return fake_get_usages
 
 
+@mock.patch('nova.utils.get_domain_name',
+            new=mock.Mock(return_value='fake-domain'))
 class QuotaIntegrationTestCase(test.TestCase):
 
     REQUIRES_LOCKING = True

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -32,6 +32,7 @@ import weakref
 
 import eventlet
 from eventlet import tpool
+from keystoneauth1 import exceptions as kse
 from keystoneauth1 import loading as ks_loading
 import netaddr
 from openstack import connection
@@ -99,6 +100,10 @@ _FILE_CACHE = {}
 _SERVICE_TYPES = service_types.ServiceTypes()
 
 DEFAULT_GREEN_POOL = None
+
+# Cache of domain id to name mapping. This should never change, so we don't
+# expire this
+DOMAIN_NAMES = {}
 
 
 def _get_default_green_pool():
@@ -1299,3 +1304,36 @@ def vm_needs_special_spawning(memory_mb, flavor):
         return True
 
     return False
+
+
+def get_domain_name(context, domain_id: str) -> str:
+    """Look up the domain name for a domain in Keystone"""
+    if domain_id not in DOMAIN_NAMES:
+        adap = get_ksa_adapter(
+            'identity', ksa_auth=context.get_auth_plugin(),
+            min_version=(3, 0), max_version=(3, 'latest'))
+
+        try:
+            resp = adap.get('/domains/%s' % domain_id)
+        except kse.EndpointNotFound:
+            LOG.error(
+                "Keystone identity service version 3.0 was not found. This "
+                "might be caused by Nova misconfiguration or Keystone "
+                "problems.")
+            msg = _("Nova was unable to find Keystone service endpoint.")
+            raise exception.KeystoneConnectionFailed(msg)
+        except kse.ClientException as e:
+            LOG.exception(e)
+            raise exception.KeystoneConnectionFailed(str(e))
+
+        if resp.status_code != 200:
+            msg = (
+                f"Getting domain {domain_id} from Keystone failed "
+                f"with {resp.status_code}")
+            LOG.error(msg)
+            raise exception.KeystoneConnectionFailed(msg)
+
+        data = resp.json()
+        DOMAIN_NAMES[domain_id] = data['domain']['name']
+
+    return DOMAIN_NAMES[domain_id]


### PR DESCRIPTION
We previously already needed the domain name in the scheduler and fetched it there on-demand. This has the downside of requiring Keystone to be available for scheduling to work.

Since we plan to implement more functionalities, e.g. in the `vmwareapi` driver, which would lead to more dependence on Keystone and also to reduced performance, we save the domain name once on instance create. We can do that, since an instance cannot be moved to another project and thus not to another domain.

With getting the domain name in the api and not the scheduler, we move the code out into a more generic place. Additionally, we use the user's context to fetch the domain now instead of Nova's service-user, because we have that context available in the api and it simplifies the code a lot.

We save the domain name twice: in the `system_metadata` of an instance, which is available to anyone getting an `Instance` object, and in the `scheduler_hints` of the `RequestSpec` object. The latter makes the information available to the scheduler and its filters.

We do not implement any online data migrations for existing VMs, because they would run on every deployment of Nova in our env and would not be very efficient. Instead, we implement migrations for existing VMs in an outside script.

Change-Id: I034e89251ce44310f6642983323bed26eddc0159