### PR TITLE
Volume migration_status is optional

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -4199,7 +4199,8 @@ class API:
             if not bdm.volume_id:
                 continue
             volume = self.volume_api.get(context, bdm.volume_id)
-            migration_status_valid = volume['migration_status'] != 'migrating'
+            migration_status_valid = (volume.get('migration_status') !=
+                                      'migrating')
             status_and_attach_status_valid = (
                  (volume['status'] == "in-use" and
                   volume['attach_status'] == 'attached') or


### PR DESCRIPTION
The migration status is only set, if the volume is being migrated, which only happens in our custom sharding scenario.

Change-Id: I4a224042cac7d379069860b056ad24fa3388ebc7