### PR TITLE
add support for windows guest operating system with cloud hypervisor

### DIFF
--- a/nova/virt/libvirt/config.py
+++ b/nova/virt/libvirt/config.py
@@ -2808,6 +2808,18 @@ class LibvirtConfigGuestFeatureKvmHidden(LibvirtConfigGuestFeature):
         return root
 
 
+class LibvirtConfigGuestFeatureChvWindowsGuest(LibvirtConfigGuestFeature):
+
+    def __init__(self, **kwargs):
+        super().__init__("hyperv", **kwargs)
+        self.mode = "passthrough"
+
+    def format_dom(self):
+        root = super().format_dom()
+        root.set('hyperv', self.mode)
+        return root
+
+
 class LibvirtConfigGuestFeatureSMM(LibvirtConfigGuestFeature):
 
     def __init__(self, **kwargs):

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -6309,6 +6309,16 @@ class LibvirtDriver(driver.ComputeDriver):
 
             guest.features.append(hv)
 
+        if (
+            CONF.libvirt.virt_type == "ch" and
+            image_meta.properties.get('os_type') == 'windows'
+        ):
+            LOG.info(
+                "Set cloud hypervisor settings for windows "
+                "operating system via libvirt")
+            ch_win = vconfig.LibvirtConfigGuestFeatureChvWindowsGuest()
+            guest.features.append(ch_win)
+
         if CONF.libvirt.virt_type in ("qemu", "kvm"):
             # vmcoreinfo support is x86, ARM-only for now
             guestarch = self._check_emulation_arch(image_meta)


### PR DESCRIPTION
This PR contains the necessary changes to support windows operating systems with cloud hypervisor.

The resulting libvirt xml should look like:

```xml
<domain type='kvm'>
  <name>instance-00000003</name>
  [...]
  <features>
    <hyperv mode='custom'/>
  </features>
  [...]
</domain>
```

Windows Images should have properties:
* hw_disk_bus=virtio
* os_type=windows