### PR TITLE
external scheduler: Support retries on RequestException

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -1126,6 +1126,31 @@ external scheduler to respond for this long. If the external scheduler does not
 respond within this time, the request will be aborted. In this case, the
 scheduler will continue with the original host selection and weights.
 """),
+    cfg.IntOpt("external_scheduler_retries",
+        default=0,
+        help="""
+Number of retries to call the external scheduler on errors
+
+When calls to the external scheduler API fail for some reason, Nova will retry
+this many times, sleeping in between.
+
+Related options:
+
+* external_scheduler_retry_sleep_seconds
+"""),
+    cfg.FloatOpt("external_scheduler_retry_sleep_seconds",
+        default=1.0,
+        help="""
+Sleep time in seconds between retries
+
+If the external scheduler is configured for retries through
+external_scheduler_retries, the code sleeps this many seconds between the
+retries.
+
+Related options:
+
+* external_scheduler_retries
+"""),
 ]
 
 metrics_group = cfg.OptGroup(

--- a/nova/scheduler/external.py
+++ b/nova/scheduler/external.py
@@ -20,6 +20,8 @@ The external scheduler API is expected to take a list of weighed hosts and
 their weights, along with the request specification, and return a reordered
 and filtered list of host names.
 """
+import time
+
 import jsonschema
 from oslo_log import log as logging
 import requests
@@ -113,13 +115,35 @@ def call_external_scheduler_api(context, weighed_hosts, weights, spec_obj):
         "weights": weights,
     }
     LOG.debug("Calling external scheduler API with %s", json_data)
-    try:
-        response = requests.post(url, json=json_data, timeout=timeout)
-        response.raise_for_status()
-        # If the JSON parsing fails, this will also raise a RequestException.
-        response_json = response.json()
-    except requests.RequestException as e:
-        LOG.error("Failed to call external scheduler API: %s", e)
+    # retries + 1 to make at least one try
+    tries = CONF.filter_scheduler.external_scheduler_retries + 1
+    for current_try in range(1, tries + 1):
+        try:
+            response = requests.post(url, json=json_data, timeout=timeout)
+            response.raise_for_status()
+            # If the JSON parsing fails, this will also raise a
+            # RequestException.
+            response_json = response.json()
+            break
+        except requests.RequestException as e:
+            response = getattr(e, 'response', None)
+            if response is not None and response.status_code == 400:
+                LOG.error("Failed to call external scheduler API: %s", e)
+                # If we can't reach the external scheduler we return the
+                # original list of weighed hosts.
+                return weighed_hosts
+
+            LOG.error("Failed to call external scheduler API (attempt %d/%d): "
+                      "%s", current_try, tries, e)
+            sleep_time = \
+                CONF.filter_scheduler.external_scheduler_retry_sleep_seconds
+            if current_try < tries and sleep_time > 0:
+                LOG.debug("Sleeping %d second between external scheduler API "
+                          "calls", sleep_time)
+                time.sleep(sleep_time)
+    else:
+        # If we can't reach the external scheduler we return the original list
+        # of weighed hosts.
         return weighed_hosts
 
     # The external scheduler api is expected to return a json with

--- a/nova/tests/unit/scheduler/test_external.py
+++ b/nova/tests/unit/scheduler/test_external.py
@@ -14,16 +14,20 @@
 
 # Tests for external scheduler api.
 
+from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import requests
 
+import nova.conf
 from nova import context
 from nova import objects
 from nova.scheduler.external import call_external_scheduler_api
 from nova import test
 from nova.tests.unit.scheduler import fakes
+
+CONF = nova.conf.CONF
 
 
 class ExternalSchedulerAPITestCase(test.NoDBTestCase):
@@ -164,7 +168,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
 
         log = ""
 
-        def append_log(msg, data):
+        def append_log(msg, *data):
             nonlocal log
             log += msg % data
         mock_debug_log.side_effect = append_log
@@ -207,7 +211,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
 
         log = ""
 
-        def append_log(msg, data):
+        def append_log(msg, *data):
             nonlocal log
             log += msg % data
         mock_err_log.side_effect = append_log
@@ -223,7 +227,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
             ['host1', 'host2', 'host3'],
             [h.host for h in hosts]
         )
-        self.assertIn('Failed to call external scheduler API: ', log)
+        self.assertIn('Failed to call external scheduler API (attempt 1/', log)
 
     @patch('requests.post')
     @patch('nova.scheduler.external.LOG.error')
@@ -237,7 +241,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
 
         log = ""
 
-        def append_log(msg, data):
+        def append_log(msg, *data):
             nonlocal log
             log += msg % data
         mock_err_log.side_effect = append_log
@@ -266,7 +270,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
     def test_enabled_api_json_decode_err(self, mock_err_log, mock_post):
         log = ""
 
-        def append_log(msg, data):
+        def append_log(msg, *data):
             nonlocal log
             log += msg % data
         mock_err_log.side_effect = append_log
@@ -288,7 +292,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
             ['host1', 'host2', 'host3'],
             [h.host for h in hosts]
         )
-        self.assertIn('Failed to call external scheduler API: ', log)
+        self.assertIn('Failed to call external scheduler API (attempt 1/', log)
 
     @patch('requests.post')
     @patch('nova.scheduler.external.LOG.error')
@@ -297,7 +301,7 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
 
         log = ""
 
-        def append_log(msg, data):
+        def append_log(msg, *data):
             nonlocal log
             log += msg % data
         mock_err_log.side_effect = append_log
@@ -313,4 +317,159 @@ class ExternalSchedulerAPITestCase(test.NoDBTestCase):
             ['host1', 'host2', 'host3'],
             [h.host for h in hosts]
         )
+        self.assertIn('Failed to call external scheduler API (attempt 1/', log)
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.error')
+    @patch('time.sleep')
+    def test_enabled_api_error_reply_retries(self, mock_sleep, mock_err_log,
+            mock_post):
+        CONF.set_override('external_scheduler_retries', 2,
+                          group='filter_scheduler')
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_post.side_effect = (requests.exceptions.HTTPError,
+            requests.exceptions.HTTPError, requests.exceptions.HTTPError)
+
+        log = ""
+
+        def append_log(msg, *data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API (attempt 1/', log)
+        self.assertIn('Failed to call external scheduler API (attempt 2/', log)
+        self.assertIn('Failed to call external scheduler API (attempt 3/', log)
+
+        sleep_time = \
+            CONF.filter_scheduler.external_scheduler_retry_sleep_seconds
+        mock_sleep.assert_has_calls([call(sleep_time), call(sleep_time)])
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.error')
+    @patch('time.sleep')
+    def test_enabled_api_error_reply_retries_and_working(self, mock_sleep,
+            mock_err_log, mock_post):
+        CONF.set_override('external_scheduler_retries', 2,
+                          group='filter_scheduler')
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {'hosts': ['host1', 'host3']}
+
+        mock_post.side_effect = (requests.exceptions.HTTPError,
+            requests.exceptions.HTTPError, mock_response)
+
+        log = ""
+
+        def append_log(msg, *data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host3'],
+            [h.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API (attempt 1/', log)
+        self.assertIn('Failed to call external scheduler API (attempt 2/', log)
+        self.assertNotIn('Failed to call external scheduler API (attempt 3/',
+                         log)
+
+        sleep_time = \
+            CONF.filter_scheduler.external_scheduler_retry_sleep_seconds
+        mock_sleep.assert_has_calls([call(sleep_time), call(sleep_time)])
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.error')
+    @patch('time.sleep')
+    def test_enabled_api_error_reply_retries_no_sleep(self, mock_sleep,
+            mock_err_log, mock_post):
+        CONF.set_override('external_scheduler_retries', 1,
+                          group='filter_scheduler')
+        CONF.set_override('external_scheduler_retry_sleep_seconds', -1,
+                          group='filter_scheduler')
+
+        mock_post.side_effect = (requests.exceptions.HTTPError,
+            requests.exceptions.HTTPError)
+
+        log = ""
+
+        def append_log(msg, *data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.host for h in hosts]
+        )
+        self.assertIn('Failed to call external scheduler API (attempt 1/', log)
+        self.assertIn('Failed to call external scheduler API (attempt 2/', log)
+
+        mock_sleep.assert_not_called()
+
+    @patch('requests.post')
+    @patch('nova.scheduler.external.LOG.error')
+    def test_enabled_api_error_reply_no_retry_on_400(self, mock_err_log,
+            mock_post):
+        CONF.set_override('external_scheduler_retries', 1,
+                          group='filter_scheduler')
+
+        mock_error = requests.exceptions.HTTPError()
+        mock_error.response = MagicMock()
+        mock_error.response.status_code = 400
+
+        mock_post.side_effect = mock_error
+
+        log = ""
+
+        def append_log(msg, *data):
+            nonlocal log
+            log += msg % data
+        mock_err_log.side_effect = append_log
+
+        hosts = call_external_scheduler_api(
+            self.example_ctx,
+            self.example_hosts,
+            self.example_weights,
+            self.example_spec,
+        )
+
+        # Should fallback to the original host list.
+        self.assertEqual(
+            ['host1', 'host2', 'host3'],
+            [h.host for h in hosts]
+        )
         self.assertIn('Failed to call external scheduler API: ', log)
+        self.assertNotIn('Failed to call external scheduler API (attempt 1/',
+                         log)


### PR DESCRIPTION
When the external scheduler is down for a short period of time during its deployment, all requests might fail scheduling. Since we don't want that, we implement the possibility for retries, optionally with waiting a some time before trying again.

The number of retries (default 0) can be configured with `[filter_scheduler]/external_scheduler_retries`, while the amount of seconds Nova should sleep in between retries can be set via `[filter_scheduler]/external_scheduler_retry_sleep_seconds`.

Change-Id: Idbfee561e0cffb4ef59c95157a6a9b2c9073622c