### PR TITLE
vmwareapi: Wait for port realization in NSX-T during spawn

### DIFF
--- a/nova/api/openstack/compute/schemas/server_external_events.py
+++ b/nova/api/openstack/compute/schemas/server_external_events.py
@@ -32,7 +32,8 @@ create = {
                             'network-changed',
                             'network-vif-plugged',
                             'network-vif-unplugged',
-                            'network-vif-deleted'
+                            'network-vif-deleted',
+                            'network-port-realization-done',
                         ],
                     },
                     'status': {

--- a/nova/conf/vmware.py
+++ b/nova/conf/vmware.py
@@ -423,6 +423,21 @@ When this option is enabled and DRS is set to `disabled`, the VMs will
 be stacked by choosing the fullest host still having enough resources free
 to fit that VM.
 """),
+    cfg.IntOpt('port_realization_wait_timeout',
+               default=180,
+               help="""
+Time to wait in seconds for a Neutron event during VM lifecycle
+
+Neutron sends a network-port-realization-done event after the port binding to
+notify us that we can create/live-migrate/etc. the VM. If we don't receive the
+event after the given seconds, we time out, ask Neutron again if the ports are
+realized, and fail - depending on the `vif_plugging_is_fatal` configuration
+option.
+
+Possible values:
+* A positive integer: seconds to wait for the event
+* 0 or a negative integer: disable waiting for the event
+"""),
 ]
 
 vmwareapi_driver_opts = [

--- a/nova/network/neutron.py
+++ b/nova/network/neutron.py
@@ -3959,6 +3959,38 @@ class API:
                 'Subnet %s not found' % subnet_id) from e
         return subnet.get('segment_id')
 
+    def get_nsxv3_realization_status(self, context, host, port_ids):
+        """Fetch realization status for given ports
+
+        This calls a custom SAP API in Neutron that provides information from
+        the nsxv3-agent i.e. NSX-T about whether the ports have finished
+        creation in the backend i.e. got realized.
+
+        Neutron requires a host here, because during live-migrations, it's not
+        clear which of the bindings should be checked.
+        """
+        client = get_client(context, admin=True)
+
+        # If neutron doesn't support checking for realization status, we assume
+        # the ports have been realized. Otherwise, a code-path waiting for
+        # realization might never continue.
+        if not self._has_extension('nsxt-policy', context, client):
+            return {p_id: True for p_id in port_ids}
+
+        result = {}
+        for port_id in port_ids:
+            url = (f"/nsxt-policy/port/realization_status?"
+                   f"binding_host={host}"
+                   f"&port_id={port_id}")
+            try:
+                result[port_id] = client.get(url)['realized']
+            except neutron_client_exc.NeutronClientException as e:
+                LOG.exception('Unable to get port realization status for '
+                              'port %s: %s - returning False', port_id, e)
+                result[port_id] = False
+
+        return result
+
 
 def _ensure_requested_network_ordering(accessor, unordered, preferred):
     """Sort a list with respect to the preferred network ordering."""

--- a/nova/objects/external_event.py
+++ b/nova/objects/external_event.py
@@ -23,6 +23,7 @@ EVENT_NAMES = [
     'network-vif-plugged',
     'network-vif-unplugged',
     'network-vif-deleted',
+    'network-port-realization-done',
 
     # Volume was extended for this instance, tag is volume_id
     'volume-extended',

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1110,7 +1110,7 @@ object_data = {
     'InstanceActionEventList': '1.1-13d92fb953030cdbfee56481756e02be',
     'InstanceActionList': '1.1-a2b2fb6006b47c27076d3a1d48baa759',
     'InstanceDeviceMetadata': '1.0-74d78dd36aa32d26d2769a1b57caf186',
-    'InstanceExternalEvent': '1.5-1ec57351a9851c1eb43ccd90662d6dd0',
+    'InstanceExternalEvent': '1.5-bdd2e3f576462d3b823a4530f6fe6874',
     'InstanceFault': '1.2-7ef01f16f1084ad1304a513d6d410a38',
     'InstanceFaultList': '1.2-6bb72de2872fe49ded5eb937a93f2451',
     'InstanceGroup': '1.11-a26b476ba20883380476d4cb8c4b8d41',

--- a/nova/tests/unit/virt/vmwareapi/test_configdrive.py
+++ b/nova/tests/unit/virt/vmwareapi/test_configdrive.py
@@ -131,6 +131,7 @@ class ConfigDriveTestCase(test.TestCase):
         vmwareapi_fake.cleanup()
 
     @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch('nova.utils.vm_needs_special_spawning')
     @mock.patch.object(vmops.VMwareVMOps, '_get_instance_metadata',
                        return_value='fake_metadata')
@@ -140,7 +141,8 @@ class ConfigDriveTestCase(test.TestCase):
                        return_value=None)
     def _spawn_vm(self, fake_fetch_image_from_other_datastores,
                   fake_find_image_template_vm, fake_get_instance_meta,
-                  mock_vm_special_spawning, mock_update_cluster_placement,
+                  mock_vm_special_spawning, mock_wait_for_port,
+                  mock_update_cluster_placement,
                   injected_files=None, admin_password=None,
                   block_device_info=None):
 

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -405,6 +405,8 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
         with test.nested(
             mock.patch.object(self.conn._vmops, 'update_cluster_placement',
                               return_value=None),
+            mock.patch.object(self.conn._vmops, '_wait_for_port_realization',
+                              return_value=None),
             mock.patch.object(self.conn._vmops, '_find_image_template_vm',
                               return_value=None),
             mock.patch.object(self.conn._vmops,
@@ -1157,6 +1159,8 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
                 return_value=True)
     @mock.patch('nova.virt.vmwareapi.vmops.VMwareVMOps.'
                 'update_cluster_placement')
+    @mock.patch('nova.virt.vmwareapi.vmops.VMwareVMOps.'
+                '_wait_for_port_realization')
     @mock.patch.object(vm_util, 'relocate_vm')
     @mock.patch('nova.virt.vmwareapi.volumeops.VMwareVolumeOps.'
                 'attach_volume')
@@ -1169,6 +1173,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
                                   mock_get_res_pool_of_vm,
                                   mock_attach_volume,
                                   mock_relocate_vm,
+                                  mock_wait_for_port,
                                   mock_update_cluster_placement,
                                   mock_is_volume_backed,
                                   set_image_ref=True):
@@ -1202,6 +1207,8 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
                 return_value=False)
     @mock.patch('nova.virt.vmwareapi.vmops.VMwareVMOps.'
                 'update_cluster_placement')
+    @mock.patch('nova.virt.vmwareapi.vmops.VMwareVMOps.'
+                '_wait_for_port_realization')
     @mock.patch('nova.virt.vmwareapi.volumeops.VMwareVolumeOps.'
                 'attach_volume')
     @mock.patch('nova.block_device.volume_in_mapping')
@@ -1210,6 +1217,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
                                        mock_info_get_mapping,
                                        mock_block_volume_in_mapping,
                                        mock_attach_volume,
+                                       mock_wait_for_port,
                                        mock_update_cluster_placement,
                                        mock_is_volume_backed):
         self._create_instance()
@@ -2597,7 +2605,9 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
 
     @mock.patch.object(oslo_vim_util, 'serialize_object')
     @mock.patch.object(vmops.VMwareVMOps, 'place_vm')
-    def test_pre_live_migration(self, mock_place_vm, mock_serialize_object):
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
+    def test_pre_live_migration(self, mock_wait_for_port, mock_place_vm,
+                                mock_serialize_object):
         mock_place_vm.side_effect = self._create_placement_result
         self._create_instance()
         migrate_data = self._create_live_migrate_data()

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -2175,10 +2175,11 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vmops.VMwareVMOps, '_get_vm_config_info')
     @mock.patch.object(vmops.VMwareVMOps, 'build_virtual_machine')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch.object(vmops.lockutils, 'lock')
     @mock.patch.object(ds_util, 'get_datastore')
     def test_spawn_mask_block_device_info_password(self, mock_get_datastore,
-            mock_lock, mock_update_cluster_placement,
+            mock_lock, mock_wait_for_port, mock_update_cluster_placement,
             mock_build_virtual_machine, mock_get_vm_config_info,
             mock_fetch_image_if_missing, mock_debug, mock_glance,
             mock_is_volume_backed):
@@ -2269,12 +2270,14 @@ class VMwareVMOpsTestCase(test.TestCase):
         'nova.virt.vmwareapi.imagecache.ImageCacheManager.enlist_image')
     @mock.patch.object(vmops.VMwareVMOps, 'build_virtual_machine')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch.object(vmops.VMwareVMOps, '_get_vm_config_info')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
     @mock.patch.object(images.VMwareImage, 'from_image')
     def test_spawn_non_root_block_device(self, from_image,
                                          get_extra_specs,
                                          get_vm_config_info,
+                                         wait_for_port,
                                          update_cluster_placement,
                                          build_virtual_machine,
                                          enlist_image, fetch_image,
@@ -2337,12 +2340,14 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch('nova.virt.vmwareapi.vm_util.power_on_instance')
     @mock.patch.object(vmops.VMwareVMOps, 'build_virtual_machine')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch.object(vmops.VMwareVMOps, '_get_vm_config_info')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
     @mock.patch.object(images.VMwareImage, 'from_image')
     def test_spawn_with_no_image_and_block_devices(self, from_image,
                                                    get_extra_specs,
                                                    get_vm_config_info,
+                                                   wait_for_port,
                                                    update_cluster_placement,
                                                    build_virtual_machine,
                                                    power_on_instance,
@@ -2406,12 +2411,14 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch('nova.virt.vmwareapi.vm_util.power_on_instance')
     @mock.patch.object(vmops.VMwareVMOps, 'build_virtual_machine')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch.object(vmops.VMwareVMOps, '_get_vm_config_info')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
     @mock.patch.object(images.VMwareImage, 'from_image')
     def test_spawn_unsupported_hardware(self, from_image,
                                         get_extra_specs,
                                         get_vm_config_info,
+                                        wait_for_port,
                                         update_cluster_placement,
                                         build_virtual_machine,
                                         power_on_instance,
@@ -2648,6 +2655,7 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vmops.VMwareVMOps, '_create_folders',
                        return_value='fake_vm_folder')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch(
         'nova.virt.vmwareapi.vmops.VMwareVMOps._update_vnic_index')
     @mock.patch(
@@ -2684,6 +2692,7 @@ class VMwareVMOpsTestCase(test.TestCase):
                    mock_get_datastore,
                    mock_configure_config_drive,
                    mock_update_vnic_index,
+                   mock_wait_for_port,
                    mock_update_cluster_placement,
                    mock_create_folders,
                    mock_is_volume_backed,
@@ -2951,12 +2960,14 @@ class VMwareVMOpsTestCase(test.TestCase):
         'nova.virt.vmwareapi.imagecache.ImageCacheManager.enlist_image')
     @mock.patch.object(vmops.VMwareVMOps, 'build_virtual_machine')
     @mock.patch.object(vmops.VMwareVMOps, 'update_cluster_placement')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch.object(vmops.VMwareVMOps, '_get_vm_config_info')
     @mock.patch.object(vmops.VMwareVMOps, '_get_extra_specs')
     @mock.patch.object(images.VMwareImage, 'from_image')
     def test_spawn_with_ephemerals_and_swap(self, from_image,
                                             get_extra_specs,
                                             get_vm_config_info,
+                                            wait_for_port,
                                             update_cluster_placement,
                                             build_virtual_machine,
                                             enlist_image,

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -33,6 +33,7 @@ import time
 
 import decorator
 
+import eventlet
 from oslo_concurrency import lockutils
 from oslo_log import log as logging
 import oslo_messaging as messaging
@@ -1533,6 +1534,72 @@ class VMwareVMOps(object):
 
         return templ_vm_ref
 
+    def _wait_for_port_realization(self, context, instance, network_info,
+                                   timeout=300):
+        """Wait for Neutron events of NSX-T port realization
+
+        The nsxv3 driver in Neutron returns the port binding request once it
+        created the port in NSX-T. It doesn't wait for the port to be realized.
+        Instead, it sends an event once the port changes its state.
+
+        We wait for the appropriate event here, checking with an API call if we
+        already missed (some) of the ports' events.
+
+        We wait with a timeout, checking again after the timeout, because
+        `get_nsxv3_realization_status()` returns `False` for a port if any
+        problem with Neutron occurred.
+        """
+        port_ids = [vif['id'] for vif in network_info]
+        if timeout <= 0:
+            # No or a negative timeout disables waiting for the event and since
+            # this method does nothing else, we can return early.
+            return
+
+        events = [('network-port-realization-done', p_id)
+                  for p_id in port_ids]
+        try:
+            with self._virtapi.wait_for_instance_event(
+                instance, events, deadline=timeout,
+            ):
+                port_realized_states = \
+                    self._network_api.get_nsxv3_realization_status(context,
+                        self._compute_host, port_ids)
+
+                done_events = []
+                for port_id in port_ids:
+                    if port_id not in port_realized_states:
+                        LOG.warning("No relization status for port %s",
+                                    port_id, instance=instance)
+                        continue
+
+                    if not port_realized_states[port_id]:
+                        continue
+
+                    LOG.info("Port %s already realized. Disabling "
+                        "network-port-realization-done event for it.",
+                        port_id, instance=instance)
+                    done_events.append(('network-port-realization-done',
+                                        port_id))
+
+                self._virtapi.exit_wait_early(done_events)
+        except eventlet.timeout.Timeout as e:
+            port_realized_states = \
+                self._network_api.get_nsxv3_realization_status(context,
+                    self._compute_host, port_ids)
+            not_realized_port_ids = [k for k, v in port_realized_states.items()
+                                     if not v]
+            if not_realized_port_ids:
+                LOG.info("Waiting for network-port-realization-done timed "
+                         "out after %s with some ports not realized: %s",
+                         timeout, ', '.join(not_realized_port_ids),
+                         instance=instance)
+                if CONF.vif_plugging_is_fatal:
+                    raise exception.VirtualInterfaceCreateException() from e
+            else:
+                LOG.info("Waiting for network-port-realization-done timed "
+                         "out after %s, but all ports are realized",
+                         timeout, instance=instance)
+
     def spawn(self, context, instance, image_meta, injected_files,
               admin_password, network_info, block_device_info=None):
 
@@ -1551,6 +1618,11 @@ class VMwareVMOps(object):
         metadata = self._get_instance_metadata(context, instance)
         vm_folder = self._get_project_folder(
             vi.dc_info, project_id=instance.project_id, type_='Instances')
+
+        timeout = CONF.vmware.port_realization_wait_timeout
+        self._wait_for_port_realization(context, instance, network_info,
+                                        timeout=timeout)
+
         # Creates the virtual machine. The virtual machine reference returned
         # is unique within Virtual Center.
         vm_ref = self.build_virtual_machine(instance,
@@ -3100,6 +3172,10 @@ class VMwareVMOps(object):
         defaults["relocate_spec"] = spec
         # Writing the values back
         migrate_data.relocate_defaults = defaults
+
+        timeout = CONF.vmware.port_realization_wait_timeout
+        self._wait_for_port_realization(context, instance, network_info,
+                                        timeout=timeout)
 
         return migrate_data
 


### PR DESCRIPTION
Neutron sends an event to Nova once the port is realized in NSX-T. This can happen a little while after the port was created and thus the port-binding done. Without the port being realized, ESXi would create a new port instead. This port would not get the security groups assigned and thus would not work as expected for VMs.

We only wait during spawn for now, but the same problem can happen in live-migrations and probably other operations like resizes, too.

Since this is a custom event, nova-api will not accept and nova-compute will not be able to wait for it unless we make it known to Nova.

Change-Id: I9ca66b57fd3256589bc8b272e027f7cd27bd5bd4