### PR TITLE
Fix: Move trunk_vifs from vif meta to top level

### DIFF
--- a/nova/network/model.py
+++ b/nova/network/model.py
@@ -430,17 +430,26 @@ class VIF(Model):
         self['profile'] = profile
         self['preserve_on_delete'] = preserve_on_delete
         self['delegate_create'] = delegate_create
-        self['trunk_vifs'] = trunk_vifs or []
+        if trunk_vifs:
+            self['trunk_vifs'] = trunk_vifs
 
         self._set_meta(kwargs)
+
+        # NOTE(leust): Cache rows written by older code that did not have
+        # the trunk_vifs field store trunk_vifs inside meta because
+        # _set_meta captured unknown kwargs there. Move trunk_vifs back
+        # to the top level so notifications and metadata get a clean
+        # meta dict.
+        if 'trunk_vifs' in self['meta']:
+            self['trunk_vifs'] = self['meta'].pop('trunk_vifs')
 
     def __eq__(self, other):
         keys = ['id', 'address', 'network', 'vnic_type',
                 'type', 'profile', 'details', 'devname',
                 'ovs_interfaceid', 'qbh_params', 'qbg_params',
-                'active', 'preserve_on_delete', 'delegate_create',
-                'trunk_vifs']
-        return all(self[k] == other[k] for k in keys)
+                'active', 'preserve_on_delete', 'delegate_create']
+        return (all(self[k] == other[k] for k in keys) and
+                self.get('trunk_vifs') == other.get('trunk_vifs'))
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -511,15 +520,18 @@ class VIF(Model):
         return phy_network
 
     def add_trunk_vif(self, vif):
-        if any(vif['id'] == _vif['id'] for _vif in self['trunk_vifs']):
+        trunk_vifs = self.setdefault('trunk_vifs', [])
+        if any(vif['id'] == _vif['id'] for _vif in trunk_vifs):
             return
-        self['trunk_vifs'].append(vif)
+        trunk_vifs.append(vif)
 
     @classmethod
     def hydrate(cls, vif):
         vif = cls(**vif)
-        vif['trunk_vifs'] = [VIF.hydrate(trunk_vif) for trunk_vif
-                             in vif.get('trunk_vifs', [])]
+        trunk_vifs = [VIF.hydrate(trunk_vif)
+                      for trunk_vif in vif.get('trunk_vifs', ())]
+        if trunk_vifs:
+            vif['trunk_vifs'] = trunk_vifs
         vif['network'] = Network.hydrate(vif['network'])
         return vif
 

--- a/nova/tests/unit/network/test_network_info.py
+++ b/nova/tests/unit/network/test_network_info.py
@@ -478,6 +478,36 @@ class VIFTests(test.NoDBTestCase):
         self.assertEqual('subport1', hydrated['trunk_vifs'][0]['id'])
         self.assertEqual(1049, hydrated['trunk_vifs'][0]['profile']['tag'])
 
+    def test_vif_without_subports_has_no_trunk_vifs_key(self):
+        # Do not save trunk_vifs to the info_caches if it's empty
+        vif = fake_network_cache_model.new_vif({'id': 'p1', 'type': 'ovs'})
+        self.assertNotIn('trunk_vifs', vif)
+
+    def test_hydrate_moves_trunk_vifs_from_meta_to_top_level(self):
+        # Cache rows written by older code that did not have the
+        # trunk_vifs field store trunk_vifs inside vif['meta']. Hydration
+        # must move them back to the top-level field so that the
+        # IpPayload meta field (DictOfStrings) does not reject the list
+        # value.
+        subport_dict = {'id': 'subport1', 'type': 'trunk-subport',
+                        'address': 'aa:aa:aa:aa:aa:aa',
+                        'network': fake_network_cache_model.new_network(),
+                        'profile': {'tag': 1049}}
+        stored_vif = {
+            'id': 'parent1',
+            'address': 'aa:aa:aa:aa:aa:aa',
+            'network': fake_network_cache_model.new_network(),
+            'type': 'ovs',
+            'meta': {'trunk_vifs': [subport_dict]},
+        }
+
+        hydrated = model.VIF.hydrate(stored_vif)
+
+        self.assertNotIn('trunk_vifs', hydrated['meta'])
+        self.assertEqual(1, len(hydrated['trunk_vifs']))
+        self.assertIsInstance(hydrated['trunk_vifs'][0], model.VIF)
+        self.assertEqual('subport1', hydrated['trunk_vifs'][0]['id'])
+
 
 class NetworkInfoTests(test.NoDBTestCase):
     def test_create_model(self):

--- a/nova/virt/netutils.py
+++ b/nova/virt/netutils.py
@@ -190,7 +190,7 @@ def get_network_metadata(network_info):
     for vif in network_info:
         if vif.get('type') != model.VIF_TYPE_TRUNK_SUBPORT:
             vifs_with_parent.append((vif, None))
-        for subport in vif['trunk_vifs']:
+        for subport in vif.get('trunk_vifs', ()):
             vifs_with_parent.append((subport, vif))
 
     for vif, parent_vif in vifs_with_parent:


### PR DESCRIPTION
This is a backward compatibility fix for edge cases when, mainly during deployment, a newer nova-compute might save the info_cache with the new VIF.trunk_vifs field, but an older conductor will persist it in the VIF.meta which is a DictOfStrings.

Change-Id: I0f403a77bc9ff00ad4c0560117574abef5d20e86