### PR TITLE
Add JSON schema validation for hw_version_* quota

### DIFF
--- a/nova/api/openstack/compute/schemas/quota_sets.py
+++ b/nova/api/openstack/compute/schemas/quota_sets.py
@@ -63,7 +63,8 @@ update = {
         'quota_set': {
             'properties': update_quota_set,
             'patternProperties': {
-                '^instances_': common_quota
+                '^instances_': common_quota,
+                r'^hw_version_\d+_(cores|ram)$': common_quota
             },
             'additionalProperties': False,
         },


### PR DESCRIPTION
When we have custom quota on flavors defined via `quota:hw_version`, we need to allow setting quota for this. Until now, we only allowed custom quota following the `^instances_` regex. Therefore, when setting quota for a hardware version, the client would get back an error along the lines of

	'hw_version_2101_cores', 'hw_version_2101_ram' do not match any of the regexes: '^instances_'

Change-Id: I378bdd4ed54ac0b92b8021a2c6567f92c6981e4f