### PR TITLE
Ignore certain external customer domains

### DIFF
--- a/nova/conf/base.py
+++ b/nova/conf/base.py
@@ -223,6 +223,18 @@ If kept empty, the trait will not be added to any VM-build request and the
 vmwareapi driver will not consider assigning VMs to HostGroups and will not run
 its sync-loop that ensures the assignment.
 """),
+    cfg.ListOpt("external_customer_ignored_domain_names",
+        default=[],
+        help="""
+List of domain names that are ignored even if they match
+external_customer_domain_name_prefixes
+
+Some special domains might match the prefix but are stupidly by decision of
+higher-ups still not supposed to be handled like external customers in Nova's
+perspective. Lacking time for a better design, we hard-code a list of domain
+names here that are ignored whenever we use
+external_customer_domain_name_prefixes.
+"""),
 ]
 
 metrics_opts = [

--- a/nova/scheduler/request_filter.py
+++ b/nova/scheduler/request_filter.py
@@ -468,6 +468,9 @@ def external_customer_filter(
     if not domain_name.startswith(prefixes):
         return False
 
+    if domain_name in CONF.external_customer_ignored_domain_names:
+        return False
+
     request_spec.root_required.add(
         nova_utils.EXTERNAL_CUSTOMER_SUPPORTED_TRAIT)
     LOG.debug("external_customer_filter added trait %s",

--- a/nova/tests/unit/scheduler/test_request_filter.py
+++ b/nova/tests/unit/scheduler/test_request_filter.py
@@ -762,3 +762,14 @@ class TestRequestFilter(test.NoDBTestCase):
         self.assertEqual(
             {nova_utils.EXTERNAL_CUSTOMER_SUPPORTED_TRAIT},
             reqspec.root_required)
+
+    def test_external_customer_filter_prefix_matching_ignored(self):
+        """Prefix of the domain name matches, but the domain is ignored"""
+        reqspec = objects.RequestSpec(
+            scheduler_hints={'domain_name': ['test']})
+
+        self.flags(external_customer_domain_name_prefixes=['foo', 'bar', 'te'])
+        self.flags(external_customer_ignored_domain_names=['food', 'test'])
+
+        self.assertFalse(request_filter.external_customer_filter(
+                         self.context, reqspec))

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1286,7 +1286,8 @@ class VMwareVMOps(object):
         vm_group_name = None
         if domain_name in hostgroups:
             vm_group_name = f"{drs_prefix}{domain_name}"
-        elif not domain_name.startswith(prefixes):
+        elif not domain_name.startswith(prefixes) or \
+                domain_name in CONF.external_customer_ignored_domain_names:
             vm_group_name = f"{drs_prefix}internal_workload"
         else:
             prefixes_and_hg_names = [(prefix, prefix.removesuffix('-'))

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1354,6 +1354,11 @@ class VMwareVMOps(object):
         LOG.debug('Starting sync for external customer VmGroup %s',
                   vm_group_name)
 
+        # Since this is an admin group it can contain instances from more than
+        # the current project. Therefore, we need to be able to query all
+        # projects and not just to user-scoped one.
+        context = context.elevated()
+
         @utils.synchronized("vmware-external-customer-vm-group-"
                             f"{vm_group_name}")
         def _sync_vm_group(context, vm_group_name):


### PR DESCRIPTION
We didn't get time to properly do this so we now add a hard-coded list of domain names via config that are not supposed to be treated like external customer domains even though they totally look like they should be.

I hope we can revert this and build something proper with feature-flags on domains.

Change-Id: I2a917a027d3416cf9bbe80e766b912ceed650bc3
Related-Change-Id: I034e89251ce44310f6642983323bed26eddc0159
Related-Change-Id: Iea2cb2c1726adb4a4b6f6b2d6cf0875972f4b517
Related-Change-Id: Ia065958822b636c35b84349f44e88f38c923acbb