### PR TITLE
Reset the mapped field of nodes at service deletion

### DIFF
--- a/nova/db/main/api.py
+++ b/nova/db/main/api.py
@@ -383,11 +383,18 @@ def service_destroy(context, service_id):
     if service.binary == 'nova-compute':
         # TODO(sbauza): Remove the service_id filter in a later release
         # once we are sure that all compute nodes report the host field
-        model_query(context, models.ComputeNode).\
+        query = model_query(context, models.ComputeNode).\
             filter(sql.or_(
-                models.ComputeNode.service_id == service_id,
-                models.ComputeNode.host == service['host'])).\
-            soft_delete(synchronize_session=False)
+            models.ComputeNode.service_id == service_id,
+            models.ComputeNode.host == service['host']))
+
+        # NOTE(jlejeune): Make sure that the mapped field is set to 0
+        # See https://bugs.launchpad.net/nova/+bug/2085135.
+        compute_ref = query.first()
+        if compute_ref:
+            compute_ref.update({'mapped': 0})
+
+        query.soft_delete(synchronize_session=False)
 
 
 @pick_context_manager_reader


### PR DESCRIPTION
Make sure that the 'mapped' field of compute nodes is reset to 0 at nova-compute service deletion.

To let nova-manage create the missing host mapping in nova_api database.

Closes-Bug: #2085135
Change-Id: I774d4312d7e94af94d960f7269717a00fa08c583