### PR TITLE
Try to handle resource busy on unmount

### DIFF
--- a/nova/conf/libvirt.py
+++ b/nova/conf/libvirt.py
@@ -1118,6 +1118,26 @@ provide high availability and fault tolerance.
                help="""
 Number of times to scan given storage protocol to find volume.
 """),
+    cfg.IntOpt('num_umount_retries',
+               default=0,
+               min=0,
+               help="""
+Number of times to retry to umount on errors, such as device busy.
+
+Related options:
+
+* umount_retry_delay
+"""),
+    cfg.FloatOpt('umount_retry_delay',
+               default=1.0,
+               help="""
+Duration in seconds to wait between retries to umount on errors, such as device
+busy.
+
+Related options:
+
+* num_umount_retries
+"""),
 ]
 
 libvirt_volume_aoe_opts = [

--- a/nova/tests/unit/virt/libvirt/volume/test_mount.py
+++ b/nova/tests/unit/virt/libvirt/volume/test_mount.py
@@ -22,12 +22,16 @@ import fixtures
 from oslo_concurrency import processutils
 from oslo_utils.fixture import uuidsentinel as uuids
 
+import nova.conf
 from nova import exception
 from nova import test
 from nova.virt.libvirt import config as libvirt_config
 from nova.virt.libvirt import guest as libvirt_guest
 from nova.virt.libvirt import host as libvirt_host
 from nova.virt.libvirt.volume import mount
+
+
+CONF = nova.conf.CONF
 
 
 # We wait on events in a few cases. In normal execution the wait period should
@@ -316,6 +320,74 @@ class HostMountStateTestCase(test.NoDBTestCase):
 
         # Unmount vol_b. We should have umounted.
         self._sentinel_umount(m, mock.sentinel.vol_b)
+        self.mock_ensure_tree.assert_has_calls([
+            mock.call(mock.sentinel.mountpoint)])
+        self.mock_mount.assert_has_calls([
+            mock.call(mock.sentinel.fstype,
+                      mock.sentinel.export, mock.sentinel.mountpoint,
+                      [mock.sentinel.option1, mock.sentinel.option2])])
+        self.mock_umount.assert_has_calls([
+            mock.call(mock.sentinel.mountpoint)])
+        self.mock_rmdir.assert_has_calls([
+            mock.call(mock.sentinel.mountpoint)])
+
+    def test_mount_umount_oserror_raised(self):
+        # Mount a volume. Test that the OSError still raised
+        m = self._get_clean_hostmountstate()
+
+        # Mount vol_a from export
+        self._sentinel_mount(m, mock.sentinel.vol_a)
+        self.mock_ensure_tree.assert_has_calls([
+            mock.call(mock.sentinel.mountpoint)])
+        self.mock_mount.assert_has_calls([
+            mock.call(mock.sentinel.fstype,
+                      mock.sentinel.export, mock.sentinel.mountpoint,
+                      [mock.sentinel.option1, mock.sentinel.option2])])
+
+        # return also None to test that it won't call a second time and recover
+        self.mock_rmdir.side_effect = [
+            OSError(16, "Device or resource busy"), None]
+        # Unmount vol_a, it will fail with the exception
+        self.assertRaises(OSError, self._sentinel_umount, m,
+                          mock.sentinel.vol_a)
+        self.mock_ensure_tree.assert_has_calls([
+            mock.call(mock.sentinel.mountpoint)])
+        self.mock_mount.assert_has_calls([
+            mock.call(mock.sentinel.fstype,
+                      mock.sentinel.export, mock.sentinel.mountpoint,
+                      [mock.sentinel.option1, mock.sentinel.option2])])
+        self.mock_umount.assert_has_calls([
+            mock.call(mock.sentinel.mountpoint)])
+        self.mock_rmdir.assert_has_calls([
+            mock.call(mock.sentinel.mountpoint)])
+
+    def test_mount_umount_oserror_recovered(self):
+        # Mount a volume. Test that we can handle the OSerror when asked
+        m = self._get_clean_hostmountstate()
+
+        CONF.set_override(
+            "num_umount_retries", 1,
+            group='libvirt',
+        )
+
+        CONF.set_override(
+            "umount_retry_delay", 0.0,
+            group='libvirt',
+        )
+
+        # Mount vol_a from export
+        self._sentinel_mount(m, mock.sentinel.vol_a)
+        self.mock_ensure_tree.assert_has_calls([
+            mock.call(mock.sentinel.mountpoint)])
+        self.mock_mount.assert_has_calls([
+            mock.call(mock.sentinel.fstype,
+                      mock.sentinel.export, mock.sentinel.mountpoint,
+                      [mock.sentinel.option1, mock.sentinel.option2])])
+
+        self.mock_rmdir.side_effect = [
+            OSError(16, "Device or resource busy"), None]
+        # Unmount vol_a. We should have umounted.
+        self._sentinel_umount(m, mock.sentinel.vol_a)
         self.mock_ensure_tree.assert_has_calls([
             mock.call(mock.sentinel.mountpoint)])
         self.mock_mount.assert_has_calls([

--- a/nova/virt/libvirt/volume/mount.py
+++ b/nova/virt/libvirt/volume/mount.py
@@ -16,9 +16,11 @@ import collections
 import contextlib
 import os.path
 import threading
+import time
 
 from oslo_concurrency import processutils
 from oslo_log import log
+from oslo_utils import excutils
 from oslo_utils import fileutils
 
 import nova.conf
@@ -385,9 +387,18 @@ class _HostMountState(object):
             LOG.error("Couldn't unmount %(mountpoint)s: %(reason)s",
                       {'mountpoint': mountpoint, 'reason': str(ex)})
 
-        if not os.path.ismount(mountpoint):
-            nova.privsep.path.rmdir(mountpoint)
-            return False
+        umount_retries = CONF.libvirt.num_umount_retries
+        for tries in reversed(range(umount_retries + 1)):
+            try:
+                if not os.path.ismount(mountpoint):
+                    nova.privsep.path.rmdir(mountpoint)
+                    return False
+                break
+            except OSError as ose:
+                with excutils.save_and_reraise_exception() as ctx:
+                    if (ose.errno == 16 and tries > 0):
+                        ctx.reraise = False
+                        time.sleep(CONF.libvirt.umount_retry_delay)
 
         return True
 


### PR DESCRIPTION
When unmounting an nfs share, the deleting of the folder where the share was mounted occasionally runs into a Device or Resource Error. That it is sporadical suggests, that we are running into a race-condition. To work around this suspected race condition, we introduce a delay and retry which by default is disabled.

Change-Id: Id5bbfcccf9785ed7323a738fad85dda7607d4ed6