### PR TITLE
libvirt: Option to always immediately allocate memory

### DIFF
--- a/nova/conf/libvirt.py
+++ b/nova/conf/libvirt.py
@@ -859,6 +859,24 @@ Related options:
 * ``virt_type`` must be set to ``kvm`` or ``qemu``.
 * ``ram_allocation_ratio`` must be set to 1.0.
 """),
+    cfg.BoolOpt('always_allocate_memory_immediately',
+               default=False,
+               help="""
+Whether to always allocate all memory on VM startup or on demand.
+
+Set to false to leave it to the default logic, which is only preallocating
+memory for file-backed memory. Setting it to true will always request to
+allocate the whole memory on startup, which increases the startup time of the
+VM in exchange for more predictable initial memory access times.
+
+.. note::
+   This feature is not compatible with memory overcommit.
+
+Related options:
+
+* ``virt_type`` must be set to ``kvm`` or ``qemu``.
+* ``ram_allocation_ratio`` must be set to 1.0.
+"""),
     cfg.IntOpt('num_memory_encrypted_guests',
                default=None,
                min=0,

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -3542,6 +3542,14 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertTrue(result.filesource)
         self.assertTrue(result.allocateimmediate)
 
+    def test_get_guest_memory_backing_config_always_immediate(self):
+        self.flags(always_allocate_memory_immediately=True, group="libvirt")
+
+        result = self._test_get_guest_memory_backing_config(
+            None, None, None
+        )
+        self.assertTrue(result.allocateimmediate)
+
     def test_get_guest_memory_backing_config_file_backed_hugepages(self):
         self.flags(file_backed_memory=1024, group="libvirt")
         host_topology = objects.NUMATopology(cells=[

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -6528,6 +6528,11 @@ class LibvirtDriver(driver.ComputeDriver):
                 membacking = vconfig.LibvirtConfigGuestMemoryBacking()
             membacking.locked = True
 
+        if CONF.libvirt.always_allocate_memory_immediately:
+            if not membacking:
+                membacking = vconfig.LibvirtConfigGuestMemoryBacking()
+            membacking.allocateimmediate = True
+
         return membacking
 
     def _get_memory_backing_hugepages_support(self, inst_topology, numatune):


### PR DESCRIPTION
libvirt offers an option to preallocate the memory of a VM, which by default is only activated for file-backed memory as the latency there is significantly higher.
Still, with bigger memory sizes for VMs, even normal memory allocations may take more time, in particular using huge-pages. Exposing the option [libvirt]always_allocate_memory_immediately allows the operator to chose the trade-off of longer instance startup times against more predictable memory allocation times themselves.

Change-Id: I6fc6e7df9bcbd5e7b3e3e151d044dc25e88af4a5