### PR TITLE
Live-migration port binding cleanup

### DIFF
--- a/nova/conductor/tasks/live_migrate.py
+++ b/nova/conductor/tasks/live_migrate.py
@@ -170,6 +170,20 @@ class LiveMigrationTask(base.TaskBase):
                                                     self._source_cn,
                                                     self.instance,
                                                     self.migration)
+        if self.destination != self.source:
+            try:
+                # Delete any destination host port bindings.
+                self.network_api.cleanup_instance_network_on_host(
+                    self.context, self.instance, self.destination)
+            except exception.NovaException as e:
+                # Removing the inactive port bindings from the destination
+                # host is not critical so just log an error but don't fail.
+                LOG.error(
+                    'Network cleanup failed for destination host '
+                    f'{self.destination} during live migration rollback. You '
+                    'may need to manually clean up resources in the network '
+                    f'service. Error: {str(e)}',
+                    instance=self.instance)
 
     def _check_instance_is_active(self):
         # NOSTATE, as the VM might be already migrated,
@@ -370,6 +384,8 @@ class LiveMigrationTask(base.TaskBase):
 
         # Check to see that neutron supports the binding-extended API.
         if self.network_api.has_port_binding_extension(self.context):
+            self.network_api.cleanup_instance_network_on_host(
+                    self.context, self.instance, destination)
             bindings = self._bind_ports_on_destination(
                 destination, provider_mapping)
             self._update_migrate_vifs_from_bindings(self.migrate_data.vifs,

--- a/nova/network/neutron.py
+++ b/nova/network/neutron.py
@@ -3713,6 +3713,7 @@ class API:
         # setup_networks_on_host.
         search_opts = {'device_id': instance.uuid,
                        'tenant_id': instance.project_id,
+                       constants.BINDING_HOST_ID: host,
                        'fields': ['id']}  # we only need the port id
         data = self.list_ports(context, **search_opts)
         self._delete_port_bindings(context, data['ports'], host)

--- a/nova/tests/unit/conductor/tasks/test_live_migrate.py
+++ b/nova/tests/unit/conductor/tasks/test_live_migrate.py
@@ -12,6 +12,7 @@
 
 from unittest import mock
 
+import ddt
 import oslo_messaging as messaging
 from oslo_serialization import jsonutils
 from oslo_utils.fixture import uuidsentinel as uuids
@@ -41,6 +42,7 @@ fake_selection2 = objects.Selection(service_host="host2", nodename="node2",
         compute_node_uuid=uuids.compute_node2)
 
 
+@ddt.ddt
 class LiveMigrationTaskTestCase(test.NoDBTestCase):
     def setUp(self):
         super(LiveMigrationTaskTestCase, self).setUp()
@@ -918,3 +920,30 @@ class LiveMigrationTaskTestCase(test.NoDBTestCase):
         _test(resources, True)
         self.assertRaises(exception.MigrationPreCheckError,
                           _test, resources, False)
+
+    @ddt.data('source', 'destination')
+    def test_rollback_cleanup_network(self, destination):
+        """Test that rollback cleans up network on destination host."""
+        self.task.source = 'source'
+        self.task.destination = destination
+        with mock.patch.object(
+            self.task.network_api, 'cleanup_instance_network_on_host'
+        ) as mock_cleanup:
+            self.task.rollback(None)
+            if self.task.destination == self.task.source:
+                mock_cleanup.assert_not_called()
+            else:
+                mock_cleanup.assert_called_once_with(
+                    self.context, self.instance, self.task.destination)
+
+    def test_rollback_cleanup_network_raises(self):
+        """Test that rollback cleans up network on destination host."""
+        self.task.source = 'source'
+        self.task.destination = 'destination'
+        with mock.patch.object(
+            self.task.network_api, 'cleanup_instance_network_on_host',
+            side_effect=exception.NovaException('test')
+        ) as mock_cleanup:
+            self.task.rollback(None)
+            mock_cleanup.assert_called_once_with(
+                self.context, self.instance, self.task.destination)


### PR DESCRIPTION
Live migrations may fail if there are orphaned port bindings on the
destination host. We fix this by adding port binding cleanup to the
live migration task rollback and before attempting to bind ports on
the destination host.