### PR TITLE
vmware: Support 64 devices on PVSCSI adapters

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/fake.py
+++ b/nova/tests/unit/virt/vmwareapi/fake.py
@@ -399,6 +399,17 @@ class VirtualLsiLogicSASController(DataObject):
     pass
 
 
+class ParaVirtualSCSIController(DataObject):
+    """ParaVirtualSCSIController class."""
+
+    def __init__(self, key=0, scsiCtlrUnitNumber=0, busNumber=0):
+        super(ParaVirtualSCSIController, self).__init__()
+        self.key = key
+        self.busNumber = busNumber
+        self.scsiCtlrUnitNumber = scsiCtlrUnitNumber
+        self.device = []
+
+
 class VirtualPCNet32(DataObject):
     """VirtualPCNet32 class."""
 

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -711,6 +711,32 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                           vm_util.get_scsi_adapter_type,
                           devices)
 
+    def test_get_scsi_adapter_type_pvscsi(self):
+        # Test that PVSCSI adapter type is returned when available
+        vm = fake.VirtualMachine()
+        devices = vm.get("config.hardware.device").VirtualDevice
+        pvscsi_controller = fake.ParaVirtualSCSIController()
+        devices.append(pvscsi_controller)
+        fake.update_object(vm)
+        # Should return the PVSCSI adapter type
+        self.assertEqual(constants.ADAPTER_TYPE_PARAVIRTUAL,
+                         vm_util.get_scsi_adapter_type(devices))
+
+    def test_get_scsi_adapter_type_pvscsi_full(self):
+        # Test that PVSCSI adapter at capacity (63 devices) is not returned
+        vm = fake.VirtualMachine()
+        devices = vm.get("config.hardware.device").VirtualDevice
+        pvscsi_controller = fake.ParaVirtualSCSIController()
+        devices.append(pvscsi_controller)
+        fake.update_object(vm)
+        # Fill up the PVSCSI controller to capacity (63 devices)
+        for i in range(0, constants.PVSCSI_MAX_CONNECT_NUMBER):
+            pvscsi_controller.device.append('device' + str(i))
+        # Should raise error since controller is full
+        self.assertRaises(exception.StorageError,
+                          vm_util.get_scsi_adapter_type,
+                          devices)
+
     def test_find_allocated_slots(self):
         disk1 = fake.VirtualDisk(200, 0)
         disk2 = fake.VirtualDisk(200, 1)
@@ -814,6 +840,43 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
                                                 constants.DEFAULT_ADAPTER_TYPE)
         self.assertEqual(-101, controller_key)
         self.assertEqual(0, unit_number)
+        self.assertEqual(1, controller_spec.device.busNumber)
+
+    def test_allocate_controller_key_and_unit_number_pvscsi(self):
+        # Test that we can allocate up to 64 unit numbers on PVSCSI controller
+        devices = [fake.ParaVirtualSCSIController(1000, scsiCtlrUnitNumber=7)]
+        # Add 20 disks to show it works beyond regular SCSI's 16 limit
+        for unit_number in range(20):
+            disk = fake.VirtualDisk(1000, unit_number)
+            devices.append(disk)
+        factory = fake.FakeFactory()
+        (controller_key, unit_number,
+         controller_spec) = vm_util.allocate_controller_key_and_unit_number(
+            factory, devices, constants.ADAPTER_TYPE_PARAVIRTUAL)
+        # Should allocate unit 20 on the existing controller
+        self.assertEqual(1000, controller_key)
+        self.assertEqual(20, unit_number)
+        self.assertIsNone(controller_spec)
+
+    def test_allocate_controller_key_and_unit_number_pvscsi_full(self):
+        # Test that we create a new controller when PVSCSI is
+        # at capacity (63 devices)
+        devices = [fake.ParaVirtualSCSIController(1000, scsiCtlrUnitNumber=7)]
+        # Fill the controller with 63 disks (PVSCSI max, excluding
+        # unit 7 for controller)
+        for unit_number in range(64):
+            # Skip unit 7 (controller's own slot)
+            if unit_number != 7:
+                disk = fake.VirtualDisk(1000, unit_number)
+                devices.append(disk)
+        factory = fake.FakeFactory()
+        (controller_key, unit_number,
+         controller_spec) = vm_util.allocate_controller_key_and_unit_number(
+            factory, devices, constants.ADAPTER_TYPE_PARAVIRTUAL)
+        # Should create a new controller since existing one is full
+        self.assertEqual(-101, controller_key)
+        self.assertEqual(0, unit_number)
+        self.assertIsNotNone(controller_spec)
         self.assertEqual(1, controller_spec.device.busNumber)
 
     def test_get_vnc_config_spec(self):

--- a/nova/virt/vmwareapi/constants.py
+++ b/nova/virt/vmwareapi/constants.py
@@ -82,6 +82,10 @@ VCLS_EXTENSION_TYPE_AGENT = 'cluster-agent'
 # One adapter has 16 slots but one reserved for controller
 SCSI_MAX_CONNECT_NUMBER = 15
 
+# PVSCSI (ParaVirtual SCSI) adapters support 64 devices
+# One slot reserved for controller, leaving 63 usable
+PVSCSI_MAX_CONNECT_NUMBER = 63
+
 # The max number of SCSI adaptors that could be created on one instance.
 SCSI_MAX_CONTROLLER_NUMBER = 4
 

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -1092,9 +1092,14 @@ def get_scsi_adapter_type(hardware_devices):
     for device in hardware_devices:
         if device.__class__.__name__ in scsi_controller_classes:
             # find the controllers which still have available slots
-            if len(device.device) < constants.SCSI_MAX_CONNECT_NUMBER:
+            # PVSCSI supports 63 devices, regular SCSI supports 15
+            adapter_type = scsi_controller_classes[device.__class__.__name__]
+            max_devices = (constants.PVSCSI_MAX_CONNECT_NUMBER
+                          if adapter_type == constants.ADAPTER_TYPE_PARAVIRTUAL
+                          else constants.SCSI_MAX_CONNECT_NUMBER)
+            if len(device.device) < max_devices:
                 # return the first match one
-                return scsi_controller_classes[device.__class__.__name__]
+                return adapter_type
     raise exception.StorageError(
         reason=_("Unable to find iSCSI Target"))
 
@@ -1160,7 +1165,10 @@ def allocate_controller_key_and_unit_number(client_factory, devices,
         ret = _find_controller_slot(ide_keys, taken, 2)
     elif adapter_type in constants.SCSI_ADAPTER_TYPES:
         scsi_keys = [dev.key for dev in devices if _is_scsi_controller(dev)]
-        ret = _find_controller_slot(scsi_keys, taken, 16)
+        max_unit_number = (
+            64 if adapter_type == constants.ADAPTER_TYPE_PARAVIRTUAL
+            else 16)
+        ret = _find_controller_slot(scsi_keys, taken, max_unit_number)
     if ret:
         return ret[0], ret[1], None
 


### PR DESCRIPTION
Currently Nova treats PVSCSI (ParaVirtual SCSI) adapters the same as regular SCSI adapters, limiting them to 16 device slots (with 15 usable after reserving one for the controller). However, vSphere's PVSCSI adapters actually support 64 device slots with 63 usable.

With this patch, we properly differentiate PVSCSI from regular SCSI adapters in get_scsi_adapter_type() and
allocate_controller_key_and_unit_number() by checking the adapter type against ADAPTER_TYPE_PARAVIRTUAL and using the appropriate limits.

Change-Id: Ia9a3253845291b28b5354d94833e3231765928e3