### PR TITLE
vmwareapi: fix external customer VmGroup sync during migration

### DIFF
--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -4386,6 +4386,8 @@ class VMwareVMOps(object):
         # Decision matrix for migrations:
         # Mig-Status Action/Host
         #            Source  Dest
+        # Accepted   Remove  N/A
+        # Queued     Remove  N/A
         # Preparing  Remove  N/A
         # Running    Remove  Add
         # (Other states are consistent with default behaviour)
@@ -4399,7 +4401,7 @@ class VMwareVMOps(object):
         filters = {
             "host": self._compute_host,
             "instance_uuid": instance_uuids,
-            "status": ["preparing", "running"],
+            "status": ["accepted", "queued", "preparing", "running"],
         }
 
         expected_members = {}
@@ -4416,7 +4418,7 @@ class VMwareVMOps(object):
                     migration
             else:
                 # We now handle the destination side
-                if migration.status == "preparing":
+                if migration.status != "running":
                     # Not even started, we can ignore that one
                     continue
 


### PR DESCRIPTION
`_filter_instances_for_drs` may be called via callstacks different from those in the upstream starting with the introduction of external customer DRS rules and groups. In particular `update_external_customer_placement` can be called when the migration has been scheduled (`accepted`), but not triggered (`queued`, `preparing`, eventually `running`) yet during a live migration. This scenario is not covered by the filter and leads to a situation where the VM is not removed from the VmGroup, making certain migrations fail due to incorrect host affinity rules.

Fix this situation by filtering for the early states of the migration in addition to the current `preparing` and `running`.

Change-Id: I30bdc7b059e9c33e3f190184d2581a26a37445d0