### PR TITLE
Add rate-limit-middleware as custom requirement

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -9,3 +9,5 @@ statsd  # MIT
 -e git+https://github.com/sapcc/openstack-audit-middleware.git#egg=audit-middleware
 -e git+https://github.com/sapcc/python-agentliveness.git#egg=agentliveness
 -e git+https://github.com/sapcc/oslo.vmware.git@stable/2023.2-m3#egg=oslo.vmware
+-e git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
+


### PR DESCRIPTION
To avoid service failures under unexpected high load need to add rate limiting and middleware is a part of that.