### PR TITLE
Fix JSON roundtrip for hw_supported_* image attributes

### DIFF
--- a/nova/objects/image_meta.py
+++ b/nova/objects/image_meta.py
@@ -723,12 +723,17 @@ class ImageMetaProps(base.NovaObject):
             elif key in self._SET_FIELD_NAMES:
                 # SAP: Set-typed fields accept a comma-separated string from
                 # Glance (e.g. "virtio,e1000") or an already-parsed Python set.
+                # A list may also arrive when the value was serialised to JSON
+                # (e.g. via RPC transport or system_metadata) and then
+                # deserialised back.
                 if key not in image_props:
                     continue
                 value = image_props[key]
                 if isinstance(value, str):
                     value = {v.strip() for v in value.split(',')
                              if v.strip()}
+                elif isinstance(value, list):
+                    value = set(value)
                 setattr(self, key, value)
             else:
                 # traits_required will be populated by

--- a/nova/tests/unit/objects/test_image_meta.py
+++ b/nova/tests/unit/objects/test_image_meta.py
@@ -643,3 +643,27 @@ class TestImageMetaProps(test.NoDBTestCase):
             objects.ImageMetaProps.from_dict,
             props,
         )
+
+    # JSON round-trip converts sets to list
+    @ddt.data(
+        # a bit redundant to test all three fields as it is the same code,
+        # but it doesn't cost us much
+        ('hw_supported_disk_buses', ['virtio', 'scsi'],
+                                    {'virtio', 'scsi'}),
+        ('hw_supported_scsi_models', ['virtio-scsi', 'lsilogic'],
+                                    {'virtio-scsi', 'lsilogic'}),
+        ('hw_supported_vif_models', ['virtio', 'e1000'],
+                                    {'virtio', 'e1000'}),
+    )
+    @ddt.unpack
+    def test_hw_supported_from_list(self, prop_name, value, expected):
+        """hw_supported_* fields must accept a list (JSON deserialization path).
+
+        During cold migration the image dict arrives from JSON, where Python
+        sets are serialised as arrays.  from_dict() must convert them back to
+        a set instead of passing the list directly to the oslo.versionedobjects
+        Set field coerce(), which raises ValueError for non-set inputs.
+        """
+        props = {prop_name: value}
+        result = objects.ImageMetaProps.from_dict(props)
+        self.assertEqual(expected, getattr(result, prop_name))


### PR DESCRIPTION
When doing a migration, the image attributes are serialized to JSON (or msgpack) and the set becomes a list. Fix the type coercion in that case to a set as well.

Fixes: I257a24adfdde1ad2e604c1d9b160e38cf4d53e14
Change-Id: I5580bdc7539454cad8a5cb522ec6a4039c4b2fce