### PR TITLE
quota: Fix hw_version cores/ram counting

### DIFF
--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -1770,15 +1770,20 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
             if itype and itype.get('separate', False):
                 t_name = f"instances_{itype['name']}"
                 counts[t_name] = counts.get(t_name, 0) + instance_count
-            elif itype and (hw_version := itype.get('hw_version')):
+            else:
                 counts['instances'] += instance_count
+
+            # only count cores/ram if we do not explicitly disable it by
+            # QUOTA_INSTANCE_ONLY_KEY
+            if itype and itype.get('instance_only', False):
+                continue
+
+            if itype and (hw_version := itype.get('hw_version')):
                 cores_name = f"hw_version_{hw_version}_cores"
                 counts[cores_name] = counts.get(cores_name, 0) + int(cores)
                 ram_name = f"hw_version_{hw_version}_ram"
                 counts[ram_name] = counts.get(ram_name, 0) + int(ram)
             else:
-                counts['instances'] += instance_count
-            if not itype or not itype.get('instance_only', False):
                 counts['cores'] += int(cores)
                 counts['ram'] += int(ram)
 


### PR DESCRIPTION
When reporting quota with flavors having quota:hw_version properties i.e. flavors where we enforce and count a different type of cores/ram quota, we used to falsely also count the cores/ram into normal cores/ram usage.

This seems to have happened because of some code changes between writing the hw_version-quota patches and merging them. The changes came in as fixes for `quota:seaprate` and `quota:instance_only` handling.

Change-Id: I8c689ac4f9970852c05218ece574755e1acf6312
Fixup-For: Ic1c79dab1e6a8619e68e1467888a500b5f8dcf71