### PR TITLE
libvirt: Provide default disk-bus for cloudhypervisor

### DIFF
--- a/nova/tests/unit/virt/libvirt/test_blockinfo.py
+++ b/nova/tests/unit/virt/libvirt/test_blockinfo.py
@@ -1060,8 +1060,10 @@ class LibvirtBlockInfoTest(test.NoDBTestCase):
                 ('parallels', 'scsi', None, 'disk', 'scsi'),
                 ('parallels', None, None, 'disk', 'scsi'),
                 ('parallels', None, 'ide', 'cdrom', 'ide'),
-                ('parallels', None, None, 'cdrom', 'ide')
-                )
+                ('parallels', None, None, 'cdrom', 'ide'),
+                ('ch', None, None, 'disk', 'virtio'),
+                ('ch', None, None, 'cdrom', None),
+        )
         for hv, dbus, cbus, dev, res in expected:
             props = {}
             if dbus is not None:

--- a/nova/virt/libvirt/blockinfo.py
+++ b/nova/virt/libvirt/blockinfo.py
@@ -276,6 +276,11 @@ def get_disk_bus_for_device_type(instance,
             return "ide"
         elif device_type == "disk":
             return "scsi"
+    elif virt_type == "ch":
+        if device_type == "cdrom":
+            return None  # Result should never be used
+        elif device_type == "disk":
+            return "virtio"
     else:
         # If virt-type not in list then it is unsupported
         raise exception.UnsupportedVirtType(virt=virt_type)


### PR DESCRIPTION
It is fairly straight-forward with CloudHypervisor, it only supports virtio (or vhost). So, we return that. We leave the cdrom bus blank, as there is no bus we support that would be needed for cdroms. We cannot raise an error, as `blockinfo.get_disk_info()` is called by `spawn()`, and it queries also the cdrom-bus, even if it isn't needed.

Change-Id: I5911d9e82da86e8d6f1e2cf92b07e13934878700