### PR TITLE
vmwareapi: Wait for port realization in NSX-T in attach_interface

### DIFF
--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -2440,7 +2440,8 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
         self.assertTrue(found_iface_id)
         self.assertEqual(num_iface_ids, num_found)
 
-    def _attach_interface(self, vif):
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
+    def _attach_interface(self, vif, mock_wait_for_port):
         self.conn.attach_interface(self.context, self.instance, self.image,
                                    vif)
         self._validate_interfaces(vif['id'], 1, 2)
@@ -2454,8 +2455,10 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
         self._create_vm()
         vif = self._create_vif()
 
-        with mock.patch.object(self.conn._session, '_wait_for_task',
-                               side_effect=Exception):
+        with (mock.patch.object(self.conn._session, '_wait_for_task',
+                               side_effect=Exception),
+                mock.patch.object(vmops.VMwareVMOps,
+                                  '_wait_for_port_realization')):
             self.assertRaises(exception.InterfaceAttachFailed,
                               self.conn.attach_interface,
                               self.context, self.instance, self.image, vif)
@@ -2475,8 +2478,10 @@ class VMwareAPIVMTestCase(test.NoDBTestCase,
     def test_detach_interface_and_attach(self):
         vif = self._create_vif()
         self._detach_interface(vif)
-        self.conn.attach_interface(self.context, self.instance, self.image,
-                                   vif)
+        with mock.patch.object(vmops.VMwareVMOps,
+                               '_wait_for_port_realization'):
+            self.conn.attach_interface(self.context, self.instance, self.image,
+                                       vif)
         self._validate_interfaces(vif['id'], 1, 2)
 
     def test_detach_interface_no_device(self):

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -4029,10 +4029,12 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_network_attach_config_spec',
                        return_value='fake-attach-spec')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch.object(vm_util, 'get_attach_port_index', return_value=1)
     @mock.patch.object(vm_util, 'get_vm_ref', return_value='fake-ref')
     def test_attach_interface(self, mock_get_vm_ref,
                               mock_get_attach_port_index,
+                              mock_wait_for_port,
                               mock_get_network_attach_config_spec,
                               mock_reconfigure_vm,
                               mock_extra_specs):
@@ -4131,10 +4133,12 @@ class VMwareVMOpsTestCase(test.TestCase):
     @mock.patch.object(vm_util, 'reconfigure_vm')
     @mock.patch.object(vm_util, 'get_network_attach_config_spec',
                        return_value='fake-attach-spec')
+    @mock.patch.object(vmops.VMwareVMOps, '_wait_for_port_realization')
     @mock.patch.object(vm_util, 'get_attach_port_index', return_value=1)
     @mock.patch.object(vm_util, 'get_vm_ref', return_value='fake-ref')
     def test_attach_interface_with_limits(self, mock_get_vm_ref,
                               mock_get_attach_port_index,
+                              mock_wait_for_port,
                               mock_get_network_attach_config_spec,
                               mock_reconfigure_vm,
                               mock_extra_specs):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -4107,6 +4107,10 @@ class VMwareVMOps(object):
             client_factory = self._session.vim.client.factory
             extra_specs = self._get_extra_specs(instance.flavor)
 
+            timeout = CONF.vmware.port_realization_wait_timeout
+            self._wait_for_port_realization(context, instance, [vif],
+                                            timeout=timeout)
+
             attach_config_spec = vm_util.get_network_attach_config_spec(
                                         client_factory, vif_info, port_index,
                                         extra_specs.vif_limits)


### PR DESCRIPTION
When attaching a new interface to a VM, we need to wait for the port bo realized in NSX-T. Otherwise, ESXi can create a port on its own which will not get the security-groups applied.

This is basically the same problem and solution as in I9ca66b57fd3256589bc8b272e027f7cd27bd5bd4 and can probably be merged into it.

Change-Id: Iebeab64915aefa9a1c26dbe89e35ca80ac608b3f