### PR TITLE
Allow BfV rescue for VMware without image props

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -4822,8 +4822,15 @@ class API:
         volume_backed = compute_utils.is_volume_backed_instance(
             context, instance, bdms)
 
-        allow_bfv_rescue &= 'hw_rescue_bus' in image_meta.properties and \
-            'hw_rescue_device' in image_meta.properties
+        # NOTE(jkulik): We use the flavor to decide here, because we do not
+        # have access to the compute-node and it's capabilities here. For
+        # vmwareapi, we do not need the attributes. They are only required for
+        # libvirt.
+        hv_type = \
+            instance.flavor.extra_specs.get('capabilities:hypervisor_type')
+        if hv_type != 'VMware vCenter Server':
+            allow_bfv_rescue &= 'hw_rescue_bus' in image_meta.properties and \
+                'hw_rescue_device' in image_meta.properties
 
         if volume_backed and allow_bfv_rescue:
             cn = objects.ComputeNode.get_by_host_and_nodename(


### PR DESCRIPTION
Upstream added functionality to the libvirt driver in I0e1241ae691afd2af12ef15706c454c05d9f932c, that makes rescue work like in our `vmwareapi` implementation: attach the rescue disk to the end of the instance and boot from it. Previously, they only supported a new configuration with the rescue disk and the root disk.

Since for bfv, they could only do it with the new functionality, they started requiring the appropriate image metadata properties if they detected a bfv rescue in Id4c8c5f3b32985ac7d3d7c833b82e0876f7367c1.

With vmwareapi, we do not need these parameters. Therefore, we disable the check for the image properties if we detect a VMware flavor.

We thought about letting the compute nodes report a capability whether they need the image properties for bfv rescue or not, but the place checking for the image propertes - nova/compute/api.py` - doesn't have access to compute node capabilities. We were also thinking to use a setting, but since we're not in `nova-compute` but in `nova-api`, this would limit us to supporting only one hypervisor type in the whole cloud. Therefore, we opted for checking the flavor extra_spec attribute, which we also check in `nova-scheduler`.

Change-Id: I55db4856780cac474084edb1e066aa49457b2dbe