### PR TITLE
Configuring sysinfo and smbios for cloud hypervisor

### DIFF
--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -6814,6 +6814,11 @@ class LibvirtDriver(driver.ComputeDriver):
         elif CONF.libvirt.virt_type == "ch":
             guest.virt_type = 'kvm'
             guest.os_kernel = "/usr/share/cloud-hypervisor/CLOUDHV_EFI.fd"
+            caps = self._host.get_capabilities()
+            arch = caps.host.cpu.arch
+            if arch in (fields.Architecture.I686, fields.Architecture.X86_64):
+                guest.sysinfo = self._get_guest_config_sysinfo(instance)
+                guest.os_smbios = vconfig.LibvirtConfigGuestSMBIOS()
         elif CONF.libvirt.virt_type == "parallels":
             if guest.os_type == fields.VMMode.EXE:
                 guest.os_init_path = "/sbin/init"


### PR DESCRIPTION
For VMs running on Cloud Hypervisor we were lacking the DMI
configuration so far. This adds the respective configuration to the
libvirt domain XML and thus provides Cloud Hypervisor with the so far
lacking information to pass the details on towards the VM.

With this we get e.g. the correct asset tag and system information like:

```
dmidecode
...
System Information
	Manufacturer: OpenStack Foundation
	Product Name: OpenStack Nova
	Version: 28.1.1
	Serial Number: 7a23a631-ff21-4ea9-965f-e3065a0cbbe5
	UUID: 7a23a631-ff21-4ea9-965f-e3065a0cbbe5
	Wake-up Type: Reserved
	SKU Number: Not Specified
	Family: Virtual Machine
...

cat /sys/class/dmi/id/chassis_asset_tag
SAP CCloud VM
```

Change-Id: I1f56b8bef1d9a5dd7640c4a2f6384e6792ae644c