### PR TITLE
fix `quota:separate` and `quota:instance_only`

### DIFF
--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -1088,14 +1088,20 @@ def upsize_quota_delta(new_flavor, old_flavor):
     # NOTE(jkulik): We need to add the instances_* resource only if we resize
     # towards a QUOTA_SEPARATE_KEY flavor, as we're interested in positive
     # deltas only. Since we only need resource deltas, the old flavor having
-    # the same QUOTA_SEPARATE_KEY between new and old flavor adds no delta.
+    # the same QUOTA_SEPARATE_KEY between new and old flavor adds no delta. We
+    # also have to add generic instances quota when resizing away from
+    # QUOTA_SEPARATE_KEY.
     new_extra_specs = new_flavor.get('extra_specs', {})
     new_separate = new_extra_specs.get(utils.QUOTA_SEPARATE_KEY) == 'true'
-    if new_separate:
-        old_extra_specs = old_flavor.get('extra_specs', {})
-        old_separate = old_extra_specs.get(utils.QUOTA_SEPARATE_KEY) == 'true'
-        if not old_separate or new_flavor['name'] != old_flavor['name']:
-            deltas[f"instances_{new_flavor['name']}"] = 1
+    old_extra_specs = old_flavor.get('extra_specs', {})
+    old_separate = old_extra_specs.get(utils.QUOTA_SEPARATE_KEY) == 'true'
+    if new_separate and not old_separate:
+        deltas[f"instances_{new_flavor['name']}"] = 1
+    elif (old_separate and new_separate and
+            new_flavor['name'] != old_flavor['name']):
+        deltas[f"instances_{new_flavor['name']}"] = 1
+    elif old_separate and not new_separate:
+        deltas["instances"] = 1
 
     return deltas
 
@@ -1144,15 +1150,13 @@ def check_num_instances_quota(
     # Determine requested cores and ram
     req_cores = max_count * flavor.vcpus
     req_ram = max_count * flavor.memory_mb
-    deltas = {'instances': max_count, 'cores': req_cores, 'ram': req_ram}
+    deltas = {'instances': 0, 'cores': 0, 'ram': 0}
 
     quota_key_instances = 'instances'
     if flavor.get('extra_specs', {}).get(utils.QUOTA_SEPARATE_KEY) == 'true':
         quota_key_instances = 'instances_' + flavor.name
-        deltas[quota_key_instances] = max_count
-        deltas['instances'] = 0
-        deltas['cores'] = 0
-        deltas['ram'] = 0
+    deltas[quota_key_instances] = max_count
+
     reserve_cpu_ram = flavor.get('extra_specs', {}).get(
         utils.QUOTA_INSTANCE_ONLY_KEY) != 'true'
     if reserve_cpu_ram:

--- a/nova/objects/flavor.py
+++ b/nova/objects/flavor.py
@@ -704,20 +704,20 @@ class FlavorList(base.ObjectListBase, base.NovaObject):
 
     @base.remotable_classmethod
     def get_by_id(cls, context, ids):
-
-        def is_separate(extra_specs):
-            for spec in extra_specs:
-                if spec.key == utils.QUOTA_SEPARATE_KEY \
-                        and spec.value == 'true':
-                    return True
-            return False
-
         query = Flavor._flavor_get_query_from_db(context).\
             filter_by(disabled=False).\
             filter(api_models.Flavors.id.in_(ids))
 
         res = {}
         for x in query:
-            res.update({x.id: {'name': x.name,
-                               'separate': is_separate(x.extra_specs)}})
+            extra_specs_dict = {s['key']: s['value'] for s in x.extra_specs}
+            flavor_info = {
+                'name': x.name,
+                'separate':
+                    extra_specs_dict.get(utils.QUOTA_SEPARATE_KEY) == 'true',
+                'instance_only':
+                    extra_specs_dict.get(
+                        utils.QUOTA_INSTANCE_ONLY_KEY) == 'true',
+            }
+            res[x.id] = flavor_info
         return res

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -1698,9 +1698,12 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
             flavor = objects.Flavor.obj_from_primitive(
                                                 flavor_info['cur'])
             separate = flavor.extra_specs.get(utils.QUOTA_SEPARATE_KEY)
+            instance_only = flavor.extra_specs.get(
+                utils.QUOTA_INSTANCE_ONLY_KEY)
             instance_types[flavor.id] = {
                 'name': flavor.name,
-                'separate': separate == 'true'
+                'separate': separate == 'true',
+                'instance_only': instance_only == 'true',
             }
 
     @staticmethod
@@ -1761,11 +1764,13 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
                 # instances, so the overall number is correct at least.
                 # Also this should not happen.
                 LOG.error('Unknown instance type id %s', type_id)
+
             if itype and itype.get('separate', False):
                 t_name = f"instances_{itype['name']}"
                 counts[t_name] = counts.get(t_name, 0) + instance_count
             else:
                 counts['instances'] += instance_count
+            if not itype or not itype.get('instance_only', False):
                 counts['cores'] += int(cores)
                 counts['ram'] += int(ram)
 

--- a/nova/tests/unit/compute/test_utils.py
+++ b/nova/tests/unit/compute/test_utils.py
@@ -50,6 +50,7 @@ from nova.tests.unit import fake_instance
 from nova.tests.unit import fake_network
 from nova.tests.unit import fake_server_actions
 from nova.tests.unit.objects import test_flavor
+from nova import utils
 
 
 FAKE_IMAGE_REF = uuids.image_ref
@@ -1325,6 +1326,126 @@ class ComputeUtilsQuotaTestCase(test.TestCase):
         deltas = compute_utils.upsize_quota_delta(new_flavor, old_flavor)
         self.assertEqual(expected_deltas, deltas)
 
+    def test_upsize_quota_delta_instance_only_new(self):
+        """The new flavor has QUOTA_INSTANCE_ONLY_KEY
+
+        Since the new flavor only requires instances quota, we should not see
+        any deltas, because we don't require any additional quota.
+        """
+        old_flavor = objects.Flavor.get_by_name(self.context, 'm1.tiny')
+        new_flavor = objects.Flavor(vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_INSTANCE_ONLY_KEY: 'true'})
+
+        expected_deltas = {}
+
+        deltas = compute_utils.upsize_quota_delta(new_flavor, old_flavor)
+        self.assertEqual(expected_deltas, deltas)
+
+    def test_upsize_quota_delta_instance_only_old(self):
+        """The old flavor has QUOTA_INSTANCE_ONLY_KEY
+
+        Since the old flavor required no cpu and ram, we should see the new
+        flavor's cpu and ram in the deltas.
+        """
+        old_flavor = objects.Flavor(vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_INSTANCE_ONLY_KEY: 'true'})
+        new_flavor = objects.Flavor.get_by_name(self.context, 'm1.tiny')
+
+        expected_deltas = {
+            'cores': new_flavor['vcpus'],
+            'ram': new_flavor['memory_mb'],
+        }
+
+        deltas = compute_utils.upsize_quota_delta(new_flavor, old_flavor)
+        self.assertEqual(expected_deltas, deltas)
+
+    def test_upsize_quota_delta_instance_only_both(self):
+        """The old and the new flavor have QUOTA_INSTANCE_ONLY_KEY
+
+        Both flavors requiring only instances quota means that there should be
+        no deltas since we don't require additional quota.
+        """
+        old_flavor = objects.Flavor(vcpus=1, memory_mb=256,
+            extra_specs={utils.QUOTA_INSTANCE_ONLY_KEY: 'true'})
+        new_flavor = objects.Flavor(vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_INSTANCE_ONLY_KEY: 'true'})
+
+        expected_deltas = {}
+
+        deltas = compute_utils.upsize_quota_delta(new_flavor, old_flavor)
+        self.assertEqual(expected_deltas, deltas)
+
+    def test_upsize_quota_delta_quota_separate_old(self):
+        """The old flavor has QUOTA_SEPARATE_KEY
+
+        The old flavor requiring renamed instances quota means, that we don't
+        have instances quota reserved, yet, and thus need to reserve instances.
+
+        QUOTA_SEPARATE_KEY has no effect on cores/ram.
+        """
+        old_flavor = objects.Flavor(vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_SEPARATE_KEY: 'true'})
+        new_flavor = objects.Flavor(vcpus=2, memory_mb=512, extra_specs={})
+
+        expected_deltas = {'instances': 1, 'cores': 1}
+
+        deltas = compute_utils.upsize_quota_delta(new_flavor, old_flavor)
+        self.assertEqual(expected_deltas, deltas)
+
+    def test_upsize_quota_delta_quota_separate_new(self):
+        """The new flavor has QUOTA_SEPARATE_KEY
+
+        The new flavor requiring renamed instances quota means, that we have
+        reservations for instances, but not the renamed instances, yet, and
+        thus newly require the renamed instances quota.
+
+        QUOTA_SEPARATE_KEY has no effect on cores/ram.
+        """
+        old_flavor = objects.Flavor(vcpus=1, memory_mb=256, extra_specs={})
+        new_flavor = objects.Flavor(name='very_fake', vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_SEPARATE_KEY: 'true'})
+
+        expected_deltas = {'instances_very_fake': 1, 'ram': 256}
+
+        deltas = compute_utils.upsize_quota_delta(new_flavor, old_flavor)
+        self.assertEqual(expected_deltas, deltas)
+
+    def test_upsize_quota_delta_quota_separate_both_same(self):
+        """The old and the new flavor have QUOTA_SEPARATE_KEY
+
+        The old flavor requiring renamed instances quota, it depends on the
+        names of the flavors if we require new quota or not.
+
+        QUOTA_SEPARATE_KEY has no effect on cores/ram.
+        """
+        old_flavor = objects.Flavor(name='very_fake', vcpus=1, memory_mb=256,
+            extra_specs={utils.QUOTA_SEPARATE_KEY: 'true'})
+        new_flavor = objects.Flavor(name='very_fake', vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_SEPARATE_KEY: 'true'})
+
+        expected_deltas = {'ram': 256}
+
+        deltas = compute_utils.upsize_quota_delta(new_flavor, old_flavor)
+        self.assertEqual(expected_deltas, deltas)
+
+    def test_upsize_quota_delta_quota_separate_both_different(self):
+        """The old and the new flavor have QUOTA_SEPARATE_KEY
+
+        The old flavor requiring renamed instances quota, it depends on the
+        names of the flavors if we require new quota or not.
+
+        QUOTA_SEPARATE_KEY has no effect on cores/ram.
+        """
+        old_flavor = objects.Flavor(name='not_fake', vcpus=1, memory_mb=256,
+            extra_specs={utils.QUOTA_SEPARATE_KEY: 'true'})
+        new_flavor = objects.Flavor(name='very_fake', vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_SEPARATE_KEY: 'true'})
+
+        expected_deltas = {'instances_very_fake': 1, 'ram': 256}
+
+        deltas = compute_utils.upsize_quota_delta(new_flavor, old_flavor)
+        self.assertEqual(expected_deltas, deltas)
+
     @mock.patch('nova.objects.Quotas.count_as_dict')
     def test_check_instance_quota_exceeds_with_multiple_resources(self,
                                                                   mock_count):
@@ -1393,6 +1514,165 @@ class ComputeUtilsQuotaTestCase(test.TestCase):
                 check_project_id=self.context.project_id,
                 check_user_id=self.context.user_id)
             mock_check.reset_mock()
+
+    @mock.patch('nova.objects.Quotas.check_deltas')
+    def test_check_num_instances_quota_instance_only(self, mock_check):
+        """Having QUOTA_INSTANCE_ONLY_KEY requires only instances quota
+
+        We check that we do the quota check with only the expected quotas.
+        """
+        fake_flavor = objects.Flavor(vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_INSTANCE_ONLY_KEY: 'true'})
+
+        compute_utils.check_num_instances_quota(
+            self.context, fake_flavor, 1, 1)
+
+        deltas = {'instances': 1, 'cores': 0, 'ram': 0}
+        mock_check.assert_called_with(
+            self.context, deltas, self.context.project_id, user_id=None,
+            check_project_id=self.context.project_id, check_user_id=None)
+
+    @mock.patch('nova.objects.Quotas.check_deltas')
+    def test_check_num_instances_quota_instance_only_over(self, mock_check):
+        """Having QUOTA_INSTANCE_ONLY_KEY requires only instances quota
+
+        If we get an OverQuota exception in checking the quota, we need to
+        report the right values.
+        """
+        fake_flavor = objects.Flavor(vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_INSTANCE_ONLY_KEY: 'true'})
+
+        quotas = {'cores': 1, 'instances': 2, 'ram': 512}
+        overs = ['instances']
+        over_quota_args = dict(quotas=quotas,
+                               usages={'instances': 2, 'cores': 1, 'ram': 512},
+                               overs=overs)
+        e = exception.OverQuota(**over_quota_args)
+        mock_check.side_effect = e
+        try:
+            compute_utils.check_num_instances_quota(
+                self.context, fake_flavor, 1, 1)
+        except exception.TooManyInstances as e:
+            self.assertEqual('instances', e.kwargs['overs'])
+            self.assertEqual('1', e.kwargs['req'])
+            self.assertEqual('2', e.kwargs['used'])
+            self.assertEqual('2', e.kwargs['allowed'])
+        else:
+            self.fail("Exception not raised")
+
+    @mock.patch('nova.objects.Quotas.check_deltas')
+    def test_check_num_instances_quota_instance_only_quota_separate(
+            self, mock_check):
+        """We should require only instances quota named after the flavor
+
+        Having QUOTA_INSTANCE_ONLY_KEY and QUOTA_SEPARATE_KEY requires only
+        instances quota, but the instances quota is renamed to include the
+        flavor name.
+
+        We check that we do the quota check with only the expected quotas.
+        """
+        fake_flavor = objects.Flavor(name="no_fake", vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_INSTANCE_ONLY_KEY: 'true',
+                         utils.QUOTA_SEPARATE_KEY: 'true'})
+
+        compute_utils.check_num_instances_quota(
+            self.context, fake_flavor, 1, 1)
+
+        deltas = {'instances_no_fake': 1, 'instances': 0, 'cores': 0, 'ram': 0}
+        mock_check.assert_called_with(
+            self.context, deltas, self.context.project_id, user_id=None,
+            check_project_id=self.context.project_id, check_user_id=None)
+
+    @mock.patch('nova.objects.Quotas.check_deltas')
+    def test_check_num_instances_quota_instance_only_quota_separate_over(
+            self, mock_check):
+        """We should report instances quota named after the flavor
+
+        Having QUOTA_INSTANCE_ONLY_KEY requires only instances quota and having
+        QUOTA_SEPARATE_KEY renames the instances after the flavor.
+
+        If we get an OverQuota exception in checking the quota, we need to
+        report the right values.
+        """
+        fake_flavor = objects.Flavor(name="no_fake", vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_INSTANCE_ONLY_KEY: 'true',
+                         utils.QUOTA_SEPARATE_KEY: 'true'})
+
+        quotas = {'cores': 1, 'instances': 2, 'ram': 512,
+                  'instances_no_fake': 3}
+        overs = ['instances_no_fake']
+        over_quota_args = dict(quotas=quotas,
+                               usages={'instances': 1, 'cores': 1, 'ram': 512,
+                                       'instances_no_fake': 3},
+                               overs=overs)
+        e = exception.OverQuota(**over_quota_args)
+        mock_check.side_effect = e
+        try:
+            compute_utils.check_num_instances_quota(
+                self.context, fake_flavor, 1, 1)
+        except exception.TooManyInstances as e:
+            self.assertEqual('instances_no_fake', e.kwargs['overs'])
+            self.assertEqual('1', e.kwargs['req'])
+            self.assertEqual('3', e.kwargs['used'])
+            self.assertEqual('3', e.kwargs['allowed'])
+        else:
+            self.fail("Exception not raised")
+
+    @mock.patch('nova.objects.Quotas.check_deltas')
+    def test_check_num_instances_quota_quota_separate(
+            self, mock_check):
+        """We require instances named after the flavor + ram and cpu quota
+
+        Having QUOTA_SEPARATE_KEY renames instances after the flavor but does
+        not touch cores/ram quota.
+
+        We check that we do the quota check with only the expected quotas.
+        """
+        fake_flavor = objects.Flavor(name="no_fake", vcpus=1, memory_mb=512,
+            extra_specs={utils.QUOTA_SEPARATE_KEY: 'true'})
+
+        compute_utils.check_num_instances_quota(
+            self.context, fake_flavor, 1, 1)
+
+        deltas = {'instances_no_fake': 1, 'instances': 0, 'cores': 1,
+                  'ram': 512}
+        mock_check.assert_called_with(
+            self.context, deltas, self.context.project_id, user_id=None,
+            check_project_id=self.context.project_id, check_user_id=None)
+
+    @mock.patch('nova.objects.Quotas.check_deltas')
+    def test_check_num_instances_quota_quota_separate_over(
+            self, mock_check):
+        """We should report instances quota named after the flavor + cores/ram
+
+        Having QUOTA_SEPARATE_KEY renames the instances after the flavor.
+
+        If we get an OverQuota exception in checking the quota, we need to
+        report the right values.
+        """
+        fake_flavor = objects.Flavor(name="no_fake", vcpus=4, memory_mb=512,
+            extra_specs={utils.QUOTA_SEPARATE_KEY: 'true'})
+
+        quotas = {'cores': 4, 'instances': 2, 'ram': 768,
+                  'instances_no_fake': 3}
+        overs = ['instances_no_fake', 'cores', 'ram']
+        over_quota_args = dict(quotas=quotas,
+                               usages={'instances': 1, 'cores': 4, 'ram': 512,
+                                       'instances_no_fake': 3},
+                               overs=overs)
+        e = exception.OverQuota(**over_quota_args)
+        mock_check.side_effect = e
+        try:
+            compute_utils.check_num_instances_quota(
+                self.context, fake_flavor, 1, 1)
+        except exception.TooManyInstances as e:
+            self.assertEqual('instances_no_fake, cores, ram',
+                             e.kwargs['overs'])
+            self.assertEqual('1, 4, 512', e.kwargs['req'])
+            self.assertEqual('3, 4, 512', e.kwargs['used'])
+            self.assertEqual('3, 4, 768', e.kwargs['allowed'])
+        else:
+            self.fail("Exception not raised")
 
 
 class IsVolumeBackedInstanceTestCase(test.TestCase):

--- a/nova/tests/unit/objects/test_instance.py
+++ b/nova/tests/unit/objects/test_instance.py
@@ -2139,6 +2139,67 @@ class TestInstanceListObject(test_objects._LocalTest,
                                                     {})
         self.assertEqual(2, len(insts))
 
+    def test_sum_counts(self):
+        """Counting instance resource quota
+
+        Having no type in instance_types means we count as normal, because need
+        to count somewhere.
+        """
+        instance_types = {
+            17: {'name': 'no_fake', 'separate': False, 'instance_only': False},
+            18: {'name': 'no_fake2', 'separate': False,
+                 'instance_only': False},
+        }
+        instances = [
+            (17, 2, 4, 512),
+            (18, 4, 6, 1024),
+            (19, 2, 4, 512)]
+        res = objects.InstanceList._sum_counts(instances, instance_types)
+        self.assertEqual({'instances': 8, 'cores': 14, 'ram': 2048}, res)
+
+    def test_sum_counts_instance_only(self):
+        """Flavors with QUOTA_INSTANCE_ONLY_KEY count _only_ instances"""
+        instance_types = {
+            17: {'name': 'no_fake', 'separate': False, 'instance_only': True},
+            18: {'name': 'no_fake2', 'separate': False,
+                 'instance_only': False},
+        }
+        instances = [
+            (17, 2, 4, 512),
+            (18, 4, 6, 1024)]
+        res = objects.InstanceList._sum_counts(instances, instance_types)
+        self.assertEqual({'instances': 6, 'cores': 6, 'ram': 1024}, res)
+
+    def test_sum_counts_separate(self):
+        """Flavors with QUOTA_SEPARATE_KEY count different instances quota"""
+        instance_types = {
+            17: {'name': 'so_fake', 'separate': True, 'instance_only': False},
+            18: {'name': 'no_fake2', 'separate': False,
+                 'instance_only': False},
+        }
+        instances = [
+            (17, 2, 4, 512),
+            (18, 4, 6, 1024)]
+        res = objects.InstanceList._sum_counts(instances, instance_types)
+        self.assertEqual({'instances': 4, 'cores': 10, 'ram': 1536,
+                          'instances_so_fake': 2}, res)
+
+    def test_sum_counts_instance_only_separate(self):
+        """Flavors with QUOTA_SEPARATE_KEY and QUOTA_INSTANCE_ONLY_KEY count
+        _only_ different instances quota
+        """
+        instance_types = {
+            17: {'name': 'so_fake', 'separate': True, 'instance_only': True},
+            18: {'name': 'no_fake2', 'separate': False,
+                 'instance_only': False},
+        }
+        instances = [
+            (17, 2, 4, 512),
+            (18, 4, 6, 1024)]
+        res = objects.InstanceList._sum_counts(instances, instance_types)
+        self.assertEqual({'instances': 4, 'cores': 6, 'ram': 1024,
+                          'instances_so_fake': 2}, res)
+
 
 class TestRemoteInstanceListObject(test_objects._RemoteTest,
                                    _TestInstanceListObject):


### PR DESCRIPTION
Resizing away from `quota:separate` did not return a generic "instances" requirement.

Having `quota:instance_only` had no effect on the required cores/ram quota, because the defaults already set that quota. It's supposed to change a flavor to only require "instances" or "instances_*" (flavor named) quota (depending on `quota:separate`).

'quota:separate' had an effect on cores/ram quota, even though it shouldn't.

We add tests for both `quota:separate` and `quota:instance_only` here.

Change-Id: Ic5d795e70d3174e5c70e0fc36d0d8079315e1ffa
Fixup-For: Id59478e1d35f4bda73b1156556a3cf39bb62c9b6