### PR TITLE
conductor: reset placement and auth clients after fork

### DIFF
--- a/nova/scheduler/client/report.py
+++ b/nova/scheduler/client/report.py
@@ -113,6 +113,18 @@ def report_client_singleton():
     return PLACEMENTCLIENT
 
 
+def reset_report_client():
+    """Reset the placement report client singleton.
+
+    Must be called in each child process after os.fork() to ensure the
+    child does not share a pre-fork SDK adapter (and any associated HTTP
+    connections or auth state) with other child processes or the parent.
+    Analogous to clearing nova.context.CELL_CACHE after fork.
+    """
+    global PLACEMENTCLIENT
+    PLACEMENTCLIENT = None
+
+
 def safe_connect(f):
     @functools.wraps(f)
     def wrapper(self, *a, **k):

--- a/nova/service.py
+++ b/nova/service.py
@@ -39,6 +39,8 @@ from nova import objects
 from nova.objects import base as objects_base
 from nova.objects import service as service_obj
 from nova import rpc
+from nova.scheduler.client import report as report_client
+from nova import service_auth
 from nova import servicegroup
 from nova import utils
 from nova import version
@@ -152,6 +154,18 @@ class Service(service.Service):
         # require python 3.7 as a mininum version, we must handle the situation
         # outside of oslo.db.
         context.CELL_CACHE = {}
+        # NOTE: Reset the placement report client singleton so each forked
+        # worker process creates its own fresh SDK adapter (with independent
+        # HTTP connection pool and keystoneauth token cache) rather than
+        # sharing the pre-fork object inherited from the parent process.
+        # This is analogous to the CELL_CACHE reset above.
+        # See https://bugs.python.org/issue6721 for the general fork-safety
+        # concern.
+        report_client.reset_report_client()
+        # NOTE: Reset the keystoneauth service-user auth plugin singleton so
+        # each forked worker process obtains its own independent token cache
+        # rather than sharing the pre-fork object.
+        service_auth.reset_globals()
 
         verstr = version.version_string_with_package()
         LOG.info('Starting %(topic)s node (version %(version)s)',

--- a/nova/service_auth.py
+++ b/nova/service_auth.py
@@ -25,7 +25,7 @@ _SERVICE_AUTH = None
 
 
 def reset_globals():
-    """For async unit test consistency."""
+    """For async unit test consistency and not sharing sockets after fork."""
     global _SERVICE_AUTH
     _SERVICE_AUTH = None
 


### PR DESCRIPTION
ConductorManager accesses the placement report client singleton during
__init__, which eagerly creates a keystoneauth session and an openstacksdk
Connection object including the underlying urllib3 connection pool.
When the ProcessLauncher then forks worker processes, all workers inherit
that shared pool.  Concurrent use of the same socket from independent
processes is unsafe.  Reset both the placement client and the auth globals
on worker start so each process builds its own connection pool.

Change-Id: I8cfce1f9e1d5af57cd9718ba6ea202965a33fa90
