### PR TITLE
Support multiple metadata_proxy_shared_secret

### DIFF
--- a/nova/api/metadata/handler.py
+++ b/nova/api/metadata/handler.py
@@ -52,7 +52,7 @@ class MetadataRequestHandler(wsgi.Application):
         self._cache = cache_utils.get_client(
                 expiration_time=CONF.api.metadata_cache_expiration)
         if (CONF.neutron.service_metadata_proxy and
-            not CONF.neutron.metadata_proxy_shared_secret):
+            not CONF.neutron.metadata_proxy_shared_secret[0]):
             LOG.warning("metadata_proxy_shared_secret is not configured, "
                         "the metadata information returned by the proxy "
                         "cannot be trusted")
@@ -277,7 +277,7 @@ class MetadataRequestHandler(wsgi.Application):
         instance_address = remote_address.split(',')[0]
 
         # If authentication token is set, authenticate
-        if CONF.neutron.metadata_proxy_shared_secret:
+        if CONF.neutron.metadata_proxy_shared_secret[0]:
             signature = req.headers.get('X-Metadata-Provider-Signature')
             self._validate_shared_secret(provider_id, signature,
                                          instance_address)
@@ -300,20 +300,23 @@ class MetadataRequestHandler(wsgi.Application):
 
     def _validate_shared_secret(self, requestor_id, signature,
                                 requestor_address):
-        expected_signature = hmac.new(
-            encodeutils.to_utf8(CONF.neutron.metadata_proxy_shared_secret),
-            encodeutils.to_utf8(requestor_id),
-            hashlib.sha256).hexdigest()
+        expected_signatures = [
+            hmac.new(
+                encodeutils.to_utf8(shared_secret),
+                encodeutils.to_utf8(requestor_id),
+                hashlib.sha256).hexdigest()
+            for shared_secret in CONF.neutron.metadata_proxy_shared_secret]
         if (not signature or
-            not secutils.constant_time_compare(expected_signature, signature)):
+            not any(secutils.constant_time_compare(expected, signature)
+                    for expected in expected_signatures)):
             if requestor_id:
                 LOG.warning('X-Instance-ID-Signature: %(signature)s does '
-                            'not match the expected value: '
-                            '%(expected_signature)s for id: '
+                            'not match any expected value: '
+                            '%(expected_signatures)s for id: '
                             '%(requestor_id)s. Request From: '
                             '%(requestor_address)s',
                             {'signature': signature,
-                             'expected_signature': expected_signature,
+                             'expected_signatures': expected_signatures,
                              'requestor_id': requestor_id,
                              'requestor_address': requestor_address})
             msg = _('Invalid proxy request signature.')

--- a/nova/conf/neutron.py
+++ b/nova/conf/neutron.py
@@ -122,13 +122,17 @@ Related options:
 
 * metadata_proxy_shared_secret
 """),
-     cfg.StrOpt("metadata_proxy_shared_secret",
-        default="",
+     cfg.MultiStrOpt("metadata_proxy_shared_secret",
+        default=[""],
         secret=True,
         help="""
 This option holds the shared secret string used to validate proxy requests to
 Neutron metadata requests. In order to be used, the
 'X-Metadata-Provider-Signature' header must be supplied in the request.
+
+We support multiple secrets being set here to improve the secret rotation
+experience. Nova can support the new secret and the old one, so Neutron can
+switch to the new one without downtime.
 
 Related options:
 

--- a/nova/tests/unit/test_metadata.py
+++ b/nova/tests/unit/test_metadata.py
@@ -1213,7 +1213,7 @@ class MetadataHandlerTestCase(test.TestCase):
         self.expected_instance_id = b'a-b-c-d'
 
         signed = hmac.new(
-            encodeutils.to_utf8(CONF.neutron.metadata_proxy_shared_secret),
+            encodeutils.to_utf8(CONF.neutron.metadata_proxy_shared_secret[0]),
             self.expected_instance_id,
             hashlib.sha256).hexdigest()
 
@@ -1298,7 +1298,7 @@ class MetadataHandlerTestCase(test.TestCase):
 
         # unexpected Instance-ID
         signed = hmac.new(
-            encodeutils.to_utf8(CONF.neutron.metadata_proxy_shared_secret),
+            encodeutils.to_utf8(CONF.neutron.metadata_proxy_shared_secret[0]),
            b'z-z-z-z',
            hashlib.sha256).hexdigest()
 
@@ -1339,7 +1339,7 @@ class MetadataHandlerTestCase(test.TestCase):
         expected_instance_id = b'a-b-c-d'
 
         signed = hmac.new(
-            encodeutils.to_utf8(CONF.neutron.metadata_proxy_shared_secret),
+            encodeutils.to_utf8(CONF.neutron.metadata_proxy_shared_secret[0]),
             expected_instance_id,
             hashlib.sha256).hexdigest()
 
@@ -1558,7 +1558,47 @@ class MetadataHandlerTestCase(test.TestCase):
 
         shared_secret = "testing1234"
         self.flags(
-            metadata_proxy_shared_secret=shared_secret,
+            metadata_proxy_shared_secret=[shared_secret],
+            service_metadata_proxy=True, group='neutron')
+
+        self.expected_instance_id = b'a-b-c-d'
+
+        # with X-Metadata-Provider
+        proxy_lb_id = 'edge-x'
+
+        signature = hmac.new(
+            encodeutils.to_utf8(shared_secret),
+            encodeutils.to_utf8(proxy_lb_id),
+            hashlib.sha256).hexdigest()
+
+        mock_client = mock_get_client.return_value
+        mock_client.list_ports.return_value = {
+            'ports': [{'device_id': 'a-b-c-d', 'tenant_id': 'test'}]}
+        mock_client.list_subnets.return_value = {
+            'subnets': [{'network_id': 'f-f-f-f'}]}
+
+        response = fake_request(
+            self, self.mdinst,
+            relpath="/2009-04-04/user-data",
+            address="192.192.192.2",
+            fake_get_metadata_by_instance_id=self._fake_x_get_metadata,
+            headers={'X-Forwarded-For': '192.192.192.2',
+                     'X-Metadata-Provider': proxy_lb_id,
+                     'X-Metadata-Provider-Signature': signature})
+
+        self.assertEqual(200, response.status_int)
+
+    @mock.patch.object(neutronapi, 'get_client', return_value=mock.Mock())
+    def test_metadata_lb_proxy_signed_second(self, mock_get_client):
+        """We have two secrets and the second one is used for signing
+
+        We test here, if only the first or more than on secret is checked
+        against the request.
+        """
+
+        shared_secret = "testing1234"
+        self.flags(
+            metadata_proxy_shared_secret=['thisisnotused', shared_secret],
             service_metadata_proxy=True, group='neutron')
 
         self.expected_instance_id = b'a-b-c-d'
@@ -1593,7 +1633,7 @@ class MetadataHandlerTestCase(test.TestCase):
 
         shared_secret = "testing1234"
         self.flags(
-            metadata_proxy_shared_secret=shared_secret,
+            metadata_proxy_shared_secret=[shared_secret],
             service_metadata_proxy=True, group='neutron')
 
         self.expected_instance_id = b'a-b-c-d'
@@ -1622,7 +1662,7 @@ class MetadataHandlerTestCase(test.TestCase):
         shared_secret = "testing1234"
         bad_secret = "testing3468"
         self.flags(
-            metadata_proxy_shared_secret=shared_secret,
+            metadata_proxy_shared_secret=[shared_secret],
             service_metadata_proxy=True, group='neutron')
 
         self.expected_instance_id = b'a-b-c-d'


### PR DESCRIPTION
When doing secret rotation for the shared metadata secret, Nova and Neutron have to be aligned on the new secret. Otherwise, metadata requests made through not-yet-restarted neutron-metadata agents will be denied by nova-api-metadata.

To help in this migration, Nova supports two secrets now using a MultiStrOpt. This enables Nova to add a new secret, make Neutron switch to the new secret while Nova still supports the old one, and then Nova can remove the old secret once Neutron rollout is done.

Change-Id: I9b2e15fa594c2044cfe598caed3e56b4a59c62b3