### PR TITLE
Enable multi-queue support for virtio-net with Cloud Hypervisor

### DIFF
--- a/nova/virt/libvirt/config.py
+++ b/nova/virt/libvirt/config.py
@@ -1866,6 +1866,7 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
         if (self.driver_name or
                 self.driver_iommu or
                 self.driver_packed or
+                self.vhost_queues or
                 self.net_type == "vhostuser"):
 
             drv_elem = etree.Element("driver")

--- a/nova/virt/libvirt/vif.py
+++ b/nova/virt/libvirt/vif.py
@@ -236,6 +236,10 @@ class LibvirtGenericVIFDriver(object):
             # use vhost and not None.
             driver = vhost_drv or driver
 
+        if virt_type == 'ch':
+            _, vhost_queues = self._get_virtio_mq_settings(
+                image_meta, flavor)
+
         if driver == 'vhost' or driver is None:
             # vhost backend only supports update of RX queue size
             if rx_queue_size:


### PR DESCRIPTION
This PR contains the necessary changes to support multi-queue configuration for virtio-net devices, if properly specified via the flavor.

Previously, multi-queue configuration was only passed through to Libvirt if QEMU/KVM was in use, and it was coupled to using vhost as a driver.

We decoupled it from vhost and support it if CH is currently used as a `virt_type`.

The resulting domain XML looks like:
```xml
<driver queues='2'/>
```

while the number of queues scales with the number of vCPUs by default, or some user specified value.

We have added a test in our internal CI which spawns a VM with some flavor that enables multiqueue. The test runs successfully.