### PR TITLE
compute: add evacuate_delete API for instances stuck on failed hosts

### DIFF
--- a/nova/api/openstack/compute/sap_admin_api.py
+++ b/nova/api/openstack/compute/sap_admin_api.py
@@ -171,6 +171,31 @@ class SAPAdminApiController(wsgi.Controller):
             'config': config,
         }
 
+    @wsgi.expected_errors((400, 403, 404, 409))
+    @validation.schema(sap_admin_api.evacuate_delete)
+    @_register_endpoint('POST')
+    def evacuate_delete(self, req, body):
+        """Finish a server deletion during evacuation when stuck on a
+        failed host
+        """
+        context = req.environ["nova.context"]
+        instance_uuid = body['instance_uuid']
+        instance = common.get_instance(
+            self.compute_api, context, instance_uuid)
+
+        context.can(sap_policies.POLICY_ROOT % 'evacuate-delete',
+                    target={'user_id': instance.user_id,
+                            'project_id': instance.project_id})
+
+        try:
+            self.compute_api.evacuate_delete(context, instance)
+        except exception.InstanceInvalidState as state_error:
+            common.raise_http_conflict_for_instance_invalid_state(
+                state_error, 'evacuate_delete', instance_uuid)
+        except exception.ComputeServiceInUse as e:
+            raise exc.HTTPBadRequest(explanation=e.format_message())
+        return None
+
     @_register_endpoint('GET')
     def endpoints(self, req):
         """Return the available API endpoints"""

--- a/nova/api/openstack/compute/schemas/sap_admin_api.py
+++ b/nova/api/openstack/compute/schemas/sap_admin_api.py
@@ -36,3 +36,12 @@ usage_by_az_query_params = {
     'required': ['project_id'],
     'additionalProperties': False,
 }
+
+evacuate_delete = {
+    'type': 'object',
+    'properties': {
+        'instance_uuid': parameter_types.server_id,
+    },
+    'required': ['instance_uuid'],
+    'additionalProperties': False,
+}

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -46,6 +46,7 @@ from nova.compute import power_state
 from nova.compute import rpcapi as compute_rpcapi
 from nova.compute import task_states
 from nova.compute import utils as compute_utils
+from nova.compute.utils import EventReporter
 from nova.compute.utils import wrap_instance_event
 from nova.compute import vm_states
 from nova import conductor
@@ -5820,6 +5821,65 @@ class API:
                        host=host,
                        request_spec=request_spec,
                        target_state=target_state)
+
+    @check_instance_state(vm_state=[vm_states.ACTIVE, vm_states.DELETED,
+                                     vm_states.ERROR],
+                                     task_state=[None, task_states.DELETING])
+    def evacuate_delete(self, context, instance):
+        """Force local delete for an instance stuck on a failed host.
+
+        Checking vm compute host state, if host not in expected_state,
+        raising an exception.
+
+        :param instance: The instance to delete during evacuation
+        """
+        LOG.debug('vm evacuation delete scheduled', instance=instance)
+        # We need to check the following 2 states explicitly.
+        # Those can not be represented by check_instance_state.
+        not_allowed = (
+          (instance.vm_state == vm_states.ACTIVE and
+           instance.task_state is None) or
+          (instance.vm_state == vm_states.ERROR and
+           instance.task_state is None)
+        )
+        if not_allowed:
+            raise exception.InstanceInvalidState(
+                attr='vm_state/task_state',
+                instance_uuid=instance.uuid,
+                state='%s/%s' % (instance.vm_state, instance.task_state),
+                method='evacuate_delete')
+
+        if instance.host is None:
+            raise exception.InstanceInvalidState(
+                attr='host',
+                instance_uuid=instance.uuid,
+                state='None',
+                method='evacuate_delete')
+
+        service = objects.Service.get_by_compute_host(
+            context.elevated(), instance.host)
+        if self.servicegroup_api.service_is_up(service):
+            raise exception.ComputeServiceInUse(host=instance.host)
+
+        bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
+            context, instance.uuid)
+
+        try:
+            im = objects.InstanceMapping.get_by_instance_uuid(
+                context, instance.uuid)
+            cell = im.cell_mapping
+        except exception.InstanceMappingNotFound:
+            LOG.warning('During local delete, failed to find '
+                        'instance mapping', instance=instance)
+            return
+
+        with nova_context.target_cell(context, cell) as cctxt:
+            self._record_action_start(
+                context, instance, instance_actions.SAP_EVACUATE_DELETE)
+            with EventReporter(cctxt, 'api_evacuate_delete', None,
+                               instance.uuid):
+                self._local_delete(cctxt, instance, bdms,
+                                   'delete', self._do_delete)
 
     def get_migrations(self, context, filters):
         """Get all migrations for the given filters."""

--- a/nova/compute/instance_actions.py
+++ b/nova/compute/instance_actions.py
@@ -77,3 +77,5 @@ RESET_STATE = 'resetState'
 NOVA_MANAGE_REFRESH_VOLUME_ATTACHMENT = 'refresh_volume_attachment'
 
 SAP_IN_CLUSTER_VMOTION = 'sap_in_cluster_vmotion'
+
+SAP_EVACUATE_DELETE = 'sap_evacuate_delete'

--- a/nova/policies/sap_admin_api.py
+++ b/nova/policies/sap_admin_api.py
@@ -88,6 +88,17 @@ sap_admin_api_policies = [
             }
         ],
         scope_types=['system', 'project']),
+    policy.DocumentedRuleDefault(
+        name=POLICY_ROOT % 'evacuate-delete',
+        check_str=base.RULE_ADMIN_API,
+        description="Force local delete of a server stuck on a failed host",
+        operations=[
+            {
+                'method': 'POST',
+                'path': '/sap/evacuate_delete'
+            }
+        ],
+        scope_types=['system', 'project']),
 ]
 
 

--- a/nova/tests/unit/api/openstack/compute/test_evacuate_delete.py
+++ b/nova/tests/unit/api/openstack/compute/test_evacuate_delete.py
@@ -1,0 +1,83 @@
+#   Copyright 2013 OpenStack Foundation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+from oslo_utils.fixture import uuidsentinel as uuids
+import webob
+
+from nova.api.openstack.compute import sap_admin_api
+from nova.compute import task_states
+from nova.compute import vm_states
+import nova.conf
+from nova import exception
+from nova import test
+from nova.tests.unit.api.openstack import fakes
+from nova.tests.unit import fake_instance
+
+
+CONF = nova.conf.CONF
+
+
+def fake_compute_api(*args, **kwargs):
+    return True
+
+
+def fake_compute_api_get(self, context, instance_id, **kwargs):
+    if instance_id == uuids.not_found:
+        raise exception.InstanceNotFound(instance_id=instance_id)
+    else:
+        return fake_instance.fake_instance_obj(context, id=1, uuid=instance_id,
+                                               task_state=task_states.DELETING,
+                                               host='host1',
+                                               vm_state=vm_states.ACTIVE)
+
+
+class EvacuateDeleteTestV295(test.NoDBTestCase):
+    validation_error = exception.ValidationError
+    _method = 'evacuate_delete'
+
+    def setUp(self):
+        super(EvacuateDeleteTestV295, self).setUp()
+        self.stub_out('nova.compute.api.API.get', fake_compute_api_get)
+        self.UUID = uuids.fake
+        self.stub_out('nova.compute.api.API.%s' %
+                      self._method, fake_compute_api)
+        self.controller = sap_admin_api.SAPAdminApiController()
+        self.admin_req = fakes.HTTPRequest.blank('', use_admin_context=True)
+        self.req = fakes.HTTPRequest.blank('')
+
+    def _get_evacuate_delete_response(self, body, uuid=None):
+        body['instance_uuid'] = uuid or self.UUID
+        return self.controller.evacuate_delete(self.admin_req, body=body)
+
+    def _check_evacuate_delete_failure(self, exception, body, uuid=None):
+        body['instance_uuid'] = uuid or self.UUID
+        return self.assertRaises(exception, self.controller.evacuate_delete,
+                                 self.admin_req, body=body)
+
+    def test_evacuate_delete_with_valid_instance(self):
+        res = self._get_evacuate_delete_response({})
+
+        self.assertIsNone(res)
+
+    def test_evacuate_delete_with_invalid_instance(self):
+        self._check_evacuate_delete_failure(webob.exc.HTTPNotFound, {},
+                                            uuid=uuids.not_found)
+
+    def test_evacuate_with_active_service(self):
+        def fake_evacuate_delete(*args, **kwargs):
+            raise exception.ComputeServiceInUse("Service still in use")
+
+        self.stub_out('nova.compute.api.API.evacuate_delete',
+                      fake_evacuate_delete)
+        self._check_evacuate_delete_failure(webob.exc.HTTPBadRequest, {})

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -12365,6 +12365,95 @@ class ComputeAPITestCase(BaseTestCase):
             host='fake_dest_host', on_shared_storage=True,
             admin_password=None)
 
+    @mock.patch('nova.compute.api.API._record_action_start')
+    @mock.patch('nova.compute.api.API._local_delete')
+    @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid',
+                return_value=[])
+    @mock.patch('nova.objects.Service.get_by_compute_host')
+    def test_evacuate_delete_active_deleting_host_down(
+            self, mock_service, mock_bdms, mock_local_delete, mock_record):
+        instance = self._create_fake_instance_obj({
+            'vm_state': vm_states.ACTIVE,
+            'task_state': task_states.DELETING,
+            'host': 'fake_host',
+        })
+        mock_service.return_value = mock.Mock()
+        self.stub_out('nova.servicegroup.api.API.service_is_up',
+                      lambda *a, **kw: False)
+
+        self.compute_api.evacuate_delete(self.context, instance)
+
+        mock_local_delete.assert_called_once()
+        mock_record.assert_called_once_with(
+            self.context, instance, instance_actions.SAP_EVACUATE_DELETE)
+
+    @mock.patch('nova.compute.api.API._record_action_start')
+    @mock.patch('nova.compute.api.API._local_delete')
+    @mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid',
+                return_value=[])
+    @mock.patch('nova.objects.Service.get_by_compute_host')
+    def test_evacuate_delete_deleted_state_host_down(
+            self, mock_service, mock_bdms, mock_local_delete, mock_record):
+        instance = self._create_fake_instance_obj({
+            'vm_state': vm_states.DELETED,
+            'task_state': None,
+            'host': 'fake_host',
+        })
+        mock_service.return_value = mock.Mock()
+        self.stub_out('nova.servicegroup.api.API.service_is_up',
+                      lambda *a, **kw: False)
+
+        self.compute_api.evacuate_delete(self.context, instance)
+
+        mock_local_delete.assert_called_once()
+        mock_record.assert_called_once_with(
+            self.context, instance, instance_actions.SAP_EVACUATE_DELETE)
+
+    @mock.patch('nova.objects.Service.get_by_compute_host')
+    def test_evacuate_delete_host_up_raises(self, mock_service):
+        instance = self._create_fake_instance_obj({
+            'vm_state': vm_states.ACTIVE,
+            'task_state': task_states.DELETING,
+            'host': 'fake_host',
+        })
+        mock_service.return_value = mock.Mock()
+        self.stub_out('nova.servicegroup.api.API.service_is_up',
+                      lambda *a, **kw: True)
+
+        self.assertRaises(
+            exception.ComputeServiceInUse,
+            self.compute_api.evacuate_delete,
+            self.context,
+            instance)
+
+    def test_evacuate_delete_wrong_state_raises(self):
+        states = [vm_states.BUILDING, vm_states.PAUSED, vm_states.SUSPENDED,
+                  vm_states.RESCUED, vm_states.RESIZED, vm_states.SOFT_DELETED]
+        instances = [self._create_fake_instance_obj({'vm_state': state})
+                     for state in states]
+
+        for instance in instances:
+            self.assertRaises(
+                exception.InstanceInvalidState,
+                self.compute_api.evacuate_delete,
+                self.context,
+                instance)
+
+        # Edge case for ACTIVE/ERROR and task_state None
+        for vm_state, task_state in [
+            (vm_states.ACTIVE, None),
+            (vm_states.ERROR, None),
+        ]:
+            instance = self._create_fake_instance_obj({
+                'vm_state': vm_state,
+                'task_state': task_state,
+            })
+            self.assertRaises(
+                exception.InstanceInvalidState,
+                self.compute_api.evacuate_delete,
+                self.context,
+                instance)
+
     @mock.patch('nova.objects.MigrationList.get_by_filters')
     def test_get_migrations(self, mock_migration):
         migration = test_migration.fake_db_migration()

--- a/nova/tests/unit/test_policy.py
+++ b/nova/tests/unit/test_policy.py
@@ -396,6 +396,7 @@ class RealRolePolicyTestCase(test.NoDBTestCase):
 "os_compute_api:sap:all-instance-uuids",
 "os_compute_api:sap:usage-by-az",
 "os_compute_api:sap:get-scheduler-settings",
+"os_compute_api:sap:evacuate-delete",
 )
 
         self.admin_or_owner_rules = (


### PR DESCRIPTION
Problem:
When a compute host fails, instances may become stuck in deletion states (e.g., ACTIVE/DELETING or DELETED). In such cases an evacuate does not help. Even worse, after calling evacuate the first time the instance removes the last state and goes into error state. When retrying evacuate it would recreate a vm that was meant to be deleted by the customer.

Solution:
Add a new admin-only API endpoint that performs a forced local deletion of instances when their compute host is confirmed to be down by the kvm-ha-service. The implementation includes:
* New REST API endpoint: POST /sap/evacuate_delete
* Core compute API method evacuate_delete() with safety checks:
  - Validates instance is not in ACTIVE/None or ERROR/None states
  - Raises ComputeServiceInUse if host is still operational
  - Uses existing _local_delete() infrastructure for cleanup
* Admin-only policy (os_compute_api:sap:evacuate-delete

Change-Id: I14f2d9aa331315ddbe67e204a4aaf1e8b1726ed9