### PR TITLE
libvirt/chv: Support re-sending RARP packages

### DIFF
--- a/nova/conf/workarounds.py
+++ b/nova/conf/workarounds.py
@@ -471,6 +471,53 @@ known-features detection *before* passing the image to qemu-img. Generally,
 this inspection should be enabled for maximum safety, but this workaround
 option allows disabling it if there is a compatibility concern.
 """),
+    cfg.BoolOpt('enable_chv_announce_self',
+                default=False,
+                help="""
+If it is set to True the libvirt driver will try as a best effort to send
+the vm.post-migration-announce command to chv so that it generates RARP frames
+to update network switches in the post live migration phase on the destination.
+
+Related options:
+
+* :oslo.config:option:`DEFAULT.compute_driver` (libvirt)
+"""),
+    cfg.IntOpt('chv_announce_self_count',
+                default=3,
+                min=1,
+                help="""
+The total number of times to send the vm.post-migration-announce command to chv
+when enable_chv_announce_self is enabled.
+
+Related options:
+
+* :oslo.config:option:`WORKAROUNDS.enable_chv_announce_self` (libvirt)
+"""),
+    cfg.IntOpt('chv_announce_self_interval',
+                default=1,
+                min=1,
+                help="""
+The number of seconds to wait before re-sending the announce_self
+command to chv.
+
+Related options:
+
+* :oslo.config:option:`WORKAROUNDS.enable_chv_announce_self` (libvirt)
+"""),
+    cfg.StrOpt('chv_socket_path_template',
+               default="/run/libvirt/ch/%s-socket",
+               help="""
+A template for the path to the cloud hypervisor socket for an instance.
+
+Since there is no libvirt support for chv's vm.post-migration-announce command,
+the libvirt driver has to talk directly to the unix-domain socket created by
+chv. To get the socket path, the driver will template this string with the
+Instance.name.
+
+Related options:
+
+* :oslo.config:option:`WORKAROUNDS.enable_chv_announce_self` (libvirt)
+"""),
 ]
 
 

--- a/nova/privsep/libvirt.py
+++ b/nova/privsep/libvirt.py
@@ -27,6 +27,7 @@ from oslo_concurrency import processutils
 from oslo_log import log as logging
 from oslo_utils import units
 from oslo_utils import uuidutils
+import requests_unixsocket
 
 import nova.privsep
 
@@ -224,6 +225,13 @@ def readpty(path):
             'Ignored error while reading from instance console pty: %s', exc
         )
         return ''
+
+
+@nova.privsep.sys_admin_pctxt.entrypoint
+def chv_socket_request(request_type, request_url):
+    with requests_unixsocket.Session() as session:
+        resp = getattr(session, request_type)(request_url)
+        return resp.status_code, resp.text
 
 
 @nova.privsep.sys_admin_pctxt.entrypoint

--- a/nova/virt/libvirt/chv_client.py
+++ b/nova/virt/libvirt/chv_client.py
@@ -1,0 +1,57 @@
+# Copyright 2025 SAP SE
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import urllib.parse
+
+import nova.conf
+import nova.privsep.libvirt
+
+CONF = nova.conf.CONF
+
+
+class ChvClientError(Exception):
+    pass
+
+
+class ChvClient:
+
+    def __init__(self, instance):
+        if not (path_template := CONF.workarounds.chv_socket_path_template):
+            raise ChvClientError(
+                '[workarounds]/chv_socket_path_template is not set.')
+
+        try:
+            socket_path = path_template % (instance.name, )
+        except Exception as e:
+            raise ChvClientError("Could not template [workarounds]/"
+                f"chv_socket_path_template ({path_template}) with "
+                f"{instance.name}: {e}")
+
+        quoted_socket_path = urllib.parse.quote_plus(socket_path)
+        self._base_url = f"http+unix://{quoted_socket_path}/api/v1"
+
+    def post_migration_announce(self):
+        """Calls the VM's vm.post-migration-announce endpoint
+
+        Raises ChvClientError if the response is not an HTTP 204
+        """
+        url = f"{self._base_url}/vm.post-migration-announce"
+        try:
+            status_code, resp_text = \
+                nova.privsep.libvirt.chv_socket_request('put', url)
+        except Exception as e:
+            raise ChvClientError(e) from e
+
+        if status_code != 204:
+            raise ChvClientError("vm.post-migration-announce returned "
+                f"{status_code} instead of 204: {resp_text}")

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -113,6 +113,7 @@ from nova.virt import hardware
 from nova.virt.image import model as imgmodel
 from nova.virt import images
 from nova.virt.libvirt import blockinfo
+from nova.virt.libvirt import chv_client
 from nova.virt.libvirt import config as vconfig
 from nova.virt.libvirt.cpu import api as libvirt_cpu
 from nova.virt.libvirt import designer
@@ -11342,6 +11343,50 @@ class LibvirtDriver(driver.ComputeDriver):
                      'max_attempts': max_attempts}, instance=instance)
                 LOG.exception()
 
+    def _chv_announce_self(self, instance):
+        # NOTE(jkulik): Try to keep it in sync with
+        # _qemu_monitor_announce_self() above!
+        if not CONF.workarounds.enable_chv_announce_self:
+            return
+
+        try:
+            client = chv_client.ChvClient(instance)
+        except Exception as e:
+            LOG.warning("Could not create a ChvClient for sending "
+                        "announce-self command: %s.", e)
+            return
+
+        current_attempt = 0
+
+        max_attempts = (
+            CONF.workarounds.chv_announce_self_count)
+        # chv_announce_retry_interval specified in seconds
+        announce_pause = (
+            CONF.workarounds.chv_announce_self_interval)
+
+        while(current_attempt < max_attempts):
+            # Increment attempt
+            current_attempt += 1
+
+            # Only use announce_pause after the first attempt to avoid
+            # pausing before calling announce_self for the first attempt
+            if current_attempt != 1:
+                greenthread.sleep(announce_pause)
+
+            LOG.info('Sending announce-self command to chv. '
+                     'Attempt %(current_attempt)s of %(max_attempts)s',
+                     {'current_attempt': current_attempt,
+                      'max_attempts': max_attempts}, instance=instance)
+            try:
+                client.post_migration_announce()
+            except Exception:
+                LOG.warning('Failed to send announce-self command to '
+                    'chv. Attempt %(current_attempt)s of '
+                    '%(max_attempts)s',
+                    {'current_attempt': current_attempt,
+                     'max_attempts': max_attempts}, instance=instance)
+                LOG.exception("Failed to send announce-self")
+
     def post_live_migration_at_destination(self, context,
                                            instance,
                                            network_info,
@@ -11358,6 +11403,7 @@ class LibvirtDriver(driver.ComputeDriver):
         """
         self._reattach_instance_vifs(context, instance, network_info)
         self._qemu_monitor_announce_self(instance)
+        self._chv_announce_self(instance)
 
     def _get_instance_disk_info_from_config(self, guest_config,
                                             block_device_info):

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,3 +65,5 @@ futurist>=1.8.0 # Apache-2.0
 openstacksdk>=0.35.0 # Apache-2.0
 PyYAML>=5.1 # MIT
 packaging>=21.0  # Apache-2.0
+
+requests-unixsocket>=0.3.0


### PR DESCRIPTION
Like already implemented for qemu, we implement an optional workaround into the libvirt driver that allows Nova to request re-sending of RARP packages after the live-migration finished.

This is only required as workaround if the network isn't fast enough available on the target hypervisor side.

We implement a new `ChvClient` here to encapsulate talking to the cloud hypervisor instance socket. This keeps the `_chv_announce_self()` method closer to `_qemu_monitor_announce_self()` and allows us to re-use it for any future workarounds.

Since the sockets are not world-writable and owned by root:root, we need to move the actual sending of the request into a privsep helper. We keep it as simple as possible right now, since we don't require more than a request_type and an URL.

Change-Id: Icebd0c346545e8fdda1270a86ece147bf2004a16