### PR TITLE
Cherry-Pick: db: Fix api_db_opts reading main_db_opts

### DIFF
--- a/nova/conf/database.py
+++ b/nova/conf/database.py
@@ -50,7 +50,7 @@ api_db_opts = copy.deepcopy(oslo_db_opts.database_opts)
 # We don't support the experimental use of database reconnect on connection
 # lost, so remove the config option that would suggest we do
 main_db_opts = [opt for opt in main_db_opts if opt.name != 'use_db_reconnect']
-api_db_opts = [opt for opt in main_db_opts if opt.name != 'use_db_reconnect']
+api_db_opts = [opt for opt in api_db_opts if opt.name != 'use_db_reconnect']
 
 
 def register_opts(conf):


### PR DESCRIPTION
In Ie7e4ccaf32f7222b8e305a38b48de7980744a98f we introduced a bug by copy&paste error that made api_db_opts use main_db_opts and thus sharing the same config options.

Change-Id: Ibed6a27006ebe7e9004a09976b59e679e43fc2d5
Closes-Bug: #2120164