### PR TITLE
Backports: Reset mapping on delete

### DIFF
--- a/nova/db/main/api.py
+++ b/nova/db/main/api.py
@@ -383,18 +383,18 @@ def service_destroy(context, service_id):
     if service.binary == 'nova-compute':
         # TODO(sbauza): Remove the service_id filter in a later release
         # once we are sure that all compute nodes report the host field
-        query = model_query(context, models.ComputeNode).\
-            filter(sql.or_(
-            models.ComputeNode.service_id == service_id,
-            models.ComputeNode.host == service['host']))
-
-        # NOTE(jlejeune): Make sure that the mapped field is set to 0
+        # NOTE(jlejeune): Make sure that the mapped field of the
+        # relevant compute nodes is set to 0
         # See https://bugs.launchpad.net/nova/+bug/2085135.
-        compute_ref = query.first()
-        if compute_ref:
-            compute_ref.update({'mapped': 0})
-
-        query.soft_delete(synchronize_session=False)
+        model_query(context, models.ComputeNode).\
+            filter(sql.or_(
+                models.ComputeNode.service_id == service_id,
+                models.ComputeNode.host == service['host'])).\
+            update({'deleted': models.ComputeNode.id,
+                    'updated_at': models.ComputeNode.updated_at,
+                    'deleted_at': timeutils.utcnow(),
+                    'mapped': 0},
+                   synchronize_session=False)
 
 
 @pick_context_manager_reader

--- a/nova/test.py
+++ b/nova/test.py
@@ -448,6 +448,8 @@ class TestCase(base.BaseTestCase):
             ctxt = context.get_context()
             cell_name = cell_name or CELL1_NAME
             cell = self.cell_mappings[cell_name]
+            svc = self.useFixture(
+                nova_fixtures.ServiceFixture(name, host, cell=cell, **kwargs))
             if (host or name) not in self.host_mappings:
                 # NOTE(gibi): If the HostMapping does not exists then this is
                 # the first start of the service so we create the mapping.
@@ -456,8 +458,19 @@ class TestCase(base.BaseTestCase):
                                          cell_mapping=cell)
                 hm.create()
                 self.host_mappings[hm.host] = hm
-        svc = self.useFixture(
-            nova_fixtures.ServiceFixture(name, host, cell=cell, **kwargs))
+
+                # NOTE(jlejeune): update the compute node's mapped field
+                # like it's done in _check_and_create_node_host_mappings()
+                # function.
+                with context.target_cell(ctxt, cell) as cctxt:
+                    node = objects.ComputeNode.get_by_service_id(
+                        context=cctxt,
+                        service_id=svc.service.service_ref.id)
+                    node.mapped = 1
+                    node.save()
+        else:
+            svc = self.useFixture(
+                nova_fixtures.ServiceFixture(name, host, cell=cell, **kwargs))
 
         # Keep track of how many instances of this service are running.
         self._service_fixture_count[name] += 1

--- a/nova/tests/functional/regressions/test_bug_2085135.py
+++ b/nova/tests/functional/regressions/test_bug_2085135.py
@@ -1,0 +1,75 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from nova import context
+from nova.db.main import api as db
+from nova import exception
+from nova import objects
+from nova.objects import host_mapping
+from nova import test
+from nova.tests import fixtures
+from nova import utils
+
+
+class HostMappingDiscoveryTestFail(test.TestCase):
+    """Regression test for bug 2085135
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.ctxt = context.get_admin_context()
+
+        api_fixture = self.useFixture(fixtures.OSAPIFixture(
+            api_version='v2.1'))
+        self.admin_api = api_fixture.admin_api
+        self.admin_api.microversion = 'latest'
+
+    def test_discover_host_fail_after_service_deletion(self):
+        # Create compute
+        host_name = "compute-1"
+        service = self._start_compute(host_name)
+
+        # Store its node uuid
+        node_uuid = service.service_ref.compute_node.uuid
+
+        # Now delete its service
+        # It will delete the related compute node and host mapping
+        self.admin_api.api_delete(
+            '/os-services/%s' % service.service_ref.uuid)
+        # Check its deletion
+        self.assertRaises(exception.HostBinaryNotFound,
+            db.service_get_by_host_and_binary,
+            self.ctxt, host_name, 'nova-compute')
+
+        # Check that compute node and its mappings have correctly been deleted
+        with utils.temporary_mutation(self.ctxt, read_deleted='yes'):
+            node = db.compute_node_get_by_nodename(self.ctxt, host_name)
+            self.assertEqual(node['deleted'], node['id'])
+        self.assertRaises(exception.HostMappingNotFound,
+            objects.HostMapping.get_by_host,
+            self.ctxt, host_name)
+
+        # Now recreate the service and compute node by updating its resources
+        # like if the services restarts
+        service.manager.update_available_resource(self.ctxt)
+
+        # At this point, service and compute come back to life
+        # with the same compute uuid
+        node = db.compute_node_get_by_nodename(self.ctxt, host_name)
+        self.assertEqual(node['deleted'], 0)
+        self.assertEqual(node['uuid'], node_uuid)
+
+        # Bug #2085135: node should be unmapped and be discoverable
+        self.assertEqual(node['mapped'], 1)
+        mappings = host_mapping.discover_hosts(
+            self.ctxt, status_fn=lambda m: None)
+        self.assertEqual(0, len(mappings))


### PR DESCRIPTION
When deleting the service we delete the mapping but do not reset the `mapped` field, 
breaking the periodic `_discover_hosts_in_cells` .

Already fixed in upstream.
