### PR TITLE
Fix DifferentHostFilter and SameHostFilter returning None

### DIFF
--- a/nova/scheduler/filters/affinity_filter.py
+++ b/nova/scheduler/filters/affinity_filter.py
@@ -42,7 +42,7 @@ class DifferentHostFilter(filters.BaseHostFilter):
     def host_info_requiring_instance_ids(self, spec_obj):
         different_host = spec_obj.get_scheduler_hint('different_host')
         if not different_host:
-            return different_host
+            return set()
 
         if isinstance(different_host, str):
             return set([different_host])
@@ -70,7 +70,7 @@ class SameHostFilter(filters.BaseHostFilter):
     def host_info_requiring_instance_ids(self, spec_obj):
         same_host = spec_obj.get_scheduler_hint('same_host')
         if not same_host:
-            return same_host
+            return set()
 
         if isinstance(same_host, str):
             return set([same_host])

--- a/nova/tests/unit/scheduler/test_host_filters.py
+++ b/nova/tests/unit/scheduler/test_host_filters.py
@@ -16,6 +16,7 @@ Tests For Scheduler Host Filters.
 """
 from unittest import mock
 
+from nova import objects
 from nova.scheduler import filters
 from nova.scheduler.filters import all_hosts_filter
 from nova.scheduler.filters import compute_filter
@@ -51,3 +52,26 @@ class HostFiltersTestCase(test.NoDBTestCase):
         filt_cls = all_hosts_filter.AllHostsFilter()
         host = fakes.FakeHostState('host1', 'node1', {})
         self.assertTrue(filt_cls.host_passes(host, {}))
+
+    def test_all_filters_host_info_requiring_instance_ids_is_iterable(self):
+        """All filters must return an iterable (set) from
+           host_info_requiring_instance_ids.
+
+        HostFilterHandler calls set.update() on each filter's return value, so
+        returning None causes TypeError: 'NoneType' object is not iterable.
+        """
+        filter_handler = filters.HostFilterHandler()
+        all_filter_classes = filter_handler.get_matching_classes(
+            ['nova.scheduler.filters.all_filters'])
+        spec_obj = objects.RequestSpec(
+            context=mock.sentinel.ctx,
+            scheduler_hints=None,
+            instance_group=None)
+        for filter_cls in all_filter_classes:
+            result = filter_handler.host_info_requiring_instance_ids(
+                [filter_cls()], spec_obj)
+            self.assertIsInstance(
+                result, set,
+                '%s.host_info_requiring_instance_ids() must return a set '
+                '(contract of BaseHostFilter), got %r' % (
+                    filter_cls.__name__, result))


### PR DESCRIPTION
host_info_requiring_instance_ids() must always return an iterable. When no scheduler hint is set, return set() instead of None.

HostFilterHandler calls set.update() on each filter's return value, so None causes TypeError: 'NoneType' object is not iterable. BaseHostFilter already returns set() as the correct default; this fix aligns the two subclasses with that contract.

Fixup-For: I3ea05f98e300bbf0e4b0b42ad334e86d34b21ab6
Fixup-For: Ibb69e15654ec6818a1bc920b1c8197f6a3c52080
Change-Id: I9e4b74820d914efa8dfbcd2b9e5e51767a49fcfd