### PR TITLE
SAP: Allow update of tags in error state

### DIFF
--- a/nova/api/openstack/compute/server_tags.py
+++ b/nova/api/openstack/compute/server_tags.py
@@ -51,7 +51,8 @@ class ServerTagsController(wsgi.Controller):
     def _check_instance_in_valid_state(self, context, server_id, action):
         instance = common.get_instance(self.compute_api, context, server_id)
         if instance.vm_state not in (vm_states.ACTIVE, vm_states.PAUSED,
-                                     vm_states.SUSPENDED, vm_states.STOPPED):
+                                     vm_states.SUSPENDED, vm_states.STOPPED,
+                                     vm_states.ERROR):
             exc = exception.InstanceInvalidState(attr='vm_state',
                                                  instance_uuid=instance.uuid,
                                                  state=instance.vm_state,


### PR DESCRIPTION
One might want to avoid updating tags in a transient state to avoid concurrency issues, but there is limited risk in updating the database on a VM in an error state.

Change-Id: Ie9cc32fc37711a125c6556e02e5575b2b6088dc4