### PR TITLE
Fix not logging credentials

### DIFF
--- a/nova/scheduler/external.py
+++ b/nova/scheduler/external.py
@@ -67,11 +67,15 @@ def call_external_scheduler_api(context, weighed_hosts, weights, spec_obj):
     # sensitive information.
     spec_data = spec_obj.obj_to_primitive()
     obj_key = "nova_object.data"  # Used by obj_to_primitive to wrap objects.
-    if "requested_destination" in (unwrapped := spec_data[obj_key]):
-        req_destination = unwrapped["requested_destination"]
-        if "cell" in (unwrapped := req_destination[obj_key]):
-            del unwrapped["cell"][obj_key]["database_connection"]
-            del unwrapped["cell"][obj_key]["transport_url"]
+    unwrapped = spec_data
+    for key in [obj_key, 'requested_destination', obj_key, 'cell', obj_key]:
+        if not unwrapped or key not in unwrapped:
+            unwrapped = None
+            break
+        unwrapped = unwrapped[key]
+    if unwrapped:
+        del unwrapped["database_connection"]
+        del unwrapped["transport_url"]
     context_data = context.to_dict()
     if "auth_token" in context_data:
         del context_data["auth_token"]

--- a/nova/tests/unit/scheduler/test_external.py
+++ b/nova/tests/unit/scheduler/test_external.py
@@ -129,6 +129,32 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
         self.assertNotIn('transport_url', cell_mapping[obj_key])
 
     @patch('requests.post')
+    def test_no_credentials_in_cell_mapping_missing_keys(self, mock_post):
+        """This should not raise if requested_destination or cell is missing"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': ['host1', 'host3']}
+        mock_post.return_value = mock_response
+
+        self.example_spec.requested_destination.cell = None
+
+        call_external_scheduler_api(
+            self.example_ctx,
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+
+        self.example_spec.requested_destination = None
+
+        call_external_scheduler_api(
+            self.example_ctx,
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+
+    @patch('requests.post')
     @patch('nova.scheduler.external.LOG.debug')
     def test_enabled_api_success(self, mock_debug_log, mock_post):
         mock_response = MagicMock()


### PR DESCRIPTION
Some keys might exist but can be None. We would get a `TypeError` trying to use them as dicts.

Change-Id: Iab523b9d637d4c3ef3633ce84f35a874ce68b3f2
Fixup-For: External scheduler: don't log credentials