### PR TITLE
Clean up orphaned resources for live migrations and evacuations

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4086,6 +4086,7 @@ class ComputeManager(manager.Manager):
             bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
                     context, instance.uuid)
 
+        self._delete_dangling_bdms(context, instance, bdms)
         block_device_info = \
             self._get_instance_block_device_info(
                     context, instance, bdms=bdms)
@@ -4236,7 +4237,7 @@ class ComputeManager(manager.Manager):
             # attachments as there cannot be dangling bdms.
             # if we cannot connect to cinder we cannot check for dangling
             # bdms so we skip the check. Intermittent connection issues
-            # to cinder should not cause instance reboot to fail.
+            # to cinder should not cause instance task to fail.
             return
 
         # attachments present in nova DB, ones nova knows about

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4065,8 +4065,12 @@ class ComputeManager(manager.Manager):
         instance.save(expected_task_state=[task_states.REBUILDING])
 
         if evacuate:
+            # Clean up potential orphaned port bindings on the destination
+            # host from e.g. previous failed instance tasks.
+            self.network_api.cleanup_instance_network_on_host(
+                context, instance, self.host)
             self.network_api.setup_networks_on_host(
-                    context, instance, self.host)
+                context, instance, self.host)
             # For nova-network this is needed to move floating IPs
             # For neutron this updates the host in the port binding
             # TODO(cfriesen): this network_api call and the one above

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4221,10 +4221,15 @@ class ComputeManager(manager.Manager):
         :param instance: instance object.
         :param bdms: BlockDeviceMappingList list object.
         """
-
+        # Use get_admin_context() to authenticate as Cinder admin using Nova's
+        # service credentials and allow usage of `all_tenants=True`
+        cinder_context = nova.context.get_admin_context()
         try:
+            # Use `all_tenants=True` to also obtain attachments when this is
+            # called by an admin user from a different project than the
+            # instance's project.
             cinder_attachments = self.volume_api.attachment_get_all(
-                context, instance.uuid)
+                cinder_context, instance.uuid, all_tenants=True)
         except (keystone_exception.EndpointNotFound,
                 cinder_exception.ClientException):
             # if cinder is not deployed we never need to check for
@@ -4240,7 +4245,8 @@ class ComputeManager(manager.Manager):
         for bdm in bdms.objects:
             if bdm.volume_id and bdm.attachment_id:
                 try:
-                    self.volume_api.attachment_get(context, bdm.attachment_id)
+                    self.volume_api.attachment_get(cinder_context,
+                                                   bdm.attachment_id)
                 except exception.VolumeAttachmentNotFound:
                     LOG.info(
                         f"Removing stale volume attachment "
@@ -4261,7 +4267,7 @@ class ComputeManager(manager.Manager):
             # delete only cinder known attachments, from cinder DB.
             LOG.debug(
                 f"Removing attachment '{each_attach}'", instance=instance)
-            self.volume_api.attachment_delete(context, each_attach)
+            self.volume_api.attachment_delete(cinder_context, each_attach)
 
         # refresh bdms object
         for bdm in bdms_to_delete:
@@ -8997,8 +9003,14 @@ class ComputeManager(manager.Manager):
         # done on source/destination. For now, this is just here for status
         # reporting
         self._set_migration_status(migration, 'preparing')
+
+        elevated = context.elevated()
+        uncleansed_bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
+            elevated, instance.uuid)
+        self._delete_dangling_bdms(elevated, instance, uncleansed_bdms)
+
         source_bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
-                context, instance.uuid)
+            context, instance.uuid)
 
         migrate_data = self._do_pre_live_migration_from_source(
             context, dest, instance, block_migration, migration, migrate_data,

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -9660,18 +9660,19 @@ class ComputeManager(manager.Manager):
                     # NOTE(lyarwood): 3.44 cinder api flow. Delete the
                     # attachment used by the bdm and reset it to that of
                     # the original bdm.
-                    self.volume_api.attachment_delete(context,
-                                                      bdm.attachment_id)
-                    bdm.attachment_id = original_bdm.attachment_id
+                    try:
+                        self.volume_api.attachment_delete(context,
+                                                          bdm.attachment_id)
+                    except cinder_exception.ClientException:
+                        LOG.warning("Ignoring cinderclient exception when "
+                                    "attempting to delete attachment %s for "
+                                    "volume %s while rolling back volume "
+                                    "bdms.", bdm.attachment_id, bdm.volume_id,
+                                    instance=instance)
+                bdm.attachment_id = original_bdm.attachment_id
                 # NOTE(lyarwood): Reset the connection_info to the original
                 bdm.connection_info = original_bdm.connection_info
                 bdm.save()
-            except cinder_exception.ClientException:
-                LOG.warning("Ignoring cinderclient exception when "
-                            "attempting to delete attachment %s for volume "
-                            "%s while rolling back volume bdms.",
-                            bdm.attachment_id, bdm.volume_id,
-                            instance=instance)
             except Exception:
                 with excutils.save_and_reraise_exception():
                     LOG.exception("Exception while attempting to rollback "

--- a/nova/tests/fixtures/cinder.py
+++ b/nova/tests/fixtures/cinder.py
@@ -427,7 +427,8 @@ class CinderFixture(fixtures.Fixture):
         return limits
 
     def fake_attachment_get_all(
-            self, context, instance_id=None, volume_id=None):
+            self, context, instance_id=None, volume_id=None,
+            all_tenants=False):
         if not instance_id and not volume_id:
             raise exception.InvalidRequest(
                 "Either instance or volume id must be passed.")

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -6445,8 +6445,9 @@ class ComputeTestCase(BaseTestCase,
         # the same connection_info and attachment_id as the first BDMs
         # generated (before calling pre_live_migration), and that we saved
         # them.
-        self.assertGreater(len(fake_bdms), 1)
-        for source_bdm, final_bdm in zip(fake_bdms[0], fake_bdms[-1]):
+        self.assertEqual(mock_get_bdms.call_count, 3)
+        self.assertEqual(len(fake_bdms), 3)
+        for source_bdm, final_bdm in zip(fake_bdms[1], fake_bdms[2]):
             self.assertEqual(source_bdm.attachment_id,
                              final_bdm.attachment_id)
             self.assertEqual(source_bdm.connection_info,

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -5471,14 +5471,15 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
     @mock.patch('nova.compute.manager.ComputeManager.'
                 '_validate_instance_group_policy')
     @mock.patch('nova.compute.manager.ComputeManager._set_migration_status')
+    @mock.patch('nova.compute.manager.ComputeManager._delete_dangling_bdms')
     @mock.patch('nova.compute.resource_tracker.ResourceTracker.rebuild_claim')
     def test_evacuate_late_server_group_policy_check(
-            self, mock_rebuild_claim, mock_set_migration_status,
-            mock_validate_policy, mock_image_meta, mock_notify_exists,
-            mock_notify_legacy, mock_notify, mock_instance_save,
-            mock_setup_networks, mock_setup_instance_network, mock_get_bdms,
-            mock_mutate_migration, mock_appy_migration, mock_drop_migration,
-            mock_context_elevated):
+            self, mock_rebuild_claim, mock_delete_dangling_bdms,
+            mock_set_migration_status, mock_validate_policy, mock_image_meta,
+            mock_notify_exists, mock_notify_legacy, mock_notify,
+            mock_instance_save, mock_setup_networks,
+            mock_setup_instance_network, mock_get_bdms, mock_mutate_migration,
+            mock_appy_migration, mock_drop_migration, mock_context_elevated):
         self.flags(api_servers=['http://localhost/image/v2'], group='glance')
         instance = fake_instance.fake_instance_obj(self.context)
         instance.trusted_certs = None
@@ -5619,6 +5620,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
                               'setup_instance_network_on_host'),
             mock.patch.object(self.compute.network_api,
                               'get_instance_nw_info'),
+            mock.patch.object(self.compute, '_delete_dangling_bdms'),
             mock.patch.object(self.compute,
                               '_get_instance_block_device_info',
                               return_value='fake-bdminfo'),
@@ -5628,6 +5630,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
              mock_setup,
              mock_setup_inst,
              mock_get_nw_info,
+             mock_delete_dangling_bdms,
              mock_get_blk,
              mock_check_trusted_certs
         ):
@@ -5686,6 +5689,8 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
                 self.context, instance, mock.ANY, mock.ANY,
                 provider_mappings=mock.sentinel.mapping)
             mock_get_nw_info.assert_called_once_with(self.context, instance)
+            mock_delete_dangling_bdms.assert_called_once_with(
+                self.context, instance, bdms)
 
     @ddt.data((False, False), (False, True), (True, False), (True, True))
     @ddt.unpack

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -5615,6 +5615,8 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
             mock.patch.object(self.compute,
                               '_notify_about_instance_usage'),
             mock.patch.object(self.compute.network_api,
+                              'cleanup_instance_network_on_host'),
+            mock.patch.object(self.compute.network_api,
                               'setup_networks_on_host'),
             mock.patch.object(self.compute.network_api,
                               'setup_instance_network_on_host'),
@@ -5627,6 +5629,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
             mock.patch.object(self.compute, '_check_trusted_certs'),
         ) as(
              mock_notify_usage,
+             mock_cleanup_networks,
              mock_setup,
              mock_setup_inst,
              mock_get_nw_info,
@@ -5683,6 +5686,8 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
             self.assertTrue(mock_image_ref.called)
             self.assertTrue(mock_save.called)
             self.assertTrue(mock_notify_exists.called)
+            mock_cleanup_networks.assert_called_once_with(
+                self.context, instance, self.compute.host)
             mock_setup.assert_called_once_with(self.context, instance,
                                                mock.ANY)
             mock_setup_inst.assert_called_once_with(

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -10170,8 +10170,10 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase,
     @mock.patch('nova.compute.rpcapi.ComputeAPI.pre_live_migration')
     @mock.patch('nova.compute.manager.ComputeManager._post_live_migration')
     @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid')
+    @mock.patch('nova.compute.manager.ComputeManager._delete_dangling_bdms')
     def test_live_migration_wait_vif_plugged(
-            self, mock_get_bdms, mock_post_live_mig, mock_pre_live_mig):
+            self, mock_delete_dangling_bdms, mock_get_bdms,
+            mock_post_live_mig, mock_pre_live_mig):
         """Tests the happy path of waiting for network-vif-plugged events from
         neutron when pre_live_migration returns a migrate_data object with
         wait_for_vif_plugged=True.
@@ -10197,6 +10199,8 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase,
         self.assertEqual(2, len(wait_for_event.call_args[0][1]))
         self.assertEqual(CONF.vif_plugging_timeout,
                          wait_for_event.call_args[1]['deadline'])
+        mock_delete_dangling_bdms.assert_called_once_with(
+            mock.ANY, self.instance, mock_get_bdms.return_value)
         mock_pre_live_mig.assert_called_once_with(
             self.context, self.instance, None, None, 'dest-host',
             migrate_data)
@@ -10205,9 +10209,10 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase,
     @mock.patch('nova.compute.manager.ComputeManager._post_live_migration')
     @mock.patch('nova.compute.manager.LOG.debug')
     @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid')
+    @mock.patch('nova.compute.manager.ComputeManager._delete_dangling_bdms')
     def test_live_migration_wait_vif_plugged_old_dest_host(
-            self, mock_get_bdms, mock_log_debug, mock_post_live_mig,
-            mock_pre_live_mig):
+            self, mock_delete_dangling_bdms, mock_get_bdms, mock_log_debug,
+            mock_post_live_mig, mock_pre_live_mig):
         """Tests the scenario that the destination compute returns a
         migrate_data with no wait_for_vif_plugged set because the dest compute
         doesn't have that code yet. In this case, we default to legacy behavior
@@ -10237,8 +10242,10 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase,
     @mock.patch('nova.compute.rpcapi.ComputeAPI.pre_live_migration')
     @mock.patch('nova.compute.manager.ComputeManager._rollback_live_migration')
     @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid')
+    @mock.patch('nova.compute.manager.ComputeManager._delete_dangling_bdms')
     def test_live_migration_wait_vif_plugged_vif_plug_error(
-            self, mock_get_bdms, mock_rollback_live_mig, mock_pre_live_mig):
+            self, mock_delete_dangling_bdms, mock_get_bdms,
+            mock_rollback_live_mig, mock_pre_live_mig):
         """Tests the scenario where wait_for_instance_event fails with
         VirtualInterfacePlugException.
         """
@@ -10271,8 +10278,10 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase,
     @mock.patch('nova.compute.rpcapi.ComputeAPI.pre_live_migration')
     @mock.patch('nova.compute.manager.ComputeManager._rollback_live_migration')
     @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid')
+    @mock.patch('nova.compute.manager.ComputeManager._delete_dangling_bdms')
     def test_live_migration_wait_vif_plugged_timeout_error(
-            self, mock_get_bdms, mock_rollback_live_mig, mock_pre_live_mig):
+            self, mock_delete_dangling_bdms, mock_get_bdms,
+            mock_rollback_live_mig, mock_pre_live_mig):
         """Tests the scenario where wait_for_instance_event raises an
         eventlet Timeout exception and we're configured such that vif plugging
         failures are fatal (which is the default).
@@ -10308,8 +10317,10 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase,
     @mock.patch('nova.compute.manager.ComputeManager._rollback_live_migration')
     @mock.patch('nova.compute.manager.ComputeManager._post_live_migration')
     @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid')
+    @mock.patch('nova.compute.manager.ComputeManager._delete_dangling_bdms')
     def test_live_migration_wait_vif_plugged_timeout_non_fatal(
-            self, mock_get_bdms, mock_post_live_mig, mock_rollback_live_mig,
+            self, mock_delete_dangling_bdms, mock_get_bdms,
+            mock_post_live_mig, mock_rollback_live_mig,
             mock_pre_live_mig):
         """Tests the scenario where wait_for_instance_event raises an
         eventlet Timeout exception and we're configured such that vif plugging
@@ -10356,7 +10367,10 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase,
     @mock.patch.object(compute_utils, 'notify_about_instance_action')
     @mock.patch('nova.compute.manager.ComputeManager._rollback_live_migration')
     @mock.patch('nova.compute.rpcapi.ComputeAPI.pre_live_migration')
-    def test_live_migration_aborted_before_running(self, mock_rpc,
+    @mock.patch('nova.compute.manager.ComputeManager._delete_dangling_bdms')
+    def test_live_migration_aborted_before_running(self,
+                                                   mock_delete_dangling_bdms,
+                                                   mock_rpc,
                                                    mock_rollback,
                                                    mock_action_notify,
                                                    mock_usage_notify,

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -10938,33 +10938,45 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase,
 
     @mock.patch('nova.compute.manager.LOG')
     @mock.patch('nova.volume.cinder.API.attachment_delete')
-    def test_rollback_volume_bdms_exc(self, mock_delete_attachment, mock_log):
+    def test_rollback_volume_bdms_client_exc(
+            self, mock_delete_attachment, mock_log):
         instance = fake_instance.fake_instance_obj(self.context,
                                                    uuid=uuids.instance)
         bdms = self._generate_volume_bdm_list(instance)
         original_bdms = self._generate_volume_bdm_list(instance,
                                                        original=True)
 
-        # Assert that we ignore cinderclient exceptions and continue to attempt
-        # to rollback any remaining bdms.
+        # Assert that we ignore cinderclient exceptions, reset the BDM state
+        # and continue to attempt to rollback any remaining bdms.
         mock_delete_attachment.side_effect = [
             cinder_exception.ClientException(code=9001), None]
         self.compute._rollback_volume_bdms(self.context, bdms,
                 original_bdms, instance)
+        self.assertEqual(uuids.vol1_attach_original,
+                         bdms[0].attachment_id)
+        self.assertEqual("{'data': {'host': 'original'}}",
+                         bdms[0].connection_info)
         self.assertEqual(uuids.vol2_attach_original,
                          bdms[1].attachment_id)
         self.assertEqual("{'data': {'host': 'original'}}",
                          bdms[1].connection_info)
-        bdms[0].save.assert_not_called()
+        bdms[0].save.assert_called_once()
         bdms[1].save.assert_called_once()
         mock_log.warning.assert_called_once()
         self.assertIn('Ignoring cinderclient exception',
                 mock_log.warning.call_args[0][0])
 
+    @mock.patch('nova.compute.manager.LOG')
+    @mock.patch('nova.volume.cinder.API.attachment_delete')
+    def test_rollback_volume_bdms_unknown_exc(
+            self, mock_delete_attachment, mock_log):
+        instance = fake_instance.fake_instance_obj(self.context,
+                                                   uuid=uuids.instance)
+        bdms = self._generate_volume_bdm_list(instance)
+        original_bdms = self._generate_volume_bdm_list(instance,
+                                                       original=True)
+
         # Assert that we raise unknown Exceptions
-        mock_log.reset_mock()
-        bdms[0].save.reset_mock()
-        bdms[1].save.reset_mock()
         mock_delete_attachment.side_effect = test.TestingException
         self.assertRaises(test.TestingException,
             self.compute._rollback_volume_bdms, self.context,

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -21119,12 +21119,20 @@ class LibvirtConnTestCase(test.NoDBTestCase,
     def test_live_migration_hostname_invalid(self, mock_hostname, mock_lm):
         drvr = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), False)
         mock_hostname.return_value = False
+        dest = "foo/?com=/bin/sh"
+        recover_method = mock.MagicMock()
+        migrate_data = objects.LibvirtLiveMigrateData()
         self.assertRaises(exception.InvalidHostname,
                           drvr.live_migration,
                           self.context, self.test_instance,
-                          "foo/?com=/bin/sh",
+                          dest,
                           lambda x: x,
-                          lambda x: x)
+                          recover_method,
+                          migrate_data=migrate_data)
+        recover_method.assert_called_once_with(
+            self.context, self.test_instance, dest, migrate_data)
+        # Verify _live_migration was NOT called
+        mock_lm.assert_not_called()
 
     def test_live_migration_force_complete(self):
         drvr = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), False)

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -14303,7 +14303,11 @@ class LibvirtConnTestCase(test.NoDBTestCase,
     def _test_live_migration_main(self, mock_abort, mock_copy_disk_path,
                                   mock_running, mock_guest, mock_monitor,
                                   mock_thread, mock_conn,
-                                  mon_side_effect=None):
+                                  mon_side_effect=None,
+                                  abort_side_effect=None,
+                                  guest_side_effect=None,
+                                  copy_disk_path_side_effect=None,
+                                  thread_side_effect=None):
         drvr = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), False)
         instance = objects.Instance(**self.test_instance)
 
@@ -14313,47 +14317,103 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         migrate_data = objects.LibvirtLiveMigrateData(block_migration=True)
         disks_to_copy = (['/some/path/one', '/test/path/two'],
                          ['vda', 'vdb'])
-        mock_copy_disk_path.return_value = disks_to_copy
 
+        mock_guest.side_effect = guest_side_effect
         mock_guest.return_value = guest
+        mock_copy_disk_path.side_effect = copy_disk_path_side_effect
+        mock_copy_disk_path.return_value = disks_to_copy
+        mock_thread.side_effect = thread_side_effect
         mock_monitor.side_effect = mon_side_effect
+        mock_abort.side_effect = abort_side_effect
 
         def fake_post():
             pass
 
-        def fake_recover():
-            pass
+        recover_method = mock.MagicMock()
+        dest = "fakehost"
 
-        if mon_side_effect:
-            self.assertRaises(mon_side_effect, drvr._live_migration,
-                              self.context, instance, "fakehost", fake_post,
-                              fake_recover, True, migrate_data)
-            mock_abort.assert_called_once_with(instance)
+        # Determine which exception we expect based on what fails first
+        setup_side_effect = (guest_side_effect or
+                             copy_disk_path_side_effect)
+        side_effect = (setup_side_effect or thread_side_effect or
+                       mon_side_effect)
+        if side_effect:
+            self.assertRaises(side_effect, drvr._live_migration, self.context,
+                              instance, dest, fake_post, recover_method, True,
+                              migrate_data)
         else:
-            drvr._live_migration(self.context, instance, "fakehost", fake_post,
-                                 fake_recover, True, migrate_data)
+            drvr._live_migration(self.context, instance, dest, fake_post,
+                                 recover_method, True, migrate_data)
 
+        if setup_side_effect:
+            # Setup failure
+            recover_method.assert_called_once_with(
+                self.context, instance, dest, migrate_data)
+            return
+
+        mock_guest.assert_called_once_with(instance)
         mock_copy_disk_path.assert_called_once_with(self.context, instance,
                                                     guest)
+        mock_thread.assert_called_once_with(
+            drvr._live_migration_operation,
+            self.context, instance, dest, True,
+            migrate_data, guest, disks_to_copy[1])
+
+        if thread_side_effect:
+            # Thread spawn failure
+            recover_method.assert_not_called()
+            return
 
         class AnyEventletEvent(object):
             def __eq__(self, other):
                 return type(other) == eventlet.event.Event
 
-        mock_thread.assert_called_once_with(
-            drvr._live_migration_operation,
-            self.context, instance, "fakehost", True,
-            migrate_data, guest, disks_to_copy[1])
         mock_monitor.assert_called_once_with(
-            self.context, instance, guest, "fakehost",
-            fake_post, fake_recover, True,
+            self.context, instance, guest, dest,
+            fake_post, recover_method, True,
             migrate_data, AnyEventletEvent(), disks_to_copy[0])
+
+        if mon_side_effect:
+            # Monitoring phase failure
+            mock_abort.assert_called_once_with(instance)
+            # recover_method is only called if abort succeeds
+            if abort_side_effect:
+                recover_method.assert_not_called()
+            else:
+                recover_method.assert_called_once_with(
+                    self.context, instance, dest, migrate_data)
+            return
+
+        recover_method.assert_not_called()
 
     def test_live_migration_main(self):
         self._test_live_migration_main()
 
-    def test_live_migration_main_monitoring_failed(self):
+    def test_live_migration_setup_get_guest_fails(self):
+        # When get_guest fails during setup, recover_method is called
+        self._test_live_migration_main(
+            guest_side_effect=Exception)
+
+    def test_live_migration_setup_copy_disk_paths_fails(self):
+        # When _live_migration_copy_disk_paths fails during setup,
+        # recover_method is called
+        self._test_live_migration_main(
+            copy_disk_path_side_effect=Exception)
+
+    def test_live_migration_spawn_fails(self):
+        # When utils.spawn fails, recover_method should NOT be called
+        self._test_live_migration_main(
+            thread_side_effect=Exception)
+
+    def test_live_migration_monitoring_fails(self):
         self._test_live_migration_main(mon_side_effect=Exception)
+
+    def test_live_migration_monitoring_fails_abort_fails(self):
+        # When monitoring fails and abort also fails (e.g., post-copy mode),
+        # recover_method should NOT be called
+        self._test_live_migration_main(
+            mon_side_effect=Exception,
+            abort_side_effect=fakelibvirt.libvirtError("abort failed"))
 
     @mock.patch.object(host.Host, "get_connection", new=mock.Mock())
     @mock.patch.object(utils, "spawn", new=mock.Mock())
@@ -14380,14 +14440,14 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         instance = objects.Instance(**self.test_instance)
         post_method = mock.Mock()
         migrate_data = mock.Mock()
+        recover_method = mock.Mock()
         disks_to_copy = (['/some/path/one', '/test/path/two'],
                          ['vda', 'vdb'])
         mock_copy_disk_paths.return_value = disks_to_copy
 
         func = drvr._live_migration
         args = (self.context, instance, mock.sentinel.dest, post_method,
-                mock.sentinel.recover_method, mock.sentinel.block_migration,
-                migrate_data)
+                recover_method, mock.sentinel.block_migration, migrate_data)
 
         if expect_success:
             func(*args)

--- a/nova/tests/unit/volume/test_cinder.py
+++ b/nova/tests/unit/volume/test_cinder.py
@@ -831,6 +831,19 @@ class CinderApiTestCase(test.NoDBTestCase):
         mock_attachment.list.assert_called_once_with(search_opts=search_opts)
 
     @mock.patch('nova.volume.cinder.cinderclient')
+    def test_attachment_get_all_all_tenants(self, mock_cinderclient):
+        mock_attachment = mock.MagicMock()
+        mock_cinderclient.return_value = \
+            mock.MagicMock(attachments=mock_attachment)
+
+        instance_id = uuids.instance_id
+        search_opts = {'all_tenants': True, 'instance_id': instance_id}
+        self.api.attachment_get_all(self.ctx, instance_id, all_tenants=True)
+        mock_cinderclient.assert_called_once_with(self.ctx, '3.44',
+                                                  skip_version_check=True)
+        mock_attachment.list.assert_called_once_with(search_opts=search_opts)
+
+    @mock.patch('nova.volume.cinder.cinderclient')
     def test_attachment_get_all_failed(self, mock_cinderclient):
         err = "Either instance or volume id must be passed."
         mock_cinderclient.return_value.attachments.show.side_effect = (

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -10220,8 +10220,14 @@ class LibvirtDriver(driver.ComputeDriver):
         # 'dest' will be substituted into 'migration_uri' so ensure
         # it doesn't contain any characters that could be used to
         # exploit the URI accepted by libvirt
-        if not libvirt_utils.is_valid_hostname(dest):
-            raise exception.InvalidHostname(hostname=dest)
+        try:
+            if not libvirt_utils.is_valid_hostname(dest):
+                LOG.error("Failed live migration due to invalid destination "
+                          f"hostname {dest}", instance=instance)
+                raise exception.InvalidHostname(hostname=dest)
+        except Exception:
+            with excutils.save_and_reraise_exception():
+                recover_method(context, instance, dest, migrate_data)
 
         self._live_migration(context, instance, dest,
                              post_method, recover_method, block_migration,

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -10733,15 +10733,20 @@ class LibvirtDriver(driver.ComputeDriver):
         operation, and then this thread monitors the progress of
         migration and controls its operation
         """
+        try:
+            guest = self._host.get_guest(instance)
 
-        guest = self._host.get_guest(instance)
-
-        disk_paths = []
-        device_names = []
-        if (migrate_data.block_migration and
-                CONF.libvirt.virt_type != "parallels"):
-            disk_paths, device_names = self._live_migration_copy_disk_paths(
-                context, instance, guest)
+            disk_paths = []
+            device_names = []
+            if (migrate_data.block_migration and
+                    CONF.libvirt.virt_type != "parallels"):
+                disk_paths, device_names = \
+                    self._live_migration_copy_disk_paths(context, instance,
+                                                         guest)
+        except Exception:
+            with excutils.save_and_reraise_exception():
+                LOG.exception("Failed live migration setup", instance=instance)
+                recover_method(context, instance, dest, migrate_data)
 
         opthread = utils.spawn(self._live_migration_operation,
                                      context, instance, dest,
@@ -10749,44 +10754,48 @@ class LibvirtDriver(driver.ComputeDriver):
                                      migrate_data, guest,
                                      device_names)
 
-        finish_event = eventlet.event.Event()
-        self.active_migrations[instance.uuid] = deque()
-
-        def thread_finished(thread, event):
-            LOG.debug("Migration operation thread notification",
-                      instance=instance)
-            event.send()
-        opthread.link(thread_finished, finish_event)
-
-        # Let eventlet schedule the new thread right away
-        time.sleep(0)
-
         try:
+            finish_event = eventlet.event.Event()
+            self.active_migrations[instance.uuid] = deque()
+
+            def thread_finished(thread, event):
+                LOG.debug("Migration operation thread notification",
+                          instance=instance)
+                event.send()
+            opthread.link(thread_finished, finish_event)
+
+            # Let eventlet schedule the new thread right away
+            time.sleep(0)
+
             LOG.debug("Starting monitoring of live migration",
                       instance=instance)
             self._live_migration_monitor(context, instance, guest, dest,
                                          post_method, recover_method,
                                          block_migration, migrate_data,
                                          finish_event, disk_paths)
-        except Exception as ex:
-            LOG.warning("Error monitoring migration: %(ex)s",
-                        {"ex": ex}, instance=instance, exc_info=True)
-            # NOTE(aarents): Ensure job is aborted if still running before
-            # raising the exception so this would avoid the migration to be
-            # done and the libvirt guest to be resumed on the target while
-            # the instance record would still related to the source host.
-            try:
-                # If migration is running in post-copy mode and guest
-                # already running on dest host, libvirt will refuse to
-                # cancel migration job.
-                self.live_migration_abort(instance)
-            except libvirt.libvirtError:
-                LOG.warning("Error occured when trying to abort live ",
-                            "migration job, ignoring it.", instance=instance)
-            raise
-        finally:
             LOG.debug("Live migration monitoring is all done",
                       instance=instance)
+        except Exception:
+            with excutils.save_and_reraise_exception():
+                LOG.exception("Error during live migration monitoring",
+                              instance=instance)
+                # NOTE(aarents): Ensure job is aborted if still running before
+                # raising the exception so this would avoid the migration to be
+                # done and the libvirt guest to be resumed on the target while
+                # the instance record would still related to the source host.
+                try:
+                    # If migration is running in post-copy mode and guest
+                    # already running on dest host, libvirt will refuse to
+                    # cancel migration job.
+                    self.live_migration_abort(instance)
+                except libvirt.libvirtError:
+                    LOG.warning("Error occured when trying to abort live ",
+                                "migration job, ignoring it.",
+                                instance=instance)
+                else:
+                    # If the migration job was successfully aborted, call the
+                    # recover_method for cleanup.
+                    recover_method(context, instance, dest, migrate_data)
 
     def _is_post_copy_enabled(self, migration_flags):
         return (migration_flags & libvirt.VIR_MIGRATE_POSTCOPY) != 0

--- a/nova/volume/cinder.py
+++ b/nova/volume/cinder.py
@@ -888,12 +888,16 @@ class API(object):
                            'msg': str(ex),
                            'code': getattr(ex, 'code', None)})
 
-    def attachment_get_all(self, context, instance_id=None, volume_id=None):
-        """Get all attchments by instance id or volume id
+    def attachment_get_all(self, context, instance_id=None, volume_id=None,
+                           all_tenants=False):
+        """Get all attachments by instance id or volume id
 
         :param context: The nova request context.
         :param instance_id: UUID of the instance attachment to get.
         :param volume_id: UUID of the volume attachment to get.
+        :param all_tenants: If True, query attachments across all projects.
+            Requires a context with Cinder admin privileges, e.g. via
+            nova.context.get_admin_context().
         :returns: a list of cinderclient.v3.attachments.VolumeAttachment
             objects.
         """
@@ -903,6 +907,8 @@ class API(object):
 
         search_opts = {}
 
+        if all_tenants:
+            search_opts['all_tenants'] = True
         if instance_id:
             search_opts['instance_id'] = instance_id
         if volume_id:


### PR DESCRIPTION
- Cleanup of orphaned volume attachments for and from live migrations
- Cleanup of orphaned port bindings and volume attachments at the start of evacuations / rebuilds

Details in the commit messages