### PR TITLE
libvirt: Skip over firmware metadata with missing information

### DIFF
--- a/nova/tests/unit/virt/libvirt/test_host.py
+++ b/nova/tests/unit/virt/libvirt/test_host.py
@@ -1938,6 +1938,26 @@ Active:          8381604 kB
     def test_get_loader(self, mock_get_mtype, mock_loaders):
         loaders = [
             {
+                'description': 'Stateless descriptor',
+                'interface-types': ['uefi'],
+                'mapping': {
+                    'device': 'flash',
+                    'executable': {
+                        'filename': '/usr/share/edk2/ovmf/OVMF_CODE.fd',
+                        'format': 'raw',
+                    },
+                    'mode': 'stateless',
+                },
+                'targets': [
+                    {
+                        'architecture': 'x86_64',
+                        'machines': ['pc-q35-*'],  # exclude pc-i440fx-*
+                    },
+                ],
+                'features': ['acpi-s3', 'amd-sev', 'verbose-dynamic'],
+                'tags': [],
+            },
+            {
                 'description': 'Sample descriptor',
                 'interface-types': ['uefi'],
                 'mapping': {
@@ -2000,7 +2020,7 @@ Active:          8381604 kB
             'x86_64', 'pc', has_secure_boot=False)
 
         # add the secure-boot feature flag
-        loaders[0]['features'].append('secure-boot')
+        loaders[1]['features'].append('secure-boot')
 
         # this should pass because we're reporting the secure-boot feature
         # which is what we want
@@ -2011,7 +2031,7 @@ Active:          8381604 kB
         self.assertFalse(loader[2])
 
         # check that we get SMM bool correctly (True) when required
-        loaders[0]['features'].append('requires-smm')
+        loaders[1]['features'].append('requires-smm')
         loader = self.host.get_loader('x86_64', 'q35', has_secure_boot=True)
         self.assertTrue(loader[2])
 

--- a/nova/virt/libvirt/host.py
+++ b/nova/virt/libvirt/host.py
@@ -1921,10 +1921,15 @@ class Host(object):
             if has_secure_boot != ('secure-boot' in loader['features']):
                 continue
 
-            return (
-                loader['mapping']['executable']['filename'],
-                loader['mapping']['nvram-template']['filename'],
-                'requires-smm' in loader['features'],
-            )
+            try:
+                return (
+                    loader['mapping']['executable']['filename'],
+                    loader['mapping']['nvram-template']['filename'],
+                    'requires-smm' in loader['features'],
+                )
+            except KeyError:
+                # Let's just skip what doesn't match our expectations:
+                # I.e. the stateless firmware doesn't have a nvram-template
+                continue
 
         raise exception.UEFINotSupported()


### PR DESCRIPTION
Stateless UEFI firmware doesn't have nvram-template, so it will raise a KeyError. As that might not be the only backwards incompatible change one will run into, let's just skip over entries that don't match the expectations.

Change-Id: If1b14b21c7f28b8afb54dd5ac18e8b14828180ff