### PR TITLE
libvirt: Check instance numa cell ids against host

### DIFF
--- a/nova/exception.py
+++ b/nova/exception.py
@@ -2542,3 +2542,8 @@ class HostConflict(Exception):
 
 class VolumeMigrationError(NovaException):
     msg_fmt = 'Migration of volume %(volume_id)s failed: %(reason)s'
+
+
+class InvalidGuestCpuNumaConfig(NovaException):
+    msg_fmt = _('The guest is configured with a cell with id %(cell_id)s '
+                'which the host does not provide.')

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -4767,6 +4767,44 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         conf = drvr._get_cpu_numa_config_from_instance(None, False)
         self.assertIsNone(conf)
 
+    def test_get_cell_pairs(self):
+        host_topology = objects.InstanceNUMATopology(cells=[
+            objects.InstanceNUMACell(
+                id=0, cpuset=set([1, 2]), pcpuset=set(), memory=128),
+            objects.InstanceNUMACell(
+                id=1, cpuset=set([3, 4]), pcpuset=set(), memory=128),
+            objects.InstanceNUMACell(
+                id=2, cpuset=set([5, 6]), pcpuset=set(), memory=128),
+        ])
+        instance_topology = objects.InstanceNUMATopology(
+            cells=[
+                objects.InstanceNUMACell(
+                    id=0, cpuset=set([1, 2]), pcpuset=set(), memory=128),
+                objects.InstanceNUMACell(
+                    id=2, cpuset=set([1, 2]), pcpuset=set(), memory=128),
+            ])
+        drvr = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), True)
+        self.assertEqual(
+            [(instance_topology.cells[0], host_topology.cells[0]),
+             (instance_topology.cells[1], host_topology.cells[2])],
+            drvr._get_cell_pairs(instance_topology, host_topology))
+
+    def test_get_cell_pairs_non_matching_ids(self):
+        host_topology = objects.InstanceNUMATopology(cells=[
+            objects.InstanceNUMACell(
+                id=0, cpuset=set([1, 2]), pcpuset=set(), memory=128),
+            objects.InstanceNUMACell(
+                id=1, cpuset=set([3, 4]), pcpuset=set(), memory=128),
+        ])
+        instance_topology = objects.InstanceNUMATopology(
+            cells=[
+                objects.InstanceNUMACell(
+                    id=2, cpuset=set([1, 2]), pcpuset=set(), memory=128),
+            ])
+        drvr = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), True)
+        self.assertRaises(exception.InvalidGuestCpuNumaConfig,
+            drvr._get_cell_pairs, instance_topology, host_topology)
+
     @mock.patch.object(libvirt_driver.LibvirtDriver, "_has_numa_support",
                        return_value=True)
     def test_get_memnode_numa_config_from_instance(self, mock_numa):

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -5939,8 +5939,17 @@ class LibvirtDriver(driver.ComputeDriver):
         cell_pairs = []
         for guest_config_cell in guest_cpu_numa_config.cells:
             for host_cell in host_topology.cells:
-                if guest_config_cell.id == host_cell.id:
-                    cell_pairs.append((guest_config_cell, host_cell))
+                if guest_config_cell.id != host_cell.id:
+                    continue
+
+                cell_pairs.append((guest_config_cell, host_cell))
+                break
+            else:
+                # NOTE(jkulik): We can end up here if a migration to a node
+                # with more NUMA cells broke and thus the instance's
+                # numa_topology points to an invalid cell.
+                raise exception.InvalidGuestCpuNumaConfig(
+                    cell_id=guest_config_cell.id)
         return cell_pairs
 
     def _get_pin_cpuset(self, vcpu, inst_cell, host_cell):


### PR DESCRIPTION
When a VM fails to migrate to another host, it can stay in a state where the `numa_topology` of the target host stays in the `instance_extra` table. If the target host has e.g. more NUMA cells than the source, this data can reference an invalid NUMA cell. When trying to start up the VM on the old host after resetting the state, the instance might have no or too little CPUs configured in libvirt. This can lead to libvirt proclaiming e.g.
    invalid argument: Failed to parse bitmap ''

When building the cell pairs, we now check that we find a host cell for every cell configured in the client instead of ignoring not-found cells.

Change-Id: Ia864389b3cc0ffacd78e365e214f953661d47d59