### PR TITLE
Format-Inspector: Check only till first zero byte

### DIFF
--- a/nova/image/format_inspector.py
+++ b/nova/image/format_inspector.py
@@ -752,8 +752,11 @@ class VMDKInspector(FileInspector):
             return False
 
         try:
-            # Descriptor is padded to 512 bytes
-            desc_data = self.region('descriptor').data.rstrip(b'\x00')
+            # Descriptor is null-padded to 512 bytes. Find the first one and
+            # use it as the end of the text string.
+            desc_data = self.region('descriptor').data
+            pad_idx = desc_data.index(b'\x00')
+            desc_data = desc_data[:pad_idx]
             # Descriptor is actually case-insensitive ASCII text
             desc_text = desc_data.decode('ascii').lower()
         except UnicodeDecodeError:


### PR DESCRIPTION
Partial backport from oslo_utils (b68be957).
VMware also gives us a zero byte followed by a newline, which will trip the old check.
The code is obsolete with 2024.2

Change-Id: Ib0bce580746f6130327874bbae62378691a9d74d