### PR TITLE
External scheduler: don't log or send credentials

### DIFF
--- a/nova/scheduler/external.py
+++ b/nova/scheduler/external.py
@@ -63,11 +63,22 @@ def call_external_scheduler_api(context, weighed_hosts, weights, spec_obj):
         return weighed_hosts
     timeout = CONF.filter_scheduler.external_scheduler_timeout
 
+    # Serialize the request spec and context to plain dicts, but remove
+    # sensitive information.
+    spec_data = spec_obj.obj_to_primitive()
+    obj_key = "nova_object.data"  # Used by obj_to_primitive to wrap objects.
+    if "requested_destination" in (unwrapped := spec_data[obj_key]):
+        req_destination = unwrapped["requested_destination"]
+        if "cell" in (unwrapped := req_destination[obj_key]):
+            del unwrapped["cell"][obj_key]["database_connection"]
+            del unwrapped["cell"][obj_key]["transport_url"]
+    context_data = context.to_dict()
+    if "auth_token" in context_data:
+        del context_data["auth_token"]
+
     json_data = {
-        "spec": spec_obj.obj_to_primitive(),
-        # Also serialize the request context, which contains the global request
-        # id and other information helpful for logging and request tracing.
-        "context": context.to_dict(),
+        "spec": spec_data,
+        "context": context_data,
         # Extract some flags from the spec to indicate the type of
         # request. This will allow the external scheduler to quickly
         # decide if it wants to handle the request or not.

--- a/nova/tests/unit/scheduler/test_external.py
+++ b/nova/tests/unit/scheduler/test_external.py
@@ -49,6 +49,8 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
             is_admin=False,
             read_deleted='no',
             global_request_id='fake_global_request_id',
+            # Sensitive data to be removed.
+            auth_token='fake_auth_token',
         )
         self.example_spec = objects.RequestSpec(
             context=self.example_ctx,
@@ -57,6 +59,15 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
                 vcpus=4,
                 memory_mb=1024,
                 extra_specs={},
+            ),
+            requested_destination=objects.Destination(
+                host='fake_host',
+                cell=objects.CellMapping(
+                    uuid=objects.CellMapping.CELL0_UUID,
+                    # Sensitive data to be removed.
+                    database_connection='fake_db_conn',
+                    transport_url='fake_transport_url',
+                ),
             ),
         )
 
@@ -84,11 +95,38 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
             'global_request_id', kwargs['json']['context'],
             'Global request ID should be included in the context'
         )
+        expected_dict = self.example_ctx.to_dict()
+        del expected_dict['auth_token']
         self.assertEqual(
-            self.example_ctx.to_dict(),
+            expected_dict,
             kwargs['json']['context'],
             'Context should be serialized correctly'
         )
+
+    @patch('requests.post')
+    def test_no_credentials_in_cell_mapping(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': ['host1', 'host3']}
+        mock_post.return_value = mock_response
+
+        call_external_scheduler_api(
+            self.example_ctx,
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+
+        # Check that sensitive data in cell mapping is removed
+        _, kwargs = mock_post.call_args
+        spec_data = kwargs['json']['spec']
+        obj_key = "nova_object.data"
+        self.assertIn('requested_destination', spec_data[obj_key])
+        req_destination = spec_data[obj_key]['requested_destination']
+        self.assertIn('cell', req_destination[obj_key])
+        cell_mapping = req_destination[obj_key]['cell']
+        self.assertNotIn('database_connection', cell_mapping[obj_key])
+        self.assertNotIn('transport_url', cell_mapping[obj_key])
 
     @patch('requests.post')
     @patch('nova.scheduler.external.LOG.debug')


### PR DESCRIPTION
The external scheduler call logged two types of credentials:

1. DB and mqtt connection secrets nested in the cell mapping
2. The user's auth token from the request context

This change removes the credentials from logging and also
avoids sending them to the external scheduler.