### PR TITLE
Revert chv multi queue support

### DIFF
--- a/nova/virt/libvirt/config.py
+++ b/nova/virt/libvirt/config.py
@@ -1866,7 +1866,6 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
         if (self.driver_name or
                 self.driver_iommu or
                 self.driver_packed or
-                self.vhost_queues or
                 self.net_type == "vhostuser"):
 
             drv_elem = etree.Element("driver")

--- a/nova/virt/libvirt/vif.py
+++ b/nova/virt/libvirt/vif.py
@@ -236,10 +236,6 @@ class LibvirtGenericVIFDriver(object):
             # use vhost and not None.
             driver = vhost_drv or driver
 
-        if virt_type == 'ch':
-            _, vhost_queues = self._get_virtio_mq_settings(
-                image_meta, flavor)
-
         if driver == 'vhost' or driver is None:
             # vhost backend only supports update of RX queue size
             if rx_queue_size:


### PR DESCRIPTION
This feature triggers a bug in cloud-hypervisor when a vm is suspended or during a managed save. Disable it until the issue is resolved. See https://github.com/cobaltcore-dev/cobaltcore/issues/473