### PR TITLE
Revisit try to handle resource busy on unmount

### DIFF
--- a/nova/conf/libvirt.py
+++ b/nova/conf/libvirt.py
@@ -1118,26 +1118,6 @@ provide high availability and fault tolerance.
                help="""
 Number of times to scan given storage protocol to find volume.
 """),
-    cfg.IntOpt('num_umount_retries',
-               default=0,
-               min=0,
-               help="""
-Number of times to retry to umount on errors, such as device busy.
-
-Related options:
-
-* umount_retry_delay
-"""),
-    cfg.FloatOpt('umount_retry_delay',
-               default=1.0,
-               help="""
-Duration in seconds to wait between retries to umount on errors, such as device
-busy.
-
-Related options:
-
-* num_umount_retries
-"""),
 ]
 
 libvirt_volume_aoe_opts = [

--- a/nova/tests/unit/virt/libvirt/volume/test_mount.py
+++ b/nova/tests/unit/virt/libvirt/volume/test_mount.py
@@ -346,7 +346,7 @@ class HostMountStateTestCase(test.NoDBTestCase):
 
         # return also None to test that it won't call a second time and recover
         self.mock_rmdir.side_effect = [
-            OSError(16, "Device or resource busy"), None]
+            OSError(111, "Unexpected error"), None]
         # Unmount vol_a, it will fail with the exception
         self.assertRaises(OSError, self._sentinel_umount, m,
                           mock.sentinel.vol_a)
@@ -361,19 +361,9 @@ class HostMountStateTestCase(test.NoDBTestCase):
         self.mock_rmdir.assert_has_calls([
             mock.call(mock.sentinel.mountpoint)])
 
-    def test_mount_umount_oserror_recovered(self):
+    def test_mount_umount_oserror_logged(self):
         # Mount a volume. Test that we can handle the OSerror when asked
         m = self._get_clean_hostmountstate()
-
-        CONF.set_override(
-            "num_umount_retries", 1,
-            group='libvirt',
-        )
-
-        CONF.set_override(
-            "umount_retry_delay", 0.0,
-            group='libvirt',
-        )
 
         # Mount vol_a from export
         self._sentinel_mount(m, mock.sentinel.vol_a)

--- a/nova/virt/libvirt/volume/mount.py
+++ b/nova/virt/libvirt/volume/mount.py
@@ -16,7 +16,6 @@ import collections
 import contextlib
 import os.path
 import threading
-import time
 
 from oslo_concurrency import processutils
 from oslo_log import log
@@ -387,18 +386,17 @@ class _HostMountState(object):
             LOG.error("Couldn't unmount %(mountpoint)s: %(reason)s",
                       {'mountpoint': mountpoint, 'reason': str(ex)})
 
-        umount_retries = CONF.libvirt.num_umount_retries
-        for tries in reversed(range(umount_retries + 1)):
+        if not os.path.ismount(mountpoint):
             try:
-                if not os.path.ismount(mountpoint):
-                    nova.privsep.path.rmdir(mountpoint)
-                    return False
-                break
+                nova.privsep.path.rmdir(mountpoint)
+                return False
             except OSError as ose:
                 with excutils.save_and_reraise_exception() as ctx:
-                    if (ose.errno == 16 and tries > 0):
+                    if ose.errno == 16:
                         ctx.reraise = False
-                        time.sleep(CONF.libvirt.umount_retry_delay)
+                        LOG.error("Couldn't delete %(mountpoint)s: %(reason)s",
+                                  {'mountpoint': mountpoint, 'reason': ose})
+                        return False
 
         return True
 


### PR DESCRIPTION
Apparently it isn't a race condition, we simply cannot delete the directory from within a container. Instead of failing, we simply log the error and continue. The code is written already in such a way, that it handles the existing folder gracefully, so we "only" leak folders, which in the worst case is a folder per NFS share.

As that number is bounded, we rather take that over not being able to migrate the VM.

This reverts commit 831fbae145e58c521dc7b8f5671d4888aa8c7ffc. (Ib60d93d9cc1b79d6a4e7da6f1d29c9b28b4f4c3c)

Change-Id: Ib60d93d9cc1b79d6a4e7da6f1d29c9b28b4f4c3c