### PR TITLE
tox: Pin virtualenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
 minversion = 3.18.0
+# specify virtualenv here to keep local runs consistent with the
+# gate (it sets the versions of pip, setuptools, and wheel)
+requires = virtualenv<20.38
 envlist = py3,functional,pep8
 
 [testenv]


### PR DESCRIPTION
`virtualenv` 2.38 bumped setuptools, which does not contain `pkg_resources` anymore. Since we're on an older release, our dependencies still require `pkg_resources` to be present. Hence, installing and running unit-tests fails.

https://github.com/pypa/virtualenv/releases
https://github.com/pypa/virtualenv/commit/d27a884e8842409a7613360eac54531db777fbbf

Change-Id: I081789d41ad1fbb1f7fa71defb5449d5822c5656