### PR TITLE
Allow images to advertise compatibility with multiple hardware types

### DIFF
--- a/nova/notifications/objects/image.py
+++ b/nova/notifications/objects/image.py
@@ -131,7 +131,10 @@ class ImageMetaPropsPayload(base.NotificationPayloadBase):
     # Version 1.11: Added 'hw_locked_memory' field
     # Version 1.12: Added 'hw_viommu_model' field
     # Version 1.13: Added 'hw_virtio_packed_ring' field
-    VERSION = '1.13'
+    # Version 1.13.1: SAP - Added set-based hardware support fields:
+    #                 'hw_supported_disk_buses', 'hw_supported_scsi_models',
+    #                 'hw_supported_vif_models' (follows ImageMetaProps 1.36.1)
+    VERSION = '1.13.1'
 
     SCHEMA = {
         k: ('image_meta_props', k) for k in image_meta.ImageMetaProps.fields}

--- a/nova/objects/fields.py
+++ b/nova/objects/fields.py
@@ -1261,6 +1261,10 @@ class DiskBusField(BaseEnumField):
     AUTO_TYPE = DiskBus()
 
 
+class SetOfDiskBusesField(AutoTypedField):
+    AUTO_TYPE = Set(DiskBus())
+
+
 class DiskConfigField(BaseEnumField):
     AUTO_TYPE = DiskConfig()
 
@@ -1313,6 +1317,10 @@ class SCSIModelField(BaseEnumField):
     AUTO_TYPE = SCSIModel()
 
 
+class SetOfSCSIModelsField(AutoTypedField):
+    AUTO_TYPE = Set(SCSIModel())
+
+
 class SecureBootField(BaseEnumField):
     AUTO_TYPE = SecureBoot()
 
@@ -1323,6 +1331,10 @@ class VideoModelField(BaseEnumField):
 
 class VIFModelField(BaseEnumField):
     AUTO_TYPE = VIFModel()
+
+
+class SetOfVIFModelsField(AutoTypedField):
+    AUTO_TYPE = Set(VIFModel())
 
 
 class VIOMMUModelField(BaseEnumField):

--- a/nova/objects/image_meta.py
+++ b/nova/objects/image_meta.py
@@ -195,14 +195,23 @@ class ImageMetaProps(base.NovaObject):
     # Version 1.35: Added 'hw_virtio_packed_ring' field
     # Version 1.36: Added 'hw_maxphysaddr_mode' and
     #                     'hw_maxphysaddr_bits' field
+    # Version 1.36.1: SAP - Added set-based hardware support fields:
+    #                 'hw_supported_disk_buses', 'hw_supported_scsi_models',
+    #                 'hw_supported_vif_models'
     # NOTE(efried): When bumping this version, the version of
     # ImageMetaPropsPayload must also be bumped. See its docstring for details.
-    VERSION = '1.36'
+    VERSION = '1.36.1'
 
-    def obj_make_compatible(self, primitive, target_version):
+    def obj_make_compatible(self, primitive, target_version):  # noqa: C901
         super(ImageMetaProps, self).obj_make_compatible(primitive,
                                                         target_version)
         target_version = versionutils.convert_version_to_tuple(target_version)
+        # SAP: Check non-standard extension fields before removing
+        if target_version < (1, 36, 1):
+            for field_name in ['hw_supported_disk_buses',
+                               'hw_supported_scsi_models',
+                               'hw_supported_vif_models']:
+                primitive.pop(field_name, None)
         if target_version < (1, 36):
             primitive.pop('hw_maxphysaddr_mode', None)
             primitive.pop('hw_maxphysaddr_bits', None)
@@ -366,6 +375,9 @@ class ImageMetaProps(base.NovaObject):
         # name of the hard disk bus to use eg virtio, scsi, ide
         'hw_disk_bus': fields.DiskBusField(),
 
+        # SAP: set of supported disk bus types
+        'hw_supported_disk_buses': fields.SetOfDiskBusesField(),
+
         # allocation mode eg 'preallocated'
         'hw_disk_type': fields.StringField(),
 
@@ -448,6 +460,9 @@ class ImageMetaProps(base.NovaObject):
         # name of the SCSI bus controller eg 'virtio-scsi', 'lsilogic', etc
         'hw_scsi_model': fields.SCSIModelField(),
 
+        # SAP: set of supported SCSI models
+        'hw_supported_scsi_models': fields.SetOfSCSIModelsField(),
+
         # name of the video adapter model to use, eg cirrus, vga, xen, qxl
         'hw_video_model': fields.VideoModelField(),
 
@@ -456,6 +471,9 @@ class ImageMetaProps(base.NovaObject):
 
         # name of a NIC device model eg virtio, e1000, rtl8139
         'hw_vif_model': fields.VIFModelField(),
+
+        # SAP: set of supported NIC device models
+        'hw_supported_vif_models': fields.SetOfVIFModelsField(),
 
         # name of IOMMU device model eg virtio, intel, smmuv3, or auto
         'hw_viommu_model': fields.VIOMMUModelField(),
@@ -685,6 +703,15 @@ class ImageMetaProps(base.NovaObject):
         if hw_numa_cpus_set:
             self.hw_numa_cpus = hw_numa_cpus
 
+    # SAP: Set-typed image properties that accept a comma-separated string
+    # when the value comes from Glance (which stores all properties as
+    # strings).
+    _SET_FIELD_NAMES = frozenset([
+        'hw_supported_disk_buses',
+        'hw_supported_scsi_models',
+        'hw_supported_vif_models',
+    ])
+
     def _set_attr_from_current_names(self, image_props):
         for key in self.fields:
             # The two NUMA fields need special handling to
@@ -693,6 +720,16 @@ class ImageMetaProps(base.NovaObject):
                 self._set_numa_mem(image_props)
             elif key == "hw_numa_cpus":
                 self._set_numa_cpus(image_props)
+            elif key in self._SET_FIELD_NAMES:
+                # SAP: Set-typed fields accept a comma-separated string from
+                # Glance (e.g. "virtio,e1000") or an already-parsed Python set.
+                if key not in image_props:
+                    continue
+                value = image_props[key]
+                if isinstance(value, str):
+                    value = {v.strip() for v in value.split(',')
+                             if v.strip()}
+                setattr(self, key, value)
             else:
                 # traits_required will be populated by
                 # _set_attr_from_trait_names

--- a/nova/tests/unit/notifications/objects/test_notification.py
+++ b/nova/tests/unit/notifications/objects/test_notification.py
@@ -386,7 +386,7 @@ notification_object_data = {
     # ImageMetaProps, so when you see a fail here for that reason, you must
     # *also* bump the version of ImageMetaPropsPayload. See its docstring for
     # more information.
-    'ImageMetaPropsPayload': '1.13-2859fbb81af5ad2f83a0e9be0b30ea60',
+    'ImageMetaPropsPayload': '1.13.1-a10e44ec02ae90febd4de0c7d9af0750',
     'InstanceActionNotification': '1.0-a73147b93b520ff0061865849d3dfa56',
     'InstanceActionPayload': '1.8-67a66ac73a5ebd2c2987b5696f89cac8',
     'InstanceActionRebuildNotification':

--- a/nova/tests/unit/objects/test_fields.py
+++ b/nova/tests/unit/objects/test_fields.py
@@ -17,6 +17,7 @@ import datetime
 import os
 from unittest import mock
 
+import ddt
 import iso8601
 from oslo_serialization import jsonutils
 from oslo_versionedobjects import exception as ovo_exc
@@ -531,6 +532,79 @@ class TestSetOfIntegers(TestField):
 
     def test_stringify(self):
         self.assertEqual('set([1,2])', self.field.stringify(set([1, 2])))
+
+
+@ddt.ddt
+class TestSetOfHwSupportedFields(test.NoDBTestCase):
+    """Tests for Set-based fields used by hardware support image properties."""
+
+    @ddt.data(
+        (fields.SetOfVIFModelsField, {'virtio', 'e1000'}, {'virtio'}),
+        (fields.SetOfSCSIModelsField, {'virtio-scsi', 'lsilogic'},
+         {'virtio-scsi'}),
+        (fields.SetOfDiskBusesField, {'virtio', 'scsi'}, {'virtio'}),
+    )
+    @ddt.unpack
+    def test_coerce_good_values(self, field_cls, multi_value_set,
+                                single_value_set):
+        field = field_cls()
+        self.assertEqual(multi_value_set,
+                         field.coerce('obj', 'attr', multi_value_set))
+        self.assertEqual(single_value_set,
+                         field.coerce('obj', 'attr', single_value_set))
+
+    @ddt.data(
+        (fields.SetOfVIFModelsField, 'virtio', 'invalid_model'),
+        (fields.SetOfSCSIModelsField, 'virtio-scsi', 'invalid_model'),
+        (fields.SetOfDiskBusesField, 'virtio', 'invalid_bus'),
+    )
+    @ddt.unpack
+    def test_coerce_bad_values(self, field_cls, valid_value, invalid_value):
+        field = field_cls()
+        # invalid enum value in set
+        self.assertRaises((TypeError, ValueError),
+                          field.coerce, 'obj', 'attr', {invalid_value})
+        # list instead of set
+        self.assertRaises((TypeError, ValueError),
+                          field.coerce, 'obj', 'attr', [valid_value])
+        # bare string instead of set
+        self.assertRaises((TypeError, ValueError),
+                          field.coerce, 'obj', 'attr', valid_value)
+
+    @ddt.data(
+        (fields.SetOfVIFModelsField, 'virtio'),
+        (fields.SetOfSCSIModelsField, 'virtio-scsi'),
+        (fields.SetOfDiskBusesField, 'virtio'),
+    )
+    @ddt.unpack
+    def test_to_primitive(self, field_cls, value):
+        field = field_cls()
+        self.assertEqual(tuple([value]),
+                         field.to_primitive('obj', 'attr', {value}))
+
+    @ddt.data(
+        (fields.SetOfVIFModelsField, 'virtio'),
+        (fields.SetOfSCSIModelsField, 'virtio-scsi'),
+        (fields.SetOfDiskBusesField, 'virtio'),
+    )
+    @ddt.unpack
+    def test_from_primitive(self, field_cls, value):
+        class ObjectLikeThing(object):
+            _context = 'context'
+        field = field_cls()
+        self.assertEqual({value},
+                         field.from_primitive(ObjectLikeThing, 'attr',
+                                              (value,)))
+
+    @ddt.data(
+        (fields.SetOfVIFModelsField, 'virtio'),
+        (fields.SetOfSCSIModelsField, 'virtio-scsi'),
+        (fields.SetOfDiskBusesField, 'virtio'),
+    )
+    @ddt.unpack
+    def test_stringify(self, field_cls, value):
+        field = field_cls()
+        self.assertEqual("set(['%s'])" % value, field.stringify({value}))
 
 
 class TestListOfSetsOfIntegers(TestField):

--- a/nova/tests/unit/objects/test_image_meta.py
+++ b/nova/tests/unit/objects/test_image_meta.py
@@ -14,6 +14,8 @@
 
 import datetime
 
+import ddt
+
 from nova import exception
 from nova import objects
 from nova.objects import fields
@@ -102,6 +104,7 @@ class TestImageMeta(test.NoDBTestCase):
         self.assertEqual('', image_meta.disk_format)
 
 
+@ddt.ddt
 class TestImageMetaProps(test.NoDBTestCase):
     def test_normal_props(self):
         props = {'os_type': 'windows',
@@ -570,3 +573,73 @@ class TestImageMetaProps(test.NoDBTestCase):
         # and is absent on older versions
         primitive = obj.obj_to_primitive('1.33')
         self.assertNotIn('hw_viommu_model', primitive['nova_object.data'])
+
+    def test_obj_make_compatible_hw_supported_vif_models(self):
+        """Check 'hw_supported_vif_models' compatibility."""
+        # assert that 'hw_supported_vif_models' is supported
+        # on version 1.36.1
+        obj = objects.ImageMetaProps(
+            hw_supported_vif_models=set(['virtio', 'e1000']),
+        )
+        primitive = obj.obj_to_primitive('1.36.1')
+        self.assertIn('hw_supported_vif_models',
+                      primitive['nova_object.data'])
+
+        # and is absent on older versions (including 1.36) when not set
+        obj_empty = objects.ImageMetaProps()
+        primitive = obj_empty.obj_to_primitive('1.36')
+        self.assertNotIn('hw_supported_vif_models',
+                         primitive['nova_object.data'])
+
+    @ddt.data(
+        ('hw_supported_disk_buses', {'virtio', 'scsi'}),
+        ('hw_supported_scsi_models', {'virtio-scsi', 'lsilogic'}),
+        ('hw_supported_vif_models', {'virtio', 'e1000'}),
+    )
+    @ddt.unpack
+    def test_obj_make_compatible_hw_supported_set(self, prop_name, value):
+        """Test that downgrade drops hw_supported_* field."""
+        obj = objects.ImageMetaProps(**{prop_name: value})
+        primitive = obj.obj_to_primitive('1.36')
+        self.assertNotIn(prop_name, primitive['nova_object.data'])
+
+    # SAP: Tests for comma-separated string parsing from Glance
+    @ddt.data(
+        # single value string is parsed into a one-element set
+        ('hw_supported_vif_models', 'virtio', {'virtio'}),
+        # comma-separated string with two values
+        ('hw_supported_vif_models', 'virtio,e1000', {'virtio', 'e1000'}),
+        # surrounding whitespace is stripped
+        ('hw_supported_vif_models', ' virtio , e1000 ', {'virtio', 'e1000'}),
+        # three-value comma-separated string
+        ('hw_supported_vif_models', 'virtio,e1000,rtl8139',
+         {'virtio', 'e1000', 'rtl8139'}),
+        # empty string produces an empty set
+        ('hw_supported_vif_models', '', set()),
+        # an already-parsed Python set is passed through unchanged
+        ('hw_supported_vif_models', {'virtio', 'e1000'}, {'virtio', 'e1000'}),
+        # Comma-separated string is parsed correctly for disk buses
+        ('hw_supported_disk_buses', 'virtio,scsi', {'virtio', 'scsi'}),
+        # Comma-separated string is parsed correctly for SCSI models
+        ('hw_supported_scsi_models', 'virtio-scsi,lsilogic',
+            {'virtio-scsi', 'lsilogic'}),
+    )
+    @ddt.unpack
+    def test_hw_supported_from_string(self, prop_name, value, expected):
+        """Test hw_supported_* fields are parsed correctly from string."""
+        props = {prop_name: value}
+        result = objects.ImageMetaProps.from_dict(props)
+        self.assertEqual(expected, getattr(result, prop_name))
+
+    @ddt.data(
+        ('hw_supported_vif_models', 'virtio,not_a_model'),
+    )
+    @ddt.unpack
+    def test_hw_supported_from_string_invalid_value(self, prop_name, value):
+        """A comma-separated string containing an invalid model raises."""
+        props = {prop_name: value}
+        self.assertRaises(
+            ValueError,
+            objects.ImageMetaProps.from_dict,
+            props,
+        )

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1103,7 +1103,7 @@ object_data = {
     'HyperVLiveMigrateData': '1.4-e265780e6acfa631476c8170e8d6fce0',
     'IDEDeviceBus': '1.0-29d4c9f27ac44197f01b6ac1b7e16502',
     'ImageMeta': '1.8-642d1b2eb3e880a367f37d72dd76162d',
-    'ImageMetaProps': '1.36-5d06cd527d8d32e6e2b457ce3b9369e0',
+    'ImageMetaProps': '1.36.1-533a64be77dae88e0bb56c858f205680',
     'Instance': '2.8-2727dba5e4a078e6cc848c1f94f7eb24',
     'InstanceAction': '1.2-9a5abc87fdd3af46f45731960651efb5',
     'InstanceActionEvent': '1.4-5b1f361bd81989f8bb2c20bb7e8a4cb4',

--- a/nova/tests/unit/virt/libvirt/test_blockinfo.py
+++ b/nova/tests/unit/virt/libvirt/test_blockinfo.py
@@ -1406,6 +1406,153 @@ class LibvirtBlockInfoTest(test.NoDBTestCase):
         self.assertRaises(exception.UnsupportedRescueBus,
                           blockinfo.get_rescue_bus, None, 'kvm', meta, 'disk')
 
+    def test_get_disk_bus_for_device_type_with_supported_buses(self):
+        # Test hw_supported_disk_buses takes priority over hw_disk_bus
+        instance = objects.Instance(**self.test_instance)
+
+        # Case 1: hw_supported_disk_buses with valid bus for KVM
+        image_meta = objects.ImageMeta.from_dict({
+            'properties': {'hw_supported_disk_buses': {'virtio', 'scsi'}}
+        })
+        bus = blockinfo.get_disk_bus_for_device_type(
+            instance, 'kvm', image_meta, device_type='disk')
+        # Should pick 'virtio' — it is first in SUPPORTED_DEVICE_BUSES['kvm']
+        self.assertEqual('virtio', bus)
+
+        # Case 2: hw_supported_disk_buses with only one valid bus
+        image_meta = objects.ImageMeta.from_dict({
+            'properties': {'hw_supported_disk_buses': {'xen', 'scsi'}}
+        })
+        bus = blockinfo.get_disk_bus_for_device_type(
+            instance, 'kvm', image_meta, device_type='disk')
+        # Should pick 'scsi' as 'xen' is not valid for kvm
+        self.assertEqual('scsi', bus)
+
+        # Case 3: hw_supported_disk_buses with no valid buses, fallback
+        image_meta = objects.ImageMeta.from_dict({
+            'properties': {'hw_supported_disk_buses': {'xen', 'uml'}}
+        })
+        bus = blockinfo.get_disk_bus_for_device_type(
+            instance, 'kvm', image_meta, device_type='disk')
+        # Should fallback to hypervisor default (virtio for kvm disk)
+        self.assertEqual('virtio', bus)
+
+    def test_get_disk_bus_for_device_type_supported_buses_priority(self):
+        # Test that hw_supported_disk_buses has priority over hw_disk_bus
+        instance = objects.Instance(**self.test_instance)
+
+        # Both hw_supported_disk_buses and hw_disk_bus are set
+        image_meta = objects.ImageMeta.from_dict({
+            'properties': {
+                'hw_supported_disk_buses': {'scsi', 'virtio'},
+                'hw_disk_bus': 'ide'
+            }
+        })
+        bus = blockinfo.get_disk_bus_for_device_type(
+            instance, 'kvm', image_meta, device_type='disk')
+        # Should pick 'virtio' (first in KVM priority list), not 'ide'
+        self.assertEqual('virtio', bus)
+
+    def test_get_disk_bus_for_device_type_supported_buses_fallback(self):
+        # Test fallback from hw_supported_disk_buses to hw_disk_bus
+        instance = objects.Instance(**self.test_instance)
+
+        # hw_supported_disk_buses has no valid buses, fall back to
+        # hw_disk_bus
+        image_meta = objects.ImageMeta.from_dict({
+            'properties': {
+                'hw_supported_disk_buses': {'xen'},
+                'hw_disk_bus': 'scsi'
+            }
+        })
+        bus = blockinfo.get_disk_bus_for_device_type(
+            instance, 'kvm', image_meta, device_type='disk')
+        # Should fallback to hw_disk_bus
+        self.assertEqual('scsi', bus)
+
+    def test_get_disk_bus_for_device_type_supported_buses_invalid(self):
+        # Test that invalid hw_disk_bus still raises exception after
+        # hw_supported_disk_buses has no valid options
+        instance = objects.Instance(**self.test_instance)
+
+        # hw_supported_disk_buses has no valid buses, hw_disk_bus is
+        # invalid
+        image_meta = objects.ImageMeta.from_dict({
+            'properties': {
+                'hw_supported_disk_buses': {'lxc'},
+                'hw_disk_bus': 'xen'
+            }
+        })
+        # Should raise UnsupportedHardware for invalid hw_disk_bus
+        self.assertRaises(
+            exception.UnsupportedHardware,
+            blockinfo.get_disk_bus_for_device_type,
+            instance, 'kvm', image_meta, device_type='disk')
+
+    def test_get_disk_bus_for_device_type_supported_buses_cdrom(self):
+        # Test that hw_supported_disk_buses is only used for disk device
+        # type
+        instance = objects.Instance(**self.test_instance)
+
+        # hw_supported_disk_buses should not affect cdrom device type
+        image_meta = objects.ImageMeta.from_dict({
+            'properties': {
+                'hw_supported_disk_buses': {'scsi'},
+                'hw_cdrom_bus': 'sata'
+            }
+        })
+        with mock.patch('nova.virt.libvirt.utils.get_arch',
+                       return_value=obj_fields.Architecture.X86_64):
+            bus = blockinfo.get_disk_bus_for_device_type(
+                instance, 'kvm', image_meta, device_type='cdrom')
+        # Should use hw_cdrom_bus, not hw_supported_disk_buses
+        self.assertEqual('sata', bus)
+
+    def test_get_disk_mapping_with_supported_disk_buses(self):
+        # Test get_disk_mapping with hw_supported_disk_buses
+        instance_ref = objects.Instance(**self.test_instance)
+        image_meta = objects.ImageMeta.from_dict({
+            'disk_format': 'raw',
+            'properties': {'hw_supported_disk_buses': {'scsi', 'virtio'}}
+        })
+
+        block_device_info = {
+            'image': [
+                {'device_type': 'disk', 'boot_index': 0},
+            ]
+        }
+        mapping = blockinfo.get_disk_mapping(
+            "kvm", instance_ref, "virtio", "ide", image_meta,
+            block_device_info=block_device_info)
+
+        # Root device should use a bus from hw_supported_disk_buses
+        self.assertIn(mapping['disk']['bus'], ['scsi', 'virtio'])
+        self.assertIn(mapping['root']['bus'], ['scsi', 'virtio'])
+
+    def test_get_disk_bus_for_device_type_supported_buses_highest_priority(
+            self):
+        # SAP: When hw_supported_disk_buses contains multiple valid buses,
+        # the bus that appears FIRST in SUPPORTED_DEVICE_BUSES[virt_type]
+        # should be selected (i.e. the implementation must iterate the
+        # hypervisor priority list and check membership, not iterate the
+        # unordered set and return the first valid hit).
+        #
+        # For KVM: SUPPORTED_DEVICE_BUSES['kvm'] = ['virtio', 'scsi', ...]
+        # so when both 'virtio' and 'scsi' are offered, 'virtio' must win.
+        instance = objects.Instance(**self.test_instance)
+        image_meta = objects.ImageMeta.from_dict({
+            'properties': {'hw_supported_disk_buses': {'scsi', 'virtio'}}
+        })
+        bus = blockinfo.get_disk_bus_for_device_type(
+            instance, 'kvm', image_meta, device_type='disk')
+        self.assertEqual(
+            'virtio', bus,
+            'Expected the highest-priority KVM bus (virtio) to be selected '
+            'when hw_supported_disk_buses contains {scsi, virtio}. '
+            'If this fails, the implementation is iterating the unordered '
+            'set instead of the hypervisor priority list.'
+        )
+
 
 class DefaultDeviceNamesTestCase(test.NoDBTestCase):
     def setUp(self):

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -6489,6 +6489,113 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         i = drvr._get_scsi_controller_next_unit(guest)
         self.assertEqual(expect_num, i)
 
+    # Tests for _get_scsi_controller() static method
+    def _assert_scsi_controller(self, controller, expected_model):
+        """Helper to assert SCSI controller properties."""
+        self.assertIsNotNone(controller)
+        self.assertIsInstance(controller, vconfig.LibvirtConfigGuestController)
+        self.assertEqual('scsi', controller.type)
+        self.assertEqual(expected_model, controller.model)
+        self.assertEqual(0, controller.index)
+
+    def test_get_scsi_controller_no_properties(self):
+        """Test that None is returned when no SCSI properties are set."""
+        image_meta = objects.ImageMeta.from_dict({})
+        result = libvirt_driver.LibvirtDriver._get_scsi_controller(
+            image_meta)
+        self.assertIsNone(result)
+
+    @ddt.data('virtio-scsi', 'lsisas1068', 'lsilogic', 'vmpvscsi')
+    def test_get_scsi_controller_hw_scsi_model_various_models(self, model):
+        """Test legacy hw_scsi_model with different model values."""
+        image_meta = objects.ImageMeta.from_dict({})
+        image_meta.properties = objects.ImageMetaProps(
+            hw_scsi_model=model
+        )
+        result = libvirt_driver.LibvirtDriver._get_scsi_controller(
+            image_meta)
+        self._assert_scsi_controller(result, model)
+
+    @ddt.data(
+        # kvm: virtio-scsi has highest priority over lsilogic
+        ('kvm', {'virtio-scsi', 'lsilogic'}, 'virtio-scsi'),
+        # qemu: same priority list as kvm, virtio-scsi wins regardless of
+        # set order
+        ('qemu', {'lsilogic', 'virtio-scsi'}, 'virtio-scsi'),
+        # kvm: lsisas1068 has higher priority than buslogic
+        ('kvm', {'lsisas1068', 'buslogic'}, 'lsisas1068'),
+        # kvm: last-priority model selected when it's the only candidate
+        ('kvm', {'ibmvscsi'}, 'ibmvscsi'),
+        # kvm: virtio-scsi wins when all models are offered
+        ('kvm', {'ibmvscsi', 'buslogic', 'lsilogic', 'lsisas1068',
+                 'lsisas1078', 'vmpvscsi', 'virtio-scsi'}, 'virtio-scsi'),
+        # qemu: same priority list as kvm
+        ('qemu', {'virtio-scsi'}, 'virtio-scsi'),
+    )
+    @ddt.unpack
+    def test_get_scsi_controller_priority_selection(
+            self, virt_type, models, expected):
+        """Test hw_supported_scsi_models respects the hypervisor priority
+        order, not the iteration order of the (unordered) set.
+        """
+        self.flags(virt_type=virt_type, group='libvirt')
+        image_meta = objects.ImageMeta.from_dict({})
+        image_meta.properties = objects.ImageMetaProps(
+            hw_supported_scsi_models=models
+        )
+        result = libvirt_driver.LibvirtDriver._get_scsi_controller(image_meta)
+        self._assert_scsi_controller(result, expected)
+
+    @ddt.data(
+        # empty set → no match → None
+        ('kvm', set()),
+        # unsupported virt_type → None
+        ('lxc', {'virtio-scsi'}),
+    )
+    @ddt.unpack
+    def test_get_scsi_controller_no_supported_match(self, virt_type, models):
+        """Test that None is returned when no supported model can be
+        selected (empty set or unsupported virt_type).
+        """
+        self.flags(virt_type=virt_type, group='libvirt')
+        image_meta = objects.ImageMeta.from_dict({})
+        image_meta.properties = objects.ImageMetaProps(
+            hw_supported_scsi_models=models
+        )
+        result = libvirt_driver.LibvirtDriver._get_scsi_controller(image_meta)
+        self.assertIsNone(result)
+
+    @mock.patch.object(CONF.libvirt, 'virt_type', 'kvm')
+    def test_get_scsi_controller_both_properties_new_takes_precedence(self):
+        """hw_supported_scsi_models takes precedence over hw_scsi_model."""
+        image_meta = objects.ImageMeta.from_dict({})
+        image_meta.properties = objects.ImageMetaProps(
+            hw_scsi_model='lsilogic',
+            hw_supported_scsi_models={'virtio-scsi'}
+        )
+        result = libvirt_driver.LibvirtDriver._get_scsi_controller(
+            image_meta)
+        # Should use virtio-scsi from hw_supported_scsi_models,
+        # not lsilogic from hw_scsi_model
+        self._assert_scsi_controller(result, 'virtio-scsi')
+
+    @mock.patch.object(CONF.libvirt, 'virt_type', 'kvm')
+    def test_get_scsi_controller_both_properties_fallback_to_legacy(self):
+        """Test fallback to hw_scsi_model when hw_supported_scsi_models doesn't match.
+
+        This test uses an empty set for hw_supported_scsi_models to ensure
+        no match is found, forcing fallback to hw_scsi_model.
+        """
+        image_meta = objects.ImageMeta.from_dict({})
+        image_meta.properties = objects.ImageMetaProps(
+            hw_scsi_model='lsilogic',
+            hw_supported_scsi_models=set()
+        )
+        result = libvirt_driver.LibvirtDriver._get_scsi_controller(
+            image_meta)
+        # Should fall back to lsilogic from hw_scsi_model
+        self._assert_scsi_controller(result, 'lsilogic')
+
     @mock.patch.object(host.Host, "_check_machine_type", new=mock.Mock())
     def test_get_guest_config_with_type_kvm_on_s390(self):
         self.flags(enabled=False, group='vnc')

--- a/nova/tests/unit/virt/libvirt/test_vif.py
+++ b/nova/tests/unit/virt/libvirt/test_vif.py
@@ -996,6 +996,116 @@ class LibvirtVifTestCase(test.NoDBTestCase):
 
             self._assertModel(xml, network_model.VIF_MODEL_VIRTIO, "qemu")
 
+    def test_model_hw_supported_vif_models_kvm(self):
+        """Test hw_supported_vif_models with KVM - select first valid model"""
+        self.flags(use_virtio_for_bridges=True,
+                   virt_type='kvm',
+                   group='libvirt')
+
+        d = vif.LibvirtGenericVIFDriver()
+        # Set hw_supported_vif_models with virtio, e1000, rtl8139
+        # KVM supports all three, should pick virtio (first in priority list)
+        image_meta = objects.ImageMeta.from_dict(
+            {'properties': {
+                'hw_supported_vif_models': set([
+                    network_model.VIF_MODEL_VIRTIO,
+                    network_model.VIF_MODEL_E1000,
+                    network_model.VIF_MODEL_RTL8139
+                ])
+            }})
+        xml = self._get_instance_xml(d, self.vif_bridge, image_meta)
+        self._assertModel(xml, network_model.VIF_MODEL_VIRTIO)
+
+    def test_model_hw_supported_vif_models_second_priority(self):
+        """Test hw_supported_vif_models selects second priority model"""
+        self.flags(use_virtio_for_bridges=True,
+                   virt_type='kvm',
+                   group='libvirt')
+
+        d = vif.LibvirtGenericVIFDriver()
+        # Set hw_supported_vif_models without virtio, ne2k_pci, pcnet (the
+        # first three in KVM list)
+        # Should pick rtl8139 (fourth in KVM priority list)
+        image_meta = objects.ImageMeta.from_dict(
+            {'properties': {
+                'hw_supported_vif_models': set([
+                    network_model.VIF_MODEL_E1000,
+                    network_model.VIF_MODEL_RTL8139
+                ])
+            }})
+        xml = self._get_instance_xml(d, self.vif_bridge, image_meta)
+        self._assertModel(xml, network_model.VIF_MODEL_RTL8139)
+
+    def test_model_hw_supported_vif_models_fallback_to_hw_vif_model(self):
+        """Test fallback to hw_vif_model when no supported models match"""
+        self.flags(use_virtio_for_bridges=True,
+                   virt_type='kvm',
+                   group='libvirt')
+
+        d = vif.LibvirtGenericVIFDriver()
+        # Set hw_supported_vif_models with only lan9118 (not supported by KVM)
+        # Should fall back to hw_vif_model
+        image_meta = objects.ImageMeta.from_dict(
+            {'properties': {
+                'hw_supported_vif_models': set([
+                    network_model.VIF_MODEL_LAN9118
+                ]),
+                'hw_vif_model': network_model.VIF_MODEL_E1000
+            }})
+        xml = self._get_instance_xml(d, self.vif_bridge, image_meta)
+        self._assertModel(xml, network_model.VIF_MODEL_E1000)
+
+    def test_model_hw_supported_vif_models_empty_set(self):
+        """Test empty hw_supported_vif_models falls back to hw_vif_model"""
+        self.flags(use_virtio_for_bridges=True,
+                   virt_type='kvm',
+                   group='libvirt')
+
+        d = vif.LibvirtGenericVIFDriver()
+        # Empty set should fall back to hw_vif_model
+        image_meta = objects.ImageMeta.from_dict(
+            {'properties': {
+                'hw_supported_vif_models': set(),
+                'hw_vif_model': network_model.VIF_MODEL_RTL8139
+            }})
+        xml = self._get_instance_xml(d, self.vif_bridge, image_meta)
+        self._assertModel(xml, network_model.VIF_MODEL_RTL8139)
+
+    def test_model_hw_supported_vif_models_parallels(self):
+        """Test hw_supported_vif_models with Parallels virt type"""
+        self.flags(use_virtio_for_bridges=True,
+                   virt_type='parallels',
+                   group='libvirt')
+
+        d = vif.LibvirtGenericVIFDriver()
+        # Parallels supports: virtio, rtl8139, e1000
+        # Set models with e1000 and rtl8139 (no virtio)
+        # Should pick rtl8139 (appears before e1000 in parallels priority)
+        image_meta = objects.ImageMeta.from_dict(
+            {'properties': {
+                'hw_supported_vif_models': set([
+                    network_model.VIF_MODEL_E1000,
+                    network_model.VIF_MODEL_RTL8139
+                ])
+            }})
+        xml = self._get_instance_xml(d, self.vif_bridge, image_meta)
+        self._assertModel(xml, network_model.VIF_MODEL_RTL8139)
+
+    def test_model_hw_supported_vif_models_not_set(self):
+        """Test behavior when hw_supported_vif_models is not set"""
+        self.flags(use_virtio_for_bridges=True,
+                   virt_type='kvm',
+                   group='libvirt')
+
+        d = vif.LibvirtGenericVIFDriver()
+        # No hw_supported_vif_models, should fall back to hw_vif_model
+        image_meta = objects.ImageMeta.from_dict(
+            {'properties': {
+                'hw_vif_model': network_model.VIF_MODEL_E1000
+            }})
+        xml = self._get_instance_xml(d, self.vif_bridge, image_meta)
+        self._assertModel(xml, network_model.VIF_MODEL_E1000)
+
     def test_generic_driver_none(self):
         d = vif.LibvirtGenericVIFDriver()
         self.assertRaises(exception.NovaException,

--- a/nova/tests/unit/virt/vmwareapi/test_images.py
+++ b/nova/tests/unit/virt/vmwareapi/test_images.py
@@ -19,6 +19,7 @@ import os
 import tarfile
 from unittest import mock
 
+import ddt
 from oslo_utils.fixture import uuidsentinel as uuids
 from oslo_utils import units
 from oslo_vmware import rw_handles
@@ -34,6 +35,7 @@ from nova.virt.vmwareapi import vm_util
 CONF = nova.conf.CONF
 
 
+@ddt.ddt
 class VMwareImagesTestCase(test.NoDBTestCase):
     """Unit tests for Vmware API connection calls."""
 
@@ -375,3 +377,309 @@ class VMwareImagesTestCase(test.NoDBTestCase):
         context = mock.Mock()
         observed = images.get_vsphere_location(context, None)
         self.assertIsNone(observed)
+
+    # Tests for hw_supported_scsi_models functionality
+
+    def _build_image_meta_with_properties(self, properties_dict):
+        """Helper to build ImageMeta object from properties dict."""
+        mdata = {
+            'size': 93 * units.Gi,
+            'disk_format': 'vmdk',
+            'owner': '',
+            'properties': properties_dict
+        }
+        return objects.ImageMeta.from_dict(mdata)
+
+    def test_supported_scsi_models_driver_preference(self):
+        """Test selecting based on driver preference order."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_supported_scsi_models': set(['lsisas1068', 'vmpvscsi']),
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # Should select vmpvscsi (driver's most preferred that image supports)
+        self.assertEqual(constants.ADAPTER_TYPE_PARAVIRTUAL,
+                        image.adapter_type)
+
+    def test_supported_scsi_models_driver_prefers_vmpvscsi(self):
+        """Test driver prefers vmpvscsi over buslogic."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_supported_scsi_models': set(['buslogic', 'vmpvscsi']),
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # Should select vmpvscsi (driver's most preferred)
+        self.assertEqual(constants.ADAPTER_TYPE_PARAVIRTUAL,
+                        image.adapter_type)
+
+    def test_supported_scsi_models_fallback_to_hw_scsi_model(self):
+        """Test fallback to hw_scsi_model when no matching models."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_supported_scsi_models': set(),
+            'hw_scsi_model': 'vmpvscsi',
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # Should fall back to hw_scsi_model
+        self.assertEqual(constants.ADAPTER_TYPE_PARAVIRTUAL,
+                        image.adapter_type)
+
+    def test_supported_scsi_models_priority_over_hw_scsi_model(self):
+        """Test hw_supported_scsi_models takes priority over hw_scsi_model."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_supported_scsi_models': set(['lsilogic', 'buslogic']),
+            'hw_scsi_model': 'vmpvscsi',
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # Should use lsilogic from hw_supported_scsi_models (driver's
+        # preference), not hw_scsi_model
+        self.assertEqual(constants.DEFAULT_ADAPTER_TYPE, image.adapter_type)
+
+    @ddt.data(
+        ('lsilogic', constants.DEFAULT_ADAPTER_TYPE),
+        ('lsisas1068', constants.ADAPTER_TYPE_LSILOGICSAS),
+        ('buslogic', constants.ADAPTER_TYPE_BUSLOGIC),
+        ('vmpvscsi', constants.ADAPTER_TYPE_PARAVIRTUAL),
+    )
+    @ddt.unpack
+    def test_supported_scsi_models_all_valid_types(self, scsi_model,
+                                                   expected_adapter):
+        """Test all valid SCSI model types."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_supported_scsi_models': {scsi_model},
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(
+                None, uuids.image, image_meta)
+
+        self.assertEqual(expected_adapter, image.adapter_type,
+                       "Failed for SCSI model: %s" % scsi_model)
+
+    def test_supported_scsi_models_with_supported_disk_buses(self):
+        """Test hw_supported_scsi_models with explicit SCSI disk bus."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_supported_scsi_models': set(['vmpvscsi', 'lsilogic']),
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # When SCSI bus is used, driver prefers vmpvscsi over lsilogic
+        self.assertEqual(constants.ADAPTER_TYPE_PARAVIRTUAL,
+                        image.adapter_type)
+
+    def test_supported_scsi_models_no_match(self):
+        """Test behavior when no SCSI models match driver preferences."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_supported_scsi_models': set(),
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # Should have None adapter_type (mapping.get(None) returns None)
+        self.assertIsNone(image.adapter_type)
+
+    def test_supported_scsi_models_empty_set(self):
+        """Test behavior with empty hw_supported_scsi_models set."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_supported_scsi_models': set(),
+            'hw_scsi_model': 'buslogic',
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # Should fall back to hw_scsi_model
+        self.assertEqual(constants.ADAPTER_TYPE_BUSLOGIC, image.adapter_type)
+
+    def test_supported_scsi_models_not_set(self):
+        """Test behavior when hw_supported_scsi_models is not set."""
+        properties = {
+            'hw_disk_bus': 'scsi',
+            'hw_scsi_model': 'lsisas1068',
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # Should use hw_scsi_model as before
+        self.assertEqual(constants.ADAPTER_TYPE_LSILOGICSAS,
+                        image.adapter_type)
+
+    def test_supported_scsi_models_ide_bus_ignored(self):
+        """Test hw_supported_scsi_models ignored when IDE bus selected."""
+        properties = {
+            'hw_disk_bus': 'ide',
+            'hw_supported_scsi_models': set(['vmpvscsi']),
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # IDE adapter should be used, SCSI models ignored
+        self.assertEqual(constants.ADAPTER_TYPE_IDE, image.adapter_type)
+
+    def test_get_scsi_model_from_image_properties_direct(self):
+        """Test _get_scsi_model_from_image_properties function directly."""
+        properties_dict = {
+            'hw_supported_scsi_models': set(['buslogic', 'lsilogic']),
+            'hw_scsi_model': 'vmpvscsi',
+        }
+        image_meta = self._build_image_meta_with_properties(properties_dict)
+        properties = image_meta.properties
+
+        result = images._get_scsi_model_from_image_properties(properties)
+
+        # Should return lsilogic (driver's preference over buslogic)
+        self.assertEqual('lsilogic', result)
+
+    def test_get_scsi_model_fallback_direct(self):
+        """Test fallback to hw_scsi_model in helper function."""
+        properties_dict = {
+            'hw_supported_scsi_models': set(),
+            'hw_scsi_model': 'lsilogic',
+        }
+        image_meta = self._build_image_meta_with_properties(properties_dict)
+        properties = image_meta.properties
+
+        result = images._get_scsi_model_from_image_properties(properties)
+
+        # Should fall back to hw_scsi_model
+        self.assertEqual('lsilogic', result)
+
+    def test_get_scsi_model_none_set(self):
+        """Test when neither supported models nor hw_scsi_model set."""
+        properties_dict = {}
+        image_meta = self._build_image_meta_with_properties(properties_dict)
+        properties = image_meta.properties
+
+        result = images._get_scsi_model_from_image_properties(properties)
+
+        # Should return None
+        self.assertIsNone(result)
+
+    # Tests for hw_supported_vif_models / get_vif_model functionality
+
+    def test_supported_vif_models_selects_vmxnet3_over_virtio(self):
+        """Test the exact failing scenario: virtio + vmxnet3 → vmxnet3."""
+        properties = {
+            'hw_vif_model': 'virtio',
+            'hw_supported_vif_models': {'virtio', 'vmxnet3'},
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # hw_supported_vif_models has priority; vmxnet3 is VMware-supported
+        self.assertEqual('vmxnet3', image.vif_model)
+
+    def test_supported_vif_models_priority_over_hw_vif_model(self):
+        """Test hw_supported_vif_models takes priority over hw_vif_model."""
+        properties = {
+            'hw_vif_model': 'e1000',
+            'hw_supported_vif_models': {'e1000', 'vmxnet3'},
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # vmxnet3 is preferred over e1000 in the driver's priority order
+        self.assertEqual('vmxnet3', image.vif_model)
+
+    def test_supported_vif_models_fallback_to_hw_vif_model(self):
+        """Test fallback to hw_vif_model when no VMware model in supported."""
+        properties = {
+            'hw_vif_model': 'e1000e',
+            'hw_supported_vif_models': {'virtio'},
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        # No VMware-compatible model in supported list → fall back to
+        # hw_vif_model
+        self.assertEqual('e1000e', image.vif_model)
+
+    def test_supported_vif_models_not_set_uses_hw_vif_model(self):
+        """Test that hw_vif_model is used when hw_supported_vif_models absent.
+        """
+        properties = {
+            'hw_vif_model': 'vmxnet3',
+        }
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        self.assertEqual('vmxnet3', image.vif_model)
+
+    def test_neither_vif_model_nor_supported_set_uses_default(self):
+        """Test that DEFAULT_VIF_MODEL is used when nothing is set."""
+        properties = {}
+        image_meta = self._build_image_meta_with_properties(properties)
+
+        with mock.patch.object(images, 'get_vsphere_location',
+                               return_value=None):
+            image = images.VMwareImage.from_image(None, uuids.image,
+                                                  image_meta)
+
+        self.assertEqual(constants.DEFAULT_VIF_MODEL, image.vif_model)

--- a/nova/tests/unit/virt/vmwareapi/test_vif.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vif.py
@@ -15,10 +15,12 @@
 
 from unittest import mock
 
+import ddt
 from oslo_vmware import vim_util
 
 from nova import exception
 from nova.network import model as network_model
+from nova import objects
 from nova import test
 from nova.tests.unit import utils
 from nova.tests.unit.virt.vmwareapi import fake
@@ -27,6 +29,7 @@ from nova.virt.vmwareapi import network_util
 from nova.virt.vmwareapi import vif
 
 
+@ddt.ddt
 class VMwareVifTestCase(test.NoDBTestCase):
     def setUp(self):
         super(VMwareVifTestCase, self).setUp()
@@ -265,3 +268,63 @@ class VMwareVifTestCase(test.NoDBTestCase):
         calls = []
         mock_network_name.assert_has_calls(calls)
         self.assertEqual(fake_network_obj, network_ref)
+
+    @ddt.data(
+        # First supported model in set is returned
+        ({'e1000', 'vmxnet3', 'e1000e'}, 'vmxnet3'),
+        # No matching model returns None
+        ({'rtl8139', 'ne2k_pci'}, None),
+        # Empty set returns None
+        (set(), None),
+        # No 'hw_supported_vif_models' property returns None
+        (None, None),
+    )
+    @ddt.unpack
+    def test_get_supported_vif_model(self, supported_models, expected):
+        """Test _get_supported_vif_model with various inputs."""
+        if supported_models is None:
+            image_meta = objects.ImageMeta.from_dict({'properties': {}})
+        else:
+            image_meta = objects.ImageMeta.from_dict({
+                'properties': {
+                    'hw_supported_vif_models': supported_models,
+                }
+            })
+        result = vif._get_supported_vif_model(image_meta)
+        self.assertEqual(expected, result)
+
+    def test_get_supported_vif_model_none_image_meta(self):
+        """Test that None is returned when image_meta is None."""
+        result = vif._get_supported_vif_model(None)
+        self.assertIsNone(result)
+
+    @ddt.data(
+        # hw_supported_vif_models takes priority over hw_vif_model
+        ({'hw_supported_vif_models': {'vmxnet3'}, 'hw_vif_model': 'e1000'},
+         'vmxnet3'),
+        # get_vif_model falls back to hw_vif_model
+        ({'hw_vif_model': 'e1000e'}, 'e1000e'),
+        # No match in supported falls back to hw_vif_model
+        ({'hw_supported_vif_models': {'rtl8139'}, 'hw_vif_model': 'e1000'},
+         'e1000'),
+        # Empty supported set falls back to hw_vif_model
+        ({'hw_supported_vif_models': set(), 'hw_vif_model': 'vmxnet'},
+         'vmxnet'),
+        # With supported models, priority is respected
+        ({'hw_supported_vif_models': {'e1000', 'e1000e', 'vmxnet3'}},
+         'vmxnet3'),
+        # No properties returns default
+        ({}, constants.DEFAULT_VIF_MODEL),
+    )
+    @ddt.unpack
+    def test_get_vif_model(self, properties, expected):
+        """Test get_vif_model with various property combinations."""
+        image_meta = objects.ImageMeta.from_dict({'properties': properties})
+        result = vif.get_vif_model(image_meta)
+        self.assertEqual(expected, result)
+
+    @ddt.data(None, objects.ImageMeta.from_dict({}))
+    def test_get_vif_model_no_image_meta(self, image_meta):
+        """Test get_vif_model returns default for missing or empty meta."""
+        result = vif.get_vif_model(image_meta)
+        self.assertEqual(constants.DEFAULT_VIF_MODEL, result)

--- a/nova/virt/libvirt/blockinfo.py
+++ b/nova/virt/libvirt/blockinfo.py
@@ -73,6 +73,7 @@ import itertools
 import operator
 
 from oslo_config import cfg
+from oslo_log import log as logging
 from oslo_serialization import jsonutils
 
 
@@ -87,6 +88,7 @@ from nova.virt.libvirt import utils as libvirt_utils
 from nova.virt import osinfo
 
 CONF = cfg.CONF
+LOG = logging.getLogger(__name__)
 
 BOOT_DEV_FOR_TYPE = {'disk': 'hd', 'cdrom': 'cdrom', 'floppy': 'fd'}
 # NOTE(aspiers): If you change this, don't forget to update the docs and
@@ -215,6 +217,47 @@ def is_disk_bus_valid_for_virt(virt_type, disk_bus):
     return disk_bus in SUPPORTED_DEVICE_BUSES[virt_type]
 
 
+def _get_disk_bus_from_image_properties(virt_type, image_meta):
+    """Get disk bus from image properties with priority handling.
+
+    Checks hw_supported_disk_buses first (choosing the first valid bus),
+    then falls back to hw_disk_bus if no supported buses are found.
+
+    :param virt_type: The virtualization type (e.g., 'kvm', 'qemu')
+    :param image_meta: objects.image_meta.ImageMeta for the instance
+    :returns: A valid disk bus string, or None if no disk bus is specified
+    :raises: UnsupportedHardware if hw_disk_bus is set but not valid
+    """
+    # PRIORITY 1: Check hw_supported_disk_buses first.
+    # Iterate the hypervisor's PRIORITY list (SUPPORTED_DEVICE_BUSES) and
+    # pick the first bus that is also present in the image's supported set.
+    # This mirrors the VIF-model selection and ensures deterministic,
+    # priority-ordered results regardless of Python set iteration order.
+    supported_buses = image_meta.properties.get('hw_supported_disk_buses')
+    if supported_buses:
+        for bus in SUPPORTED_DEVICE_BUSES.get(virt_type, []):
+            if bus in supported_buses:
+                LOG.debug("Selected disk bus '%(bus)s' from "
+                          "hw_supported_disk_buses for virt_type '%(virt)s'",
+                          {'bus': bus, 'virt': virt_type})
+                return bus
+
+        LOG.info("None of the disk buses in hw_supported_disk_buses "
+                    "%(buses)s are supported by virt_type %(virt)s, "
+                    "falling back to hw_disk_bus or defaults",
+                    {'buses': supported_buses, 'virt': virt_type})
+
+    # PRIORITY 2: Check hw_disk_bus (existing behavior)
+    disk_bus = osinfo.HardwareProperties(image_meta).disk_model
+    if disk_bus is not None:
+        if not is_disk_bus_valid_for_virt(virt_type, disk_bus):
+            raise exception.UnsupportedHardware(model=disk_bus,
+                                                virt=virt_type)
+        return disk_bus
+
+    return None
+
+
 def get_disk_bus_for_device_type(instance,
                                  virt_type,
                                  image_meta,
@@ -233,7 +276,7 @@ def get_disk_bus_for_device_type(instance,
 
     # Prefer a disk bus set against the image first of all
     if device_type == "disk":
-        disk_bus = osinfo.HardwareProperties(image_meta).disk_model
+        disk_bus = _get_disk_bus_from_image_properties(virt_type, image_meta)
     else:
         key = "hw_" + device_type + "_bus"
         disk_bus = image_meta.properties.get(key)

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -192,6 +192,27 @@ VOLUME_DRIVERS = {
 }
 
 
+# At the time of writing, that is the same as fields.SCSIModel.ALL,
+#  but that is not guaranteed, and ALL doesn't define a priority.
+PRIORITIZED_SCSI_MODELS = (
+    fields.SCSIModel.VIRTIO_SCSI,
+    fields.SCSIModel.VMPVSCSI,
+    fields.SCSIModel.LSISAS1078,
+    fields.SCSIModel.LSISAS1068,
+    fields.SCSIModel.LSILOGIC,
+    fields.SCSIModel.BUSLOGIC,
+    fields.SCSIModel.IBMVSCSI,
+)
+
+# SCSI models supported by libvirt, keyed by virt_type. The order defines
+# priority when selecting from hw_supported_scsi_models.
+SUPPORTED_SCSI_MODELS = {
+    'qemu': PRIORITIZED_SCSI_MODELS,
+    'kvm': PRIORITIZED_SCSI_MODELS,
+    'ch': (),
+}
+
+
 def patch_tpool_proxy():
     """eventlet.tpool.Proxy doesn't work with old-style class in __str__()
     or __repr__() calls. See bug #962840 for details.
@@ -5713,14 +5734,34 @@ class LibvirtDriver(driver.ComputeDriver):
 
     @staticmethod
     def _get_scsi_controller(image_meta):
-        """Return scsi controller or None based on image meta"""
-        if image_meta.properties.get('hw_scsi_model'):
-            hw_scsi_model = image_meta.properties.hw_scsi_model
+        """Return scsi controller or None based on image meta.
+
+        :param image_meta: ImageMeta object containing image properties
+        """
+        hw_scsi_model = None
+        # First try hw_supported_scsi_models
+        supported_models = image_meta.properties.get(
+            'hw_supported_scsi_models')
+        if supported_models:
+            # Iterate through SUPPORTED_SCSI_MODELS in priority order
+            # and return the first one that's in the image's supported set
+            virt_type = CONF.libvirt.virt_type
+            for model in SUPPORTED_SCSI_MODELS.get(virt_type, []):
+                if model in supported_models:
+                    hw_scsi_model = model
+                    break
+
+        # Fall back to hw_scsi_model
+        if not hw_scsi_model:
+            hw_scsi_model = image_meta.properties.get('hw_scsi_model')
+
+        if hw_scsi_model:
             scsi_controller = vconfig.LibvirtConfigGuestController()
             scsi_controller.type = 'scsi'
             scsi_controller.model = hw_scsi_model
             scsi_controller.index = 0
             return scsi_controller
+        return None
 
     def _get_host_sysinfo_serial_hardware(self):
         """Get a UUID from the host hardware

--- a/nova/virt/libvirt/vif.py
+++ b/nova/virt/libvirt/vif.py
@@ -95,6 +95,29 @@ def is_vif_model_valid_for_virt(virt_type, vif_model):
     return vif_model in SUPPORTED_VIF_MODELS[virt_type]
 
 
+def _get_supported_vif_model(virt_type, image_meta):
+    """Get the best supported VIF model from image metadata.
+
+    :param virt_type: Virtualization type (e.g., 'kvm', 'qemu', 'xen')
+    :param image_meta: ImageMeta object containing image properties
+    :returns: The first matching model from SUPPORTED_VIF_MODELS, or None
+    """
+    if not image_meta:
+        return None
+
+    supported_models = image_meta.properties.get('hw_supported_vif_models')
+    if not supported_models:
+        return None
+
+    # Iterate through SUPPORTED_VIF_MODELS in priority order
+    # and return the first one that's in the image's supported set
+    for candidate_model in SUPPORTED_VIF_MODELS.get(virt_type, []):
+        if candidate_model in supported_models:
+            return candidate_model
+
+    return None
+
+
 def set_vf_interface_vlan(pci_addr, mac_addr, vlan=0):
     vlan_id = int(vlan)
     pf_ifname = pci_utils.get_ifname_by_pci_address(pci_addr,
@@ -167,10 +190,13 @@ class LibvirtGenericVIFDriver(object):
 
         model = vif_model
 
-        # If the user has specified a 'vif_model' against the
-        # image then honour that model
         if image_meta:
-            model = osinfo.HardwareProperties(image_meta).network_model
+            # Check hw_supported_vif_models first
+            model = _get_supported_vif_model(
+                CONF.libvirt.virt_type, image_meta)
+            if not model:
+                # Fall back to hw_vif_model via HardwareProperties
+                model = osinfo.HardwareProperties(image_meta).network_model
 
         # If the virt type is KVM/QEMU/VZ(Parallels), then use virtio according
         # to the global config parameter

--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -37,6 +37,7 @@ from nova.i18n import _
 from nova.image import glance
 from nova.objects import fields
 from nova.virt.vmwareapi import constants
+from nova.virt.vmwareapi import vif as vmwarevif
 from nova.virt.vmwareapi import vm_util
 
 # NOTE(mdbooth): We use use_linked_clone below, but don't have to import it
@@ -55,6 +56,69 @@ CHUNK_SIZE = 64 * units.Ki  # default chunk size for image transfer
 
 # VMDK images having this size are considered invalid/incomplete downloads
 INVALID_VMDK_SIZE = 4096000
+
+# VMware disk buses in priority order (SCSI preferred over IDE)
+SUPPORTED_DISK_BUSES = (
+    fields.DiskBus.SCSI,
+    fields.DiskBus.IDE,
+)
+
+# Driver's SCSI model preference order (most preferred first)
+# This matches VMware's recommended best practices for performance
+SCSI_MODELS_BY_PREFERENCE = (
+    fields.SCSIModel.VMPVSCSI,      # ParaVirtual - best performance
+    fields.SCSIModel.LSILOGIC,      # LSI Logic Parallel - default
+    fields.SCSIModel.LSISAS1068,    # LSI Logic SAS
+    fields.SCSIModel.BUSLOGIC,      # BusLogic - legacy
+)
+
+
+def _get_disk_bus_from_image_properties(properties):
+    """Get disk bus from image properties with priority handling.
+
+    Checks hw_supported_disk_buses first (choosing the first valid bus),
+    then falls back to hw_disk_bus if no supported buses are found.
+
+    :param properties: ImageMetaProps object
+    :returns: A disk bus string (e.g., 'ide', 'scsi'), or None
+    """
+    supported_buses = properties.get('hw_supported_disk_buses')
+    if supported_buses:
+        for bus in SUPPORTED_DISK_BUSES:
+            if bus in supported_buses:
+                return bus
+
+        LOG.info("None of the disk buses in hw_supported_disk_buses "
+                    "%(buses)s are supported, falling back to hw_disk_bus "
+                    "or defaults",
+                    {'buses': supported_buses})
+
+    return properties.get('hw_disk_bus')
+
+
+def _get_scsi_model_from_image_properties(properties):
+    """Get SCSI model from image properties with priority handling.
+
+    Checks hw_supported_scsi_models first, selecting based on the internal
+    preference order, then falls back to hw_scsi_model if no supported
+    models are found.
+
+    :param properties: ImageMetaProps object
+    :returns: A SCSI model string (e.g., 'lsilogic', 'vmpvscsi'), or None
+    """
+
+    supported_scsi_models = properties.get('hw_supported_scsi_models')
+    if supported_scsi_models:
+        for preferred_model in SCSI_MODELS_BY_PREFERENCE:
+            if preferred_model in supported_scsi_models:
+                return preferred_model
+
+        LOG.info("None of the SCSI models in hw_supported_scsi_models "
+                    "%(models)s match driver preferences, falling back to "
+                    "hw_scsi_model or defaults",
+                    {'models': supported_scsi_models})
+
+    return properties.get('hw_scsi_model')
 
 
 class VMwareImage(object):
@@ -161,7 +225,7 @@ class VMwareImage(object):
             props['file_size'] = image_meta.size
         if image_meta.obj_attr_is_set('disk_format'):
             props['file_type'] = image_meta.disk_format
-        hw_disk_bus = properties.get('hw_disk_bus')
+        hw_disk_bus = _get_disk_bus_from_image_properties(properties)
         if hw_disk_bus:
             mapping = {
                 fields.SCSIModel.LSILOGIC:
@@ -176,13 +240,15 @@ class VMwareImage(object):
             if hw_disk_bus == fields.DiskBus.IDE:
                 props['adapter_type'] = constants.ADAPTER_TYPE_IDE
             elif hw_disk_bus == fields.DiskBus.SCSI:
-                hw_scsi_model = properties.get('hw_scsi_model')
+                hw_scsi_model = _get_scsi_model_from_image_properties(
+                    properties)
                 props['adapter_type'] = mapping.get(hw_scsi_model)
+
+        props['vif_model'] = vmwarevif.get_vif_model(image_meta)
 
         props_map = {
             'os_distro': 'os_type',
             'hw_disk_type': 'disk_type',
-            'hw_vif_model': 'vif_model'
         }
 
         for k, v in props_map.items():

--- a/nova/virt/vmwareapi/vif.py
+++ b/nova/virt/vmwareapi/vif.py
@@ -27,8 +27,70 @@ from nova.virt.vmwareapi import constants
 from nova.virt.vmwareapi import network_util
 from nova.virt.vmwareapi import vm_util
 
+
 LOG = logging.getLogger(__name__)
+
+
 CONF = nova.conf.CONF
+
+# VMware VIF models in priority order (most preferred first)
+SUPPORTED_VIF_MODELS = (
+    model.VIF_MODEL_VMXNET3,
+    model.VIF_MODEL_VMXNET,
+    model.VIF_MODEL_E1000E,
+    model.VIF_MODEL_E1000,
+    model.VIF_MODEL_PCNET,
+    model.VIF_MODEL_SRIOV,
+)
+
+
+def _get_supported_vif_model(image_meta):
+    """Get the best supported VIF model from image metadata.
+
+    :param image_meta: ImageMeta object containing image properties
+    :returns: The first matching model from SUPPORTED_VIF_MODELS, or None
+    """
+    if not image_meta:
+        return None
+
+    supported_models = image_meta.properties.get('hw_supported_vif_models')
+    if not supported_models:
+        return None
+
+    for candidate_model in SUPPORTED_VIF_MODELS:
+        if candidate_model in supported_models:
+            return candidate_model
+
+    return None
+
+
+def get_vif_model(image_meta):
+    """Get the VIF model from image metadata.
+
+    This function tries to determine the VIF model based on the image
+    metadata, if provided.
+
+    It checks hw_supported_vif_models first (selecting the first supported
+    model from the priority list), then falls back to hw_vif_model.
+
+    If either no image_meta has been provided, or the metadata
+    has not been set, it falls back to the default model.
+    :param image_meta: ImageMeta object containing image properties
+    :returns: The VIF model to use (string)
+    """
+    if not image_meta:
+        return constants.DEFAULT_VIF_MODEL
+
+    # First, check if hw_supported_vif_models is specified
+    if vif_model := _get_supported_vif_model(image_meta):
+        return vif_model
+
+    # Fall back to hw_vif_model if specified
+    if vif_model := image_meta.properties.get('hw_vif_model'):
+        return vif_model
+
+    # Return default model
+    return constants.DEFAULT_VIF_MODEL
 
 
 def _check_ovs_supported_version(session):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -3063,8 +3063,7 @@ class VMwareVMOps(object):
         config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
         extra_specs = self._get_extra_specs(instance.flavor,
                                             instance.image_meta)
-        vif_model = instance.image_meta.properties.get('hw_vif_model',
-            constants.DEFAULT_VIF_MODEL)
+        vif_model = vmwarevif.get_vif_model(instance.image_meta)
 
         vm_util.append_vif_infos_to_config_spec(
             client_factory,
@@ -3106,8 +3105,7 @@ class VMwareVMOps(object):
             return device_changes
 
         # Iterate over the network adapters and update the backing
-        vif_model = image_meta.properties.get('hw_vif_model',
-                                                constants.DEFAULT_VIF_MODEL)
+        vif_model = vmwarevif.get_vif_model(image_meta)
         hardware_devices = vm_util.get_hardware_devices(self._session, vm_ref)
         vif_infos = vmwarevif.get_vif_info(self._session,
                                            self._cluster,
@@ -4094,8 +4092,7 @@ class VMwareVMOps(object):
 
     def attach_interface(self, context, instance, image_meta, vif):
         """Attach an interface to the instance."""
-        vif_model = image_meta.properties.get('hw_vif_model',
-                                              constants.DEFAULT_VIF_MODEL)
+        vif_model = vmwarevif.get_vif_model(image_meta)
         vif_model = vm_util.convert_vif_model(vif_model)
         vif_info = vmwarevif.get_vif_dict(self._session, self._cluster,
                                           vif_model, vif)


### PR DESCRIPTION
Images are often compatible with more than one disk bus, SCSI
controller model, or NIC model. New set-valued image properties let an
image declare all supported options; drivers then pick their
highest-priority match, making images more portable across different
hypervisors without requiring hypervisor-specific image variants.

Change-Id: I257a24adfdde1ad2e604c1d9b160e38cf4d53e14