### PR TITLE
vmware: Parse requirements/capabilities

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/fake.py
+++ b/nova/tests/unit/virt/vmwareapi/fake.py
@@ -821,16 +821,19 @@ class HostSystem(ManagedObject):
     @staticmethod
     def create_config_feature_capability():
         aes = DataObject('HostFeatureCapability')
-        aes.featureName = 'cpuid.AES'
+        aes.key = aes.featureName = 'cpuid.AES'
         aes.value = '1'
         avx = DataObject('HostFeatureCapability')
-        avx.featureName = 'cpuid.AVX'
+        avx.key = avx.featureName = 'cpuid.AVX'
         avx.value = '1'
         amd = DataObject('HostFeatureCapability')
-        amd.featureName = 'cpuid.AMD'
+        amd.key = amd.featureName = 'cpuid.AMD'
         amd.value = '0'
+        tmul_max_k = DataObject('HostFeatureCapability')
+        tmul_max_k.key = tmul_max_k.featureName = 'cpuid.tmul_max_k'
+        tmul_max_k.value = '16'
         caps = _create_array_of_type('HostFeatureCapability')
-        caps.HostFeatureCapability = [aes, avx, amd]
+        caps.HostFeatureCapability = [aes, avx, amd, tmul_max_k]
         return caps
 
     def __init__(self, name=None, connected=True, ds_ref=None,

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -62,7 +62,8 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
     @staticmethod
     def _expected_cpu_info():
         return {
-            'features': ['aes', 'avx'],
+            'features': {'cpuid.aes': '1', 'cpuid.amd': '0', 'cpuid.avx': '1',
+                         'cpuid.tmul_max_k': '16'},
             'model': 'Intel(R) Xeon(R) CPU E5-4650 v4 @ 2.20GHz',
             'topology': {'cores': 8, 'sockets': 2, 'threads': 16},
             'vendor': 'Intel',
@@ -2410,6 +2411,39 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         session._call_method.assert_called_once_with(
             session.vim, "DetachDisk_Task", vm_ref, diskId=disk_id)
         session._wait_for_task.assert_called_once_with(task)
+
+    def test_feature_requirements_compatibility(self):
+        """Test parsing of the values and checking them against capabilities"""
+        aes = fake.DataObject('FeatureRequirement')
+        aes.key = aes.featureName = 'cpuid.aes'
+        aes.value = 'Bool:Min:1'
+        ple = fake.DataObject('FeatureRequirement')
+        ple.key = ple.featureName = 'vt.ple'
+        ple.value = 'Bool:Match:1'
+        rtm = fake.DataObject('FeatureRequirement')
+        rtm.key = rtm.featureName = 'cpuid.rtm'
+        rtm.value = 'Num:Match:1'
+        tp1nr = fake.DataObject('FeatureRequirement')
+        tp1nr.key = tp1nr.featureName = 'cpuid.tile_palette1_num_regs'
+        tp1nr.value = 'Num:Min:8'
+        tmul_max_k = fake.DataObject('FeatureRequirement')
+        tmul_max_k.key = tmul_max_k.featureName = 'cpuid.tmul_max_k'
+        tmul_max_k.value = '16'
+        tp1mr = fake.DataObject('FeatureRequirement')
+        tp1mr.key = tp1mr.featureName = 'cpuid.tile_palette1_max_rows'
+        tp1mr.value = 'Num:Min:0x10'
+
+        requirements = vm_util.FeatureRequirements([
+            aes, ple, rtm, tp1nr, tmul_max_k, tp1mr])
+
+        capabilities = vm_util.FeatureCapabilities({
+            'cpuid.aes': '1', 'vt.ple': '1', 'cpuid.rtm': '1',
+            'cpuid.tile_palette1_num_regs': '8', 'cpuid.tmul_max_k': '16',
+            'cpuid.tile_palette1_max_rows': '16'})
+
+        compatible, error_str = requirements.check_compatibility(capabilities)
+        self.assertTrue(compatible)
+        self.assertEqual(error_str, '')
 
 
 @mock.patch.object(vmware_session.VMwareAPISession, 'vim',

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -1125,9 +1125,8 @@ class VMwareVCDriver(driver.ComputeDriver):
         data.relocate_defaults = {
             "service": vim_util.serialize_object(service, typed=True),
             "target_host_ref_value": target_host_ref_value,
-            # NOTE(jkulik): We make it a list, because this gets serialized to
-            # JSON and JSON has no sets.
-            "supported_cpu_flags": list(self._vc_state.common_cpu_flags),
+            "supported_feature_capabilities":
+                self._vc_state.common_feature_capabilities,
         }
 
         return data
@@ -1153,11 +1152,13 @@ class VMwareVCDriver(driver.ComputeDriver):
         if dest_check_data.instance_already_migrated:
             return dest_check_data
 
-        # Drop the cpu-flags as we only had to transport them to the source and
-        # don't need them further down the line.
-        dest_cpu_flags = set(defaults.pop("supported_cpu_flags", []))
+        # Drop the feature capabilities as we only had to transport them to the
+        # source and don't need them further down the line.
+        dest_feature_capabilities = \
+            defaults.pop("supported_feature_capabilities", {})
         dest_check_data.relocate_defaults = defaults
-        self._vmops.check_can_live_migrate_source(instance, dest_cpu_flags)
+        self._vmops.check_can_live_migrate_source(
+            instance, dest_feature_capabilities)
 
         if dest_check_data.is_same_vcenter:
             # Drop the service-credentials, no need to check the volumes,

--- a/nova/virt/vmwareapi/host.py
+++ b/nova/virt/vmwareapi/host.py
@@ -163,9 +163,12 @@ class VCState(object):
         return self._stats[self._cluster_node_name].get('hostgroups', {})
 
     @property
-    def common_cpu_flags(self) -> set:
-        """Return a set of CPU flags all available hosts have in common"""
-        flags = None
+    def common_feature_capabilities(self) -> vm_util.FeatureCapabilities:
+        """Return the capabilities all available hosts have in common
+
+        These include e.g. cpu flags.
+        """
+        feature_capabilities = None
         for stats in self._stats.values():
             if not stats.get('available'):
                 continue
@@ -173,12 +176,13 @@ class VCState(object):
             if not (cpu_info := stats.get('cpu_info')):
                 continue
 
-            features = set(cpu_info['features'])
-            if flags is None:
-                flags = features
+            features = cpu_info['features']
+            if feature_capabilities is None:
+                feature_capabilities = features
             else:
-                flags &= features
-        return flags or set()
+                feature_capabilities = \
+                    feature_capabilities.commonalities(features)
+        return feature_capabilities or vm_util.FeatureCapabilities({})
 
     def _merge_stats(self, host, stats, defaults):
         result = deepcopy(defaults)

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1699,7 +1699,7 @@ def aggregate_stats_from_cluster(host_stats):
         max_mem_mb_per_host = max(max_mem_mb_per_host,
                                   memory_mb - memory_mb_reserved)
         if not aggregated_cpu_info:
-            aggregated_cpu_info = stats["cpu_info"].copy()
+            aggregated_cpu_info = copy.deepcopy(stats["cpu_info"])
         else:
             cpu_info = stats["cpu_info"]
             for key, value in cpu_info.items():
@@ -1749,21 +1749,14 @@ def _host_props_to_cpu_info(host_props):
         processor_type = t.description
         cpu_vendor = t.vendor.title()
 
-    features = []
+    features = {}
     if "config.featureCapability" in host_props:
-        feature_capability = host_props["config.featureCapability"]
-        for feature in feature_capability.HostFeatureCapability:
-            if not feature.featureName.startswith("cpuid."):
-                continue
-            if feature.value != "1":
-                continue
-
-            name = feature.featureName
-            features.append(name.split(".", 1)[1].lower())
+        features = FeatureCapabilities.from_vmware(
+            host_props["config.featureCapability"].HostFeatureCapability)
     cpu_info = {
         "model": processor_type,
         "vendor": cpu_vendor,
-        "features": sorted(features)
+        "features": features,
     }
     hardware_cpu_info = host_props.get("hardware.cpuInfo")
     if hardware_cpu_info:
@@ -2473,19 +2466,126 @@ def apply_evc_mode(session, vm_ref, evc_mode):
     session._wait_for_task(task)
 
 
-def get_vm_cpu_flags(session, vm_ref) -> set:
+class FeatureCapabilities(collections.UserDict):
+
+    def __init__(self, feature_capabilities):
+        super().__init__()
+        self.data.update(feature_capabilities)
+
+    @classmethod
+    def from_vmware(cls, host_feature_capabilities) -> 'FeatureCapabilities':
+        """Create an object from an Array of HostFeatureCapability objects"""
+        return cls({x_.key.lower(): x_.value
+                    for x_ in host_feature_capabilities})
+
+    def commonalities(self, other: 'FeatureCapabilities'
+    ) -> 'FeatureCapabilities':
+        """Return a new FeatureCapabilities both hosts can support
+
+        Returns only keys existing in both FeatureCapabilities with the value
+        set to the lower one of both `FeatureCapabilities`.
+        """
+        return FeatureCapabilities({
+            key: min(other[key], value) for key, value in self.data.items()
+            if key in other})
+
+
+class FeatureRequirements(collections.UserDict):
+    """VM runtime.featureRequirement representation"""
+
+    def __init__(self, feature_requirements):
+        """Init
+
+        `feature_requirements` is a list of FeatureRequirement objects as
+        found in a VM's `runtime.featureRequirement`, but already unpacked from
+        the ArrayOfFeatureRequirements
+        """
+        super().__init__()
+        for req in feature_requirements:
+            self.data[req.key.lower()] = req.value
+            if ':' not in req.value:
+                LOG.error("Found an invalid FeatureRequirement: %s", req.value)
+
+    def check_compatibility(self, feature_capabilities: FeatureCapabilities
+    ) -> tuple[bool, str]:
+        """Check FeatureRequirements against a host's FeatureCapability
+
+        This is what we found in production:
+            Bool:Match:1
+            Bool:Min:1
+            Num:Match:1
+            Num:Min:0x10
+            Num:Min:0x2000
+            Num:Min:0x40
+            Num:Min:0x400
+            Num:Min:1
+            Num:Min:8
+        """
+        errors = {'missing': [], 'incompatible': []}
+        for key, value in self.data.items():
+            if key not in feature_capabilities:
+                errors['missing'].append(key)
+                continue
+
+            if ':' not in value:
+                continue
+
+            split = value.split(':')
+            if len(split) != 3:
+                LOG.error("Invalid FeatureRequirement format: %s", value)
+                continue
+
+            type_, fn, num_s = split
+            if type_ not in ('Bool', 'Num'):
+                LOG.error("Unexpected FeatureRequirement type: %s", type_)
+                continue
+
+            if fn == 'Min':
+                try:
+                    if num_s.startswith('0x'):
+                        num = int(num_s, 16)
+                    else:
+                        num = int(num_s)
+                except ValueError as e:
+                    LOG.error("Could not parse integer in FeatureRequirement "
+                              "from %s: %s", num_s, e)
+                    continue
+                try:
+                    cap_num = int(feature_capabilities[key])
+                except ValueError as e:
+                    LOG.error("Could not parse integer in "
+                              "HostFeatureCapability for key %s from %s: %s",
+                              key, feature_capabilities[key], e)
+                    continue
+
+                if cap_num < num:
+                    errors['incompatible'].append(
+                        f"{key}: {feature_capabilities[key]} < {num}")
+                    continue
+            elif fn == 'Match':
+                if feature_capabilities[key] != num_s:
+                    errors['incompatible'].append(
+                        f"{key}: {feature_capabilities[key]} != {num_s}")
+                    continue
+            else:
+                LOG.error("Unknown function in FeatureRequirement: %s", fn)
+
+        if errors['missing'] or errors['incompatible']:
+            return False, (
+                f"Missing features {', '.join(errors['missing'])} "
+                f"and incompatible {', '.join(errors['incompatible'])}")
+
+        return True, ''
+
+
+def get_vm_feature_requirements(session, vm_ref) -> FeatureRequirements:
     """CPU flags are stored in an array of VirtualMachineFeatureRequirement
 
     Both featureName and key contain the same value, e.g. cpuid.aes,
     vt.realmode or hv.capable.
-
-    We only return cpuid.* features as they correspod to CPU flags. We split
-    off the common "cpuid." part the same as we do with host CPU flags.
     """
     feature_requirements = session._call_method(vutil,
                                                 "get_object_property",
                                                 vm_ref,
                                                 "runtime.featureRequirement")
-    return {r.key.split(".", 1)[1].lower()
-        for r in vim_util.get_array_items(feature_requirements)
-        if r.key.startswith("cpuid.")}
+    return FeatureRequirements(vim_util.get_array_items(feature_requirements))

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -4913,16 +4913,17 @@ class VMwareVMOps(object):
 
             vm_util.vm_ref_cache_update(vm_uuid, props['obj'])
 
-    def check_can_live_migrate_source(self, instance, dest_cpu_flags: set):
+    def check_can_live_migrate_source(self, instance, dest_cpu_flags: dict):
         """Check for CPU flags, non-configdrive CD-ROMs and vm-encryption"""
         vm_ref = vm_util.get_vm_ref(self._session, instance)
 
-        required_cpu_flags = vm_util.get_vm_cpu_flags(self._session, vm_ref)
-        missing_cpu_flags = required_cpu_flags - dest_cpu_flags
-        if missing_cpu_flags:
+        feature_requirements = \
+            vm_util.get_vm_feature_requirements(self._session, vm_ref)
+        compatible, error_str = feature_requirements.check_compatibility(
+            vm_util.FeatureCapabilities(dest_cpu_flags))
+        if not compatible:
             raise exception.MigrationPreCheckError(
-                reason="Destination cluster is missing required CPU flags: "
-                       f"{', '.join(missing_cpu_flags)}")
+                reason=f"Destination cluster is not compatible: {error_str}")
 
         devices = vm_util.get_hardware_devices_by_type(self._session, vm_ref)
         for cdrom in devices["cdroms"].values():


### PR DESCRIPTION
Until now, we took the `HostFeatureCapability` and the `VirtualMachineFeatureRequirement` literally and just compared if keys existed. With that, we already made the mistake of assuming that only entries with a value of "1" would be available and exposed to VMs. This is not the case.
Instead, the value of a `HostFeatureCapability` seems to carry another meaning e.g. it could be the amount of registers or the number of bytes one can use a certain feature with. Because of that, `VirtualMachineFeatureRequirement` contains not just "1" but more complex information about the expected type, a comparison function and a value. Therefore, a proper check needs to parse the values of the `VirtualMachineFeatureRequirement` and use the comparison function and value against the `HostFeatureCapability`'s value.

With the previous approach, we ended up with VMs not being able to migrate, because `_host_props_to_cpu_info()` filtered out certain capabilities because of their value that `get_vm_cpu_flags()` did not filter out.

This also changes what we report up into the DB. We no longer port only cpu flags, but also other capabilities. Additionally, instead of being a string, it's a dictionary now.

We tested that `jsonutils` can serialize `UserDict` objects.

Change-Id: I3f78d781a441a36be233fd967f89f6a15418bdbe