### PR TITLE
SAP: Pass set _nova_check_type hint for evacuation

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -5763,6 +5763,12 @@ class API:
         request_spec = objects.RequestSpec.get_by_instance_uuid(
             context, instance.uuid)
 
+        # The task_state is a rebuild, but the scheduler might want to handle
+        # this differently than a normal rebuild.
+        if 'scheduler_hints' not in request_spec:
+            request_spec.scheduler_hints = {}
+        request_spec.scheduler_hints['_nova_check_type'] = ['evacuate']
+
         instance.task_state = task_states.REBUILDING
         instance.save(expected_task_state=None)
         self._record_action_start(context, instance, instance_actions.EVACUATE)


### PR DESCRIPTION
Similar to Id80bfd2f3e4771856cc0d85bc1b85a7d14f3b136, but in this case we need to pass it on to Cortex, which has reservation for the evacuation and needs to know when to use it. Technically, it could be inferred from circumstantial evidence, but better let's be explicit about it.

Change-Id: Ie1f805cc9d097cc6233ef1534a63b6efbf3ac104