### PR TITLE
api/utils: detect cross-hypervisor resize and disallow

### DIFF
--- a/nova/api/openstack/compute/servers.py
+++ b/nova/api/openstack/compute/servers.py
@@ -1091,6 +1091,7 @@ class ServersController(wsgi.Controller):
             exception.CannotResizeToSameFlavor,
             exception.FlavorNotFound,
             exception.ExtendedResourceRequestOldCompute,
+            exception.InvalidCrossHvResize,
             exception.InvalidVolume,
         ) as e:
             raise exc.HTTPBadRequest(explanation=e.format_message())

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -4281,6 +4281,18 @@ class API:
         if same_flavor and flavor_id:
             raise exception.CannotResizeToSameFlavor()
 
+        source_hv_type = current_flavor.extra_specs.get(
+            'capabilities:hypervisor_type')
+        if compute_utils.is_cross_hypervisor_resize(
+                source_hv_type, new_flavor):
+            # TODO(KVMotion): When specific transitions are allowed (e.g.
+            # VMware->KVM), replace this blanket rejection with an allow-list
+            # check and let permitted transitions through to the conductor
+            raise exception.InvalidCrossHvResize(
+                src_hv_type=source_hv_type,
+                dest_hv_type=new_flavor.extra_specs.get(
+                    'capabilities:hypervisor_type'))
+
         # ensure there is sufficient headroom for upsizes
         if flavor_id:
             # Figure out if the instance is volume-backed but only if we didn't

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -1703,3 +1703,29 @@ def delete_arqs_if_needed(context, instance, arq_uuids=None):
               {'instance': instance.uuid,
                'uuid': arq_uuids})
         cyclient.delete_arqs_by_uuid(arq_uuids)
+
+
+def is_cross_hypervisor_resize(source_hypervisor_type, dest_flavor):
+    """Detect whether a resize would cross hypervisor boundaries.
+
+    Compares the source hypervisor type against the destination flavor's
+    ``capabilities:hypervisor_type`` extra spec.
+
+    :param source_hypervisor_type: The hypervisor type string of the source,
+        e.g. 'VMware vCenter Server', 'QEMU', 'CH'. May be None, in which
+        case the function returns False (cannot determine).
+    :param dest_flavor: The destination Flavor object. Its extra_specs are
+        inspected for 'capabilities:hypervisor_type'.
+    :returns: True if the resize crosses hypervisor boundaries, False if the
+        types match or if either value is unset (cannot determine).
+    """
+    from nova.scheduler.filters import extra_specs_ops
+
+    if not source_hypervisor_type:
+        return False
+
+    dest_hv_type = dest_flavor.extra_specs.get('capabilities:hypervisor_type')
+    if not dest_hv_type:
+        return False
+
+    return not extra_specs_ops.match(source_hypervisor_type, dest_hv_type)

--- a/nova/exception.py
+++ b/nova/exception.py
@@ -2547,3 +2547,8 @@ class VolumeMigrationError(NovaException):
 class InvalidGuestCpuNumaConfig(NovaException):
     msg_fmt = _('The guest is configured with a cell with id %(cell_id)s '
                 'which the host does not provide.')
+
+
+class InvalidCrossHvResize(NovaException):
+    msg_fmt = _('Resize from hypervisor type %(src_hv_type)s to '
+                '%(dest_hv_type)s is not allowed')

--- a/nova/tests/unit/api/openstack/compute/test_server_actions.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_actions.py
@@ -830,6 +830,15 @@ class ServerActionsControllerTestV21(test.TestCase):
                           self.controller._action_resize,
                           self.req, FAKE_UUID, body=body)
 
+    @mock.patch('nova.compute.api.API.resize',
+                side_effect=exception.InvalidCrossHvResize(
+                    src_hv_type='VMware vCenter Server', dest_hv_type='CH'))
+    def test_resize_raises_invalid_cross_hv_resize(self, mock_resize):
+        body = dict(resize=dict(flavorRef="http://localhost/3"))
+        self.assertRaises(webob.exc.HTTPBadRequest,
+                          self.controller._action_resize,
+                          self.req, FAKE_UUID, body=body)
+
     def test_resize_with_too_many_instances(self):
         body = dict(resize=dict(flavorRef="http://localhost/3"))
 

--- a/nova/tests/unit/compute/test_api.py
+++ b/nova/tests/unit/compute/test_api.py
@@ -7577,6 +7577,13 @@ class ComputeAPIUnitTestCase(_ComputeAPIUnitTestMixIn, test.NoDBTestCase):
         self.assertRaises(exception.CannotResizeToSameFlavor,
                           self._test_resize, same_flavor=True)
 
+    @mock.patch('nova.compute.utils.is_cross_hypervisor_resize',
+                return_value=True)
+    def test_resize_cross_hypervisor_fails(self, mock_is_cross_hv):
+        """Resize between different hypervisor types is rejected early."""
+        self.assertRaises(exception.InvalidCrossHvResize,
+                          self._test_resize)
+
     def test_find_service_in_cell_error_case(self):
         self.assertRaises(exception.NovaException,
                           compute_api._find_service_in_cell, self.context)

--- a/nova/tests/unit/compute/test_utils.py
+++ b/nova/tests/unit/compute/test_utils.py
@@ -2074,3 +2074,54 @@ class AcceleratorRequestTestCase(test.NoDBTestCase):
         compute_utils.delete_arqs_if_needed(self.context, instance, arq_uuids)
         mock_del_inst.assert_called_once_with(instance.uuid)
         mock_del_uuid.assert_called_once_with(arq_uuids)
+
+
+class IsCrossHypervisorResizeTestCase(test.NoDBTestCase):
+    """Tests for compute_utils.is_cross_hypervisor_resize."""
+
+    def _make_flavor(self, extra_specs=None):
+        flavor = objects.Flavor(
+            id=1, name='test', memory_mb=512, vcpus=1, root_gb=10,
+            ephemeral_gb=0, swap=0, rxtx_factor=1.0, flavorid='fakeid',
+            disabled=False, is_public=True,
+            extra_specs=extra_specs or {})
+        return flavor
+
+    def test_source_is_none_returns_false(self):
+        """If source hypervisor type is None, returns False."""
+        dest_flavor = self._make_flavor(
+            {'capabilities:hypervisor_type': 'QEMU'})
+        self.assertFalse(
+            compute_utils.is_cross_hypervisor_resize(None, dest_flavor))
+
+    def test_dest_has_no_hv_spec_returns_false(self):
+        """If dest flavor has no hypervisor_type spec, returns False."""
+        dest_flavor = self._make_flavor({})
+        self.assertFalse(
+            compute_utils.is_cross_hypervisor_resize(
+                'VMware vCenter Server', dest_flavor))
+
+    def test_detects_cross_hv_resize(self):
+        """Cross-hypervisor transitions return True."""
+        hv_types = ['VMware vCenter Server', 'CH', 'ironic']
+        for src in hv_types:
+            for dest in hv_types:
+                if src == dest:
+                    continue
+                with self.subTest(src=src, dest=dest):
+                    dest_flavor = self._make_flavor(
+                        {'capabilities:hypervisor_type': dest})
+                    self.assertTrue(
+                        compute_utils.is_cross_hypervisor_resize(
+                            src, dest_flavor))
+
+    def test_same_hv_returns_false(self):
+        """Same-hypervisor resizes return False."""
+        hv_types = ['VMware vCenter Server', 'CH', 'ironic']
+        for hv in hv_types:
+            with self.subTest(hv=hv):
+                dest_flavor = self._make_flavor(
+                    {'capabilities:hypervisor_type': hv})
+                self.assertFalse(
+                    compute_utils.is_cross_hypervisor_resize(
+                        hv, dest_flavor))


### PR DESCRIPTION
After KVM go-live, customers are already trying to resize their VMWare VMs to KVM VMs. This isn't supported yet, so customers end up with VMs in broken states. This detects and disallows cross-hv resizes.