### PR TITLE
vmware: fix typo rules -> existing_rules in DRS sync cleanup

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1427,9 +1427,7 @@ class VMwareVMOps(object):
                                                   key=attrgetter('name')):
             rules = list(rules)
             existing_rules[rule_name] = rules[0]
-            if len(rules) == 1:
-                continue
-            # we found a duplicated rule and have to delete all but one
+            # any additional rules are duplicates and have to be deleted
             for rule in rules[1:]:
                 config_spec.rulesSpec.append(
                     cluster_util.create_rule_spec(

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1484,7 +1484,7 @@ class VMwareVMOps(object):
             for rule_name in existing_rules.keys() - expected_rule_names:
                 config_spec.rulesSpec.append(
                     cluster_util.create_rule_spec(
-                        client_factory, rules[rule_name], 'remove'))
+                        client_factory, existing_rules[rule_name], 'remove'))
 
             superfluous_vm_group_names = \
                 existing_vm_groups.keys() - expected_vm_group_names


### PR DESCRIPTION
Fixes `list indices must be integers or slices, not Text`.
Also removes a redundant length check during rule deduplication.