### PR TITLE
libvirt: fix _live_migration logging

### DIFF
--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -10836,7 +10836,7 @@ class LibvirtDriver(driver.ComputeDriver):
                     # cancel migration job.
                     self.live_migration_abort(instance)
                 except libvirt.libvirtError:
-                    LOG.warning("Error occured when trying to abort live ",
+                    LOG.warning("Error occurred when trying to abort live "
                                 "migration job, ignoring it.",
                                 instance=instance)
                 else:


### PR DESCRIPTION
Fix a logging bug in the LibVirt driver's `_live_migration` method that was introduced by commit `88b00b69da0dddef45ac29e097938ee9a910fb26`.

Also fix a typo in the log message.