### PR TITLE
Reenable multi queue support for cloud-hypervisor

### DIFF
--- a/nova/virt/libvirt/config.py
+++ b/nova/virt/libvirt/config.py
@@ -1866,6 +1866,7 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
         if (self.driver_name or
                 self.driver_iommu or
                 self.driver_packed or
+                self.vhost_queues or
                 self.net_type == "vhostuser"):
 
             drv_elem = etree.Element("driver")

--- a/nova/virt/libvirt/vif.py
+++ b/nova/virt/libvirt/vif.py
@@ -262,6 +262,10 @@ class LibvirtGenericVIFDriver(object):
             # use vhost and not None.
             driver = vhost_drv or driver
 
+        if virt_type == 'ch':
+            _, vhost_queues = self._get_virtio_mq_settings(
+                image_meta, flavor)
+
         if driver == 'vhost' or driver is None:
             # vhost backend only supports update of RX queue size
             if rx_queue_size:


### PR DESCRIPTION
Re-enable multiqueue support for cloud-hypervisor.

In https://github.com/sapcc/nova/pull/609, we disabled multi-queue support due to a bug (see https://github.com/cobaltcore-dev/cobaltcore/issues/473)

This has been fixed in https://github.com/cyberus-technology/cloud-hypervisor/pull/116, thus, we can enable multi-queue support again.

**Important:** do not roll this out until all nodes have been updated to gardenlinux 1877.13.8