### PR TITLE
Switch to custom ironicclient

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,7 +1,6 @@
 dumb-init
 python-memcached
 pymemcache
-python-ironicclient
 statsd  # MIT
 
 -e git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven
@@ -10,4 +9,4 @@ statsd  # MIT
 -e git+https://github.com/sapcc/python-agentliveness.git#egg=agentliveness
 -e git+https://github.com/sapcc/oslo.vmware.git@stable/2023.2-m3#egg=oslo.vmware
 -e git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
-
+-e git+https://github.com/sapcc/python-ironicclient.git@stable/2023.2-m3#egg=python-ironicclient


### PR DESCRIPTION
We fixed bug with parallel version negotiation in 2023.2-m3. Since python-ironicclient is no longer in use in Epoxy (2025.1), we most likely don't have to port this commit forward.

Change-Id: I749121a7382dea29cadca2e34a8924affd5da61d