### PR TITLE
Add get all uuids sap admin endpoint

### DIFF
--- a/nova/api/openstack/compute/sap_admin_api.py
+++ b/nova/api/openstack/compute/sap_admin_api.py
@@ -22,6 +22,8 @@ from nova.api import validation
 from nova.compute import api as compute
 import nova.conf
 from nova import context as nova_context
+from nova.db.main import api as main_db_api
+from nova.db.main import models
 from nova import exception
 from nova.i18n import _
 from nova import objects
@@ -93,6 +95,30 @@ class SAPAdminApiController(wsgi.Controller):
         except exception.InstanceInvalidState as state_error:
             common.raise_http_conflict_for_instance_invalid_state(
                 state_error, 'in_cluster_vmotion', server_id)
+
+    @_register_endpoint('GET')
+    def all_instance_uuids(self, req):
+        """Get all instance uuids"""
+        context = req.environ['nova.context']
+        context.can(sap_policies.POLICY_ROOT % 'all-instance-uuids')
+
+        @main_db_api.pick_context_manager_reader
+        def _fetch_uuids(context):
+            query = main_db_api.model_query(context,
+                                            models.Instance,
+                                            args=(models.Instance.uuid,),
+                                            read_deleted="no")
+            return [row[0] for row in query.all()]
+
+        results = nova_context.scatter_gather_skip_cell0(context, _fetch_uuids)
+        instance_uuids = []
+        for cell_name, result in results.items():
+            if nova_context.is_cell_failure_sentinel(result):
+                raise exc.HTTPServiceUnavailable(
+                    _('Could not reach cell {}'.format(cell_name))
+                )
+            instance_uuids.extend(result)
+        return {"instance_uuids": instance_uuids}
 
     @wsgi.expected_errors((503,))
     @validation.query_schema(sap_admin_api.usage_by_az_query_params)

--- a/nova/policies/sap_admin_api.py
+++ b/nova/policies/sap_admin_api.py
@@ -56,6 +56,17 @@ sap_admin_api_policies = [
         ],
         scope_types=['system', 'project']),
     policy.DocumentedRuleDefault(
+        name=POLICY_ROOT % 'all-instance-uuids',
+        check_str=base.RULE_ADMIN_API,
+        description="Get all instance uuids",
+        operations=[
+            {
+                'method': 'GET',
+                'path': '/sap/all_instance_uuids'
+            }
+        ],
+        scope_types=['system', 'project']),
+    policy.DocumentedRuleDefault(
         name=POLICY_ROOT % 'usage-by-az',
         check_str=base.RULE_ADMIN_API,
         description="Show project usages split by availability-zone",

--- a/nova/tests/unit/test_policy.py
+++ b/nova/tests/unit/test_policy.py
@@ -393,6 +393,7 @@ class RealRolePolicyTestCase(test.NoDBTestCase):
 "os_compute_api:sap:endpoints:list",
 "os_compute_api:sap:clear-quota-resources-cache",
 "os_compute_api:sap:in-cluster-vmotion",
+"os_compute_api:sap:all-instance-uuids",
 "os_compute_api:sap:usage-by-az",
 "os_compute_api:sap:get-scheduler-settings",
 )


### PR DESCRIPTION
For the refactored consistency nanny, we need a uuid list of all active instances. The old nanny fetched all instances with all attributes. This API endpoint only fetches the UUID column from the database to allow a less resource intensive way to get all UUIDs.