### PR TITLE
custom-requirements: Add serialproxy-web

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -10,3 +10,4 @@ statsd  # MIT
 -e git+https://github.com/sapcc/oslo.vmware.git@stable/2023.2-m3#egg=oslo.vmware
 -e git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
 -e git+https://github.com/sapcc/python-ironicclient.git@stable/2023.2-m3#egg=python-ironicclient
+serialproxy-web


### PR DESCRIPTION
This is a package we build ourselves and only available on our own pypi. It adds the serialproxy-web static web-ui.

Cloud Hypervisor is not supporting VNC, so to provide interactive access to the vm without network, we utilize the nova-serialproxy service.
Also works with qemu vms as a lightweight alternative to VNC.

Change-Id: Idc0d0963e0b2bc42bedf0518c975a31ba4186fc7